### PR TITLE
Add download links for macos and windows apps

### DIFF
--- a/components/Developers.js
+++ b/components/Developers.js
@@ -1,21 +1,39 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faScrewdriverWrench } from '@fortawesome/free-solid-svg-icons'
 import { faWindows, faApple} from '@fortawesome/free-brands-svg-icons';
 
 import styles from './Developers.module.css';
+import Link from 'next/link';
 
 export default function Developers() {
+    const [latestRelease, setLatestRelease] = useState(null);
+    const macURL = latestRelease ? `https://github.com/OpenAdaptAI/OpenAdapt/releases/download/${latestRelease}/OpenAdapt-${latestRelease}.app.zip` : '';
+    const windowsURL = latestRelease ? `https://github.com/OpenAdaptAI/OpenAdapt/releases/download/${latestRelease}/OpenAdapt-${latestRelease}.zip` : '';
+
+    useEffect(() => {
+        fetch('https://api.github.com/repos/OpenAdaptAI/OpenAdapt/releases/latest')
+            .then(response => response.json())
+            .then(data => {
+                setLatestRelease(data.name);
+            });
+    }, [])
   return (
         <div className={ styles.row } id="developers">
             <div className="relative flex items-center justify-center mx-20 md-12">
                 <div className="grid grid-cols-1 break-words">
                     <h2 id="start" className="text-2xl mt-10 mb-5 font-light">Getting Started</h2>
-                    <h3 className="my-3">
-                        <FontAwesomeIcon icon={faScrewdriverWrench} className="text-3xl mr-4" />
-                        <b>Coming soon!</b>
-                    </h3>
+                    <div className='flex flex-col gap-10 justify-center items-center sm:flex-row'>
+                        <Link className="w-fit flex flex-col gap-y-6 h-fit btn btn-primary hover:no-underline mb-6 py-16" href={windowsURL}>
+                            <FontAwesomeIcon icon={faWindows} className='text-[96px]' />
+                            <span className='text-2xl'>Download for Windows</span>
+                        </Link>
+                        <Link className="px-8 w-fit flex flex-col gap-y-6 h-fit btn btn-primary hover:no-underline mb-6 py-16 sm:px-6" href={macURL}>
+                            <FontAwesomeIcon icon={faApple} style={{ fontSize: 96 }} />
+                            <span className='text-2xl'>Download for MacOS</span>
+                        </Link>
+                    </div>
                     <p>
                         Please <a href="#register">Register for Updates</a> and <a href="#waitlist">Join the Waitlist</a>.
                     </p>


### PR DESCRIPTION
This PR adds download links for macos and windows apps, that are built using github ci and added to the latest release

<details><summary>Desktop</summary>
<img width="2048" alt="image" src="https://github.com/OpenAdaptAI/OpenAdapt.web/assets/40872556/228fdf41-790c-4bc9-b572-e9ddb2bb2675">
</details>

<details><summary>Mobile</summary>
<img width="2048" alt="image" src="https://github.com/OpenAdaptAI/OpenAdapt.web/assets/40872556/fa54a3ec-b33d-4a51-a9c1-0b7dd9b088bf">
</details>
