### PR TITLE
Improve PostHog usage auto-mapping and one-line install UX

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Server-side PostHog credentials for /api/project-metrics
+POSTHOG_HOST=https://us.i.posthog.com
+POSTHOG_PROJECT_ID=68185
+
+# Required for reading event definitions and 30d volumes.
+# NOTE: this must be a PERSONAL API key (phx_), not the project token (phc_).
+# POSTHOG_PERSONAL_API_KEY=phx_your_personal_api_key

--- a/METRICS_SIGNAL_GUIDE.md
+++ b/METRICS_SIGNAL_GUIDE.md
@@ -21,7 +21,7 @@ Returns:
 ### Source A: PostHog (preferred)
 If server env vars are set:
 - `POSTHOG_PERSONAL_API_KEY` (or `POSTHOG_API_KEY`)
-- optional `POSTHOG_PROJECT_ID` (auto-resolved from API key if omitted)
+- optional `POSTHOG_PROJECT_ID` (defaults to `68185`, auto-resolved from API key if omitted)
 - optional `POSTHOG_HOST` (defaults to `https://us.posthog.com`)
 
 The API reads PostHog `event_definitions` and sums `volume_30_day` for matched events.

--- a/METRICS_SIGNAL_GUIDE.md
+++ b/METRICS_SIGNAL_GUIDE.md
@@ -21,7 +21,7 @@ Returns:
 ### Source A: PostHog (preferred)
 If server env vars are set:
 - `POSTHOG_PERSONAL_API_KEY` (or `POSTHOG_API_KEY`)
-- `POSTHOG_PROJECT_ID`
+- optional `POSTHOG_PROJECT_ID` (auto-resolved from API key if omitted)
 - optional `POSTHOG_HOST` (defaults to `https://us.posthog.com`)
 
 The API reads PostHog `event_definitions` and sums `volume_30_day` for matched events.

--- a/METRICS_SIGNAL_GUIDE.md
+++ b/METRICS_SIGNAL_GUIDE.md
@@ -14,7 +14,7 @@ PyPI remains useful, but should not be the lead signal by itself.
 
 Returns:
 - `github`: stars/forks/watchers/issues
-- `usage`: demos/runs/actions (30d), source metadata, caveats
+- `usage`: total events + demos/runs/actions (30d/90d/all-time when available), source metadata, caveats
 - `warnings`: non-fatal fetch warnings
 
 ## Usage metric sources
@@ -31,7 +31,17 @@ Use:
 - `OPENADAPT_METRIC_DEMOS_RECORDED_30D`
 - `OPENADAPT_METRIC_AGENT_RUNS_30D`
 - `OPENADAPT_METRIC_GUI_ACTIONS_30D`
+- `OPENADAPT_METRIC_TOTAL_EVENTS_30D`
+- `OPENADAPT_METRIC_TOTAL_EVENTS_90D`
+- `OPENADAPT_METRIC_TOTAL_EVENTS_ALL_TIME`
 - `OPENADAPT_METRIC_APPS_AUTOMATED`
+
+## UI behavior
+- The telemetry panel always shows **Total Events** first.
+- Detailed breakdown cards (Demos / Agent Runs / GUI Actions) are shown when telemetry has enough depth.
+- Current unlock gate:
+  - at least `100` total events in last 90 days, and
+  - at least `14` days of telemetry coverage (if coverage date is available).
 
 ## Current event-name mapping (exact-first)
 ### Demos

--- a/METRICS_SIGNAL_GUIDE.md
+++ b/METRICS_SIGNAL_GUIDE.md
@@ -33,12 +33,17 @@ Use:
 - `OPENADAPT_METRIC_GUI_ACTIONS_30D`
 - `OPENADAPT_METRIC_APPS_AUTOMATED`
 
-## Current event-name mapping
+## Current event-name mapping (exact-first)
 ### Demos
 - `recording_finished`
 - `recording_completed`
 - `demo_recorded`
 - `demo_completed`
+- `recording.stopped`
+- `recording.saved`
+- `record.stopped`
+- `capture.completed`
+- `capture.saved`
 
 ### Runs
 - `automation_run`
@@ -46,6 +51,7 @@ Use:
 - `benchmark_run`
 - `replay_started`
 - `episode_started`
+- `replay.started`
 
 ### Actions
 - `action_executed`
@@ -53,19 +59,28 @@ Use:
 - `mouse_click`
 - `keyboard_input`
 - `ui_action`
+- `action_triggered`
 
-If telemetry names differ, update mapping in `pages/api/project-metrics.js`.
+Ignored low-signal events:
+- `function_trace`
+- `get_events.started`
+- `get_events.completed`
+- `visualize.started`
+- `visualize.completed`
+
+If exact mappings return zero for a category, the API automatically falls back to guarded pattern matching. This keeps counters populated for new event families (for example `command:*` / `operation:*`) without relying on env overrides.
 
 ## Tradeoffs
-### PostHog event_definitions approach
+### PostHog event_definitions approach (exact-first + fallback)
 Pros:
 - no client auth exposure
 - lightweight implementation
 - easy to keep server-cached
+- uses real event names already emitted by OpenAdapt repos
 
 Cons:
-- depends on naming consistency
-- may undercount if instrumentation uses different event names
+- still depends on naming consistency for best precision
+- fallback regex can overcount if external events use similar names
 
 ### Env override approach
 Pros:
@@ -77,4 +92,4 @@ Cons:
 - risk of stale numbers without process discipline
 
 ## Recommended next step
-Standardize instrumentation event names in product repos to match this mapping, then remove env overrides once PostHog is complete.
+Standardize new instrumentation to preserve one of the existing exact-name families to minimize reliance on fallback matching.

--- a/METRICS_SIGNAL_GUIDE.md
+++ b/METRICS_SIGNAL_GUIDE.md
@@ -1,0 +1,80 @@
+# Homepage Metrics Signal Guide
+
+## Goal
+Show credibility metrics that reflect real usage, not only package installs.
+
+## Metric hierarchy
+1. **Primary**: GitHub traction + product usage metrics
+2. **Secondary**: PyPI download trends
+
+PyPI remains useful, but should not be the lead signal by itself.
+
+## Implemented API
+`GET /api/project-metrics`
+
+Returns:
+- `github`: stars/forks/watchers/issues
+- `usage`: demos/runs/actions (30d), source metadata, caveats
+- `warnings`: non-fatal fetch warnings
+
+## Usage metric sources
+### Source A: PostHog (preferred)
+If server env vars are set:
+- `POSTHOG_PERSONAL_API_KEY` (or `POSTHOG_API_KEY`)
+- `POSTHOG_PROJECT_ID`
+- optional `POSTHOG_HOST` (defaults to `https://us.posthog.com`)
+
+The API reads PostHog `event_definitions` and sums `volume_30_day` for matched events.
+
+### Source B: explicit overrides (fallback/manual)
+Use:
+- `OPENADAPT_METRIC_DEMOS_RECORDED_30D`
+- `OPENADAPT_METRIC_AGENT_RUNS_30D`
+- `OPENADAPT_METRIC_GUI_ACTIONS_30D`
+- `OPENADAPT_METRIC_APPS_AUTOMATED`
+
+## Current event-name mapping
+### Demos
+- `recording_finished`
+- `recording_completed`
+- `demo_recorded`
+- `demo_completed`
+
+### Runs
+- `automation_run`
+- `agent_run`
+- `benchmark_run`
+- `replay_started`
+- `episode_started`
+
+### Actions
+- `action_executed`
+- `step_executed`
+- `mouse_click`
+- `keyboard_input`
+- `ui_action`
+
+If telemetry names differ, update mapping in `pages/api/project-metrics.js`.
+
+## Tradeoffs
+### PostHog event_definitions approach
+Pros:
+- no client auth exposure
+- lightweight implementation
+- easy to keep server-cached
+
+Cons:
+- depends on naming consistency
+- may undercount if instrumentation uses different event names
+
+### Env override approach
+Pros:
+- explicit and deterministic
+- useful before PostHog is fully instrumented
+
+Cons:
+- manual updates needed
+- risk of stale numbers without process discipline
+
+## Recommended next step
+Standardize instrumentation event names in product repos to match this mapping, then remove env overrides once PostHog is complete.

--- a/METRICS_SIGNAL_GUIDE.md
+++ b/METRICS_SIGNAL_GUIDE.md
@@ -54,6 +54,8 @@ Use:
 - `record.stopped`
 - `capture.completed`
 - `capture.saved`
+- `correction_captured` (correction flywheel)
+- `correction_stored` (correction flywheel)
 
 ### Runs
 - `automation_run`
@@ -62,6 +64,11 @@ Use:
 - `replay_started`
 - `episode_started`
 - `replay.started`
+- `training_run` (GRPO training start/complete)
+- `training_step_completed` (per-step training metrics)
+- `rollout_collected` (RL rollout collection)
+- `checkpoint_saved` (model checkpoint saves)
+- `demo_execution` (DemoExecutor tiered execution)
 
 ### Actions
 - `action_executed`

--- a/TELEMETRY_TRANSPARENCY_DESIGN.md
+++ b/TELEMETRY_TRANSPARENCY_DESIGN.md
@@ -1,0 +1,113 @@
+# Telemetry Transparency Panel Design
+
+Date: 2026-03-06  
+Scope: `openadapt-web` adoption telemetry section (`/` homepage)
+
+## Goal
+Make telemetry metrics auditable by users without adding modal friction or inaccurate copy.
+
+Users should be able to answer:
+1. What exactly do these counters represent?
+2. Which event names are included/excluded?
+3. What data fields are collected in telemetry events?
+4. How to opt out?
+
+## Constraints
+- Must be safe for preview branches/Netlify deploy previews.
+- Must avoid "copy drift" where docs/UI differ from code.
+- Must keep the homepage readable on mobile.
+- Must not expose secrets or raw event payloads.
+
+## Options Considered
+
+### Option A: Modal dialog ("Learn what we collect")
+Pros:
+- High visual focus
+- Plenty of space for detail
+
+Cons:
+- Extra click + context switch
+- Worse mobile ergonomics
+- More complexity (focus traps, keyboard handling)
+
+### Option B: Inline expandable panel (`details/summary`) under telemetry cards
+Pros:
+- Low friction, transparent by default location
+- Native accessibility semantics
+- Easy to keep synchronized with API payload
+
+Cons:
+- Adds vertical length to the section
+- Slightly less "spotlight" than modal
+
+### Option C: Separate telemetry transparency page
+Pros:
+- Max room for detail and diagrams
+- Better long-form documentation
+
+Cons:
+- Easy to ignore
+- Higher drift risk if disconnected from live classification constants
+
+## Decision
+Use **Option B** (inline expandable panel) and generate panel content from `/api/project-metrics` response metadata.
+
+Rationale:
+- Lowest UX friction
+- Strongest anti-drift path when metadata is API-backed from server constants
+- Works well in preview and production
+
+## Proposed Implementation
+
+### 1) API metadata contract
+Add `usage.transparency` object to `/api/project-metrics` response:
+- `classification_version`
+- `dashboard_scope`:
+  - this UI uses aggregate counts (not raw event payload display)
+  - event names + timestamps + counts for metrics
+- `included_event_names` (demos/runs/actions exact lists)
+- `ignored_event_names`
+- `ignored_event_patterns`
+- `fallback_patterns` (for each category)
+- `collection_fields`:
+  - common event envelope fields (e.g., category, timestamp)
+  - common tags (internal, package, package_version, os, python_version, ci)
+  - common operation fields (command/operation/success/duration/item_count)
+- `privacy_controls`:
+  - explicit never-collect list
+  - scrubbing behaviors
+  - opt-out env vars (`DO_NOT_TRACK`, `OPENADAPT_TELEMETRY_ENABLED`)
+- `source_links`:
+  - privacy policy
+  - telemetry source docs
+
+### 2) UI panel
+In `AdoptionSignals`:
+- Add collapsible section titled `Telemetry details (what we collect)`.
+- Render sections:
+  - Metric counting scope
+  - Included event names
+  - Excluded event names/patterns
+  - Collected fields/tags
+  - Privacy controls + opt-out
+  - Source links
+- Keep panel below metric cards and status messages.
+
+### 3) Safety / trust language
+- Avoid claiming raw payload access on the web page.
+- Clearly separate:
+  - "Data used for these counters"
+  - "Telemetry client fields in OpenAdapt instrumentation"
+
+## Tradeoffs
+- More UI density, but transparent and auditable.
+- Some duplication with privacy policy, but scoped to metrics and backed by API constants.
+- Requires periodic updates if telemetry schema changes; mitigated by API-backed metadata contract.
+
+## Preview-Branch Plan
+Roll out in PR preview first. Validate:
+1. Readability on desktop + mobile
+2. No contradiction with `/privacy-policy`
+3. Metadata stays aligned with event classification constants
+
+Then decide whether to merge to main.

--- a/components/AdoptionSignals.js
+++ b/components/AdoptionSignals.js
@@ -9,7 +9,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons'
 import styles from './AdoptionSignals.module.css'
 
-const METRICS_CACHE_KEY = 'openadapt:adoption-signals:v1'
+const METRICS_CACHE_KEY = 'openadapt:adoption-signals:v2'
 const METRICS_CACHE_TTL_MS = 6 * 60 * 60 * 1000
 const FETCH_TIMEOUT_MS = 10000
 
@@ -18,8 +18,11 @@ function hasUsableUsageMetrics(payload) {
     if (!usage || usage.available !== true) return false
     const candidates = [
         usage.agentRuns30d,
+        usage.agentRuns90d,
         usage.guiActions30d,
+        usage.guiActions90d,
         usage.demosRecorded30d,
+        usage.demosRecorded90d,
         usage.agentRunsAllTime,
         usage.guiActionsAllTime,
         usage.demosRecordedAllTime,
@@ -64,7 +67,7 @@ function MetricSkeletonCard() {
     )
 }
 
-export default function AdoptionSignals() {
+export default function AdoptionSignals({ timeRange = 'all' }) {
     const [loading, setLoading] = useState(true)
     const [refreshing, setRefreshing] = useState(false)
     const [showStaleNotice, setShowStaleNotice] = useState(false)
@@ -144,6 +147,26 @@ export default function AdoptionSignals() {
     }, [])
 
     const usageAvailable = Boolean(data?.usage?.available)
+    const isAllTime = timeRange === 'all'
+    const runsPrimary = isAllTime
+        ? data?.usage?.agentRunsAllTime
+        : (data?.usage?.agentRuns90d ?? data?.usage?.agentRuns30d)
+    const actionsPrimary = isAllTime
+        ? data?.usage?.guiActionsAllTime
+        : (data?.usage?.guiActions90d ?? data?.usage?.guiActions30d)
+    const demosPrimary = isAllTime
+        ? data?.usage?.demosRecordedAllTime
+        : (data?.usage?.demosRecorded90d ?? data?.usage?.demosRecorded30d)
+    const runsSecondary = isAllTime
+        ? (data?.usage?.agentRuns90d ?? data?.usage?.agentRuns30d)
+        : data?.usage?.agentRunsAllTime
+    const actionsSecondary = isAllTime
+        ? (data?.usage?.guiActions90d ?? data?.usage?.guiActions30d)
+        : data?.usage?.guiActionsAllTime
+    const demosSecondary = isAllTime
+        ? (data?.usage?.demosRecorded90d ?? data?.usage?.demosRecorded30d)
+        : data?.usage?.demosRecordedAllTime
+    const secondaryLabel = isAllTime ? '90d' : 'all-time'
     const sourceLabel = useMemo(() => {
         if (!data?.usage?.source) return null
         if (String(data.usage.source).startsWith('posthog')) return 'Usage metrics source: PostHog'
@@ -158,7 +181,7 @@ export default function AdoptionSignals() {
             <div className={styles.header}>
                 <h3 className={styles.title}>Adoption Signals</h3>
                 <p className={styles.subtitle}>
-                    Prioritizing product usage and GitHub traction; package downloads are shown separately.
+                    Track OpenAdapt&apos;s all-time footprint and 90-day momentum.
                 </p>
             </div>
 
@@ -194,27 +217,27 @@ export default function AdoptionSignals() {
                         />
                         <MetricCard
                             icon={faChartLine}
-                            value={data?.usage?.agentRuns30d}
-                            label="Agent Runs (30d)"
+                            value={runsPrimary}
+                            label={isAllTime ? 'Agent Runs (All time)' : 'Agent Runs (90d)'}
                             title="Derived from usage telemetry event volumes"
-                            secondaryValue={data?.usage?.agentRunsAllTime}
-                            secondaryLabel="all-time"
+                            secondaryValue={runsSecondary}
+                            secondaryLabel={secondaryLabel}
                         />
                         <MetricCard
                             icon={faComputerMouse}
-                            value={data?.usage?.guiActions30d}
-                            label="GUI Actions (30d)"
+                            value={actionsPrimary}
+                            label={isAllTime ? 'GUI Actions (All time)' : 'GUI Actions (90d)'}
                             title="Derived from usage telemetry event volumes"
-                            secondaryValue={data?.usage?.guiActionsAllTime}
-                            secondaryLabel="all-time"
+                            secondaryValue={actionsSecondary}
+                            secondaryLabel={secondaryLabel}
                         />
                         <MetricCard
                             icon={faWindowRestore}
-                            value={data?.usage?.demosRecorded30d}
-                            label="Demos Recorded (30d)"
+                            value={demosPrimary}
+                            label={isAllTime ? 'Demos Recorded (All time)' : 'Demos Recorded (90d)'}
                             title="Derived from usage telemetry event volumes"
-                            secondaryValue={data?.usage?.demosRecordedAllTime}
-                            secondaryLabel="all-time"
+                            secondaryValue={demosSecondary}
+                            secondaryLabel={secondaryLabel}
                         />
                     </div>
 

--- a/components/AdoptionSignals.js
+++ b/components/AdoptionSignals.js
@@ -1,0 +1,128 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import {
+    faCodeBranch,
+    faStar,
+    faChartLine,
+    faComputerMouse,
+    faWindowRestore,
+} from '@fortawesome/free-solid-svg-icons'
+import styles from './AdoptionSignals.module.css'
+
+function formatMetric(value) {
+    if (value === null || value === undefined || Number.isNaN(value)) return '—'
+    if (value >= 1000000) return `${(value / 1000000).toFixed(1)}M`
+    if (value >= 1000) return `${(value / 1000).toFixed(1)}k`
+    return value.toLocaleString()
+}
+
+function MetricCard({ icon, value, label, title }) {
+    return (
+        <div className={styles.metricCard} title={title || ''}>
+            <div className={styles.metricValue}>
+                <FontAwesomeIcon icon={icon} className={styles.metricIcon} />
+                {formatMetric(value)}
+            </div>
+            <div className={styles.metricLabel}>{label}</div>
+        </div>
+    )
+}
+
+export default function AdoptionSignals() {
+    const [loading, setLoading] = useState(true)
+    const [error, setError] = useState(null)
+    const [data, setData] = useState(null)
+
+    useEffect(() => {
+        let cancelled = false
+
+        async function fetchMetrics() {
+            setLoading(true)
+            setError(null)
+            try {
+                const response = await fetch('/api/project-metrics')
+                if (!response.ok) {
+                    throw new Error(`API returned ${response.status}`)
+                }
+                const payload = await response.json()
+                if (!cancelled) setData(payload)
+            } catch (fetchError) {
+                if (!cancelled) setError(fetchError.message || 'Failed to load metrics')
+            } finally {
+                if (!cancelled) setLoading(false)
+            }
+        }
+
+        fetchMetrics()
+        return () => {
+            cancelled = true
+        }
+    }, [])
+
+    const usageAvailable = Boolean(data?.usage?.available)
+    const sourceLabel = useMemo(() => {
+        if (!data?.usage?.source) return null
+        if (String(data.usage.source).startsWith('posthog')) return 'Usage metrics source: PostHog'
+        if (String(data.usage.source).startsWith('env_override')) return 'Usage metrics source: configured counters'
+        return `Usage metrics source: ${data.usage.source}`
+    }, [data])
+
+    return (
+        <div className={styles.container}>
+            <div className={styles.header}>
+                <h3 className={styles.title}>OpenAdapt Adoption Signals</h3>
+                <p className={styles.subtitle}>
+                    Prioritizing product usage and GitHub traction; package downloads are shown separately.
+                </p>
+            </div>
+
+            {loading && <div className={styles.message}>Loading adoption metrics...</div>}
+            {error && <div className={styles.error}>Unable to load adoption metrics: {error}</div>}
+
+            {!loading && !error && (
+                <>
+                    <div className={styles.metricsGrid}>
+                        <MetricCard
+                            icon={faStar}
+                            value={data?.github?.stars}
+                            label="GitHub Stars"
+                            title="Repository stars from GitHub API"
+                        />
+                        <MetricCard
+                            icon={faCodeBranch}
+                            value={data?.github?.forks}
+                            label="GitHub Forks"
+                            title="Repository forks from GitHub API"
+                        />
+                        <MetricCard
+                            icon={faChartLine}
+                            value={data?.usage?.agentRuns30d}
+                            label="Agent Runs (30d)"
+                            title="Derived from usage telemetry event volumes"
+                        />
+                        <MetricCard
+                            icon={faComputerMouse}
+                            value={data?.usage?.guiActions30d}
+                            label="GUI Actions (30d)"
+                            title="Derived from usage telemetry event volumes"
+                        />
+                        <MetricCard
+                            icon={faWindowRestore}
+                            value={data?.usage?.demosRecorded30d}
+                            label="Demos Recorded (30d)"
+                            title="Derived from usage telemetry event volumes"
+                        />
+                    </div>
+
+                    {!usageAvailable && (
+                        <div className={styles.message}>
+                            Usage metrics are not configured yet. Set PostHog credentials or OPENADAPT_METRIC_* overrides.
+                        </div>
+                    )}
+
+                    {sourceLabel && <div className={styles.source}>{sourceLabel}</div>}
+                </>
+            )}
+        </div>
+    )
+}

--- a/components/AdoptionSignals.js
+++ b/components/AdoptionSignals.js
@@ -168,14 +168,14 @@ export default function AdoptionSignals() {
                         <MetricCard
                             icon={faStar}
                             value={data?.github?.stars}
-                            label="GitHub Stars"
-                            title="Repository stars from GitHub API"
+                            label="Ecosystem Stars"
+                            title="Total stars across public OpenAdaptAI openadapt* repositories"
                         />
                         <MetricCard
                             icon={faCodeBranch}
                             value={data?.github?.forks}
-                            label="GitHub Forks"
-                            title="Repository forks from GitHub API"
+                            label="Ecosystem Forks"
+                            title="Total forks across public OpenAdaptAI openadapt* repositories"
                         />
                         <MetricCard
                             icon={faChartLine}

--- a/components/AdoptionSignals.js
+++ b/components/AdoptionSignals.js
@@ -116,6 +116,245 @@ function MetricSkeletonCard() {
     )
 }
 
+function asArray(value) {
+    return Array.isArray(value) ? value : []
+}
+
+function TelemetryTransparencyPanel({ transparency }) {
+    if (!transparency) return null
+
+    const included = transparency?.includedEventNames || {}
+    const metricFamilies = asArray(transparency?.metricScope?.includedMetricFamilies)
+    const ignoredNames = asArray(transparency?.ignoredEventNames)
+    const ignoredPatterns = asArray(transparency?.ignoredEventPatterns)
+    const fallbackPatterns = transparency?.fallbackPatterns || {}
+    const model = transparency?.telemetryDataModel || {}
+    const privacy = transparency?.privacyControls || {}
+    const links = transparency?.sourceLinks || {}
+    const version = transparency?.classificationVersion || 'unknown'
+
+    return (
+        <details className={styles.transparencyPanel}>
+            <summary className={styles.transparencySummary}>
+                Telemetry details (what we collect)
+            </summary>
+            <div className={styles.transparencyBody}>
+                <p className={styles.transparencyIntro}>
+                    {transparency?.metricScope?.summary || 'Telemetry metric details.'}
+                </p>
+                <div className={styles.transparencyMeta}>
+                    Classification version: {version}
+                </div>
+
+                <div className={styles.transparencySection}>
+                    <h4 className={styles.transparencyHeading}>Metric Families</h4>
+                    <ul className={styles.transparencyList}>
+                        {metricFamilies.map((name) => (
+                            <li key={name}>
+                                <code>{name}</code>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+
+                <div className={styles.transparencySection}>
+                    <h4 className={styles.transparencyHeading}>Included Event Names</h4>
+                    <div className={styles.transparencyColumns}>
+                        <div>
+                            <div className={styles.transparencySubheading}>Demos</div>
+                            <ul className={styles.transparencyListCompact}>
+                                {asArray(included.demos).map((name) => (
+                                    <li key={`demo-${name}`}>
+                                        <code>{name}</code>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                        <div>
+                            <div className={styles.transparencySubheading}>Agent Runs</div>
+                            <ul className={styles.transparencyListCompact}>
+                                {asArray(included.runs).map((name) => (
+                                    <li key={`run-${name}`}>
+                                        <code>{name}</code>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                        <div>
+                            <div className={styles.transparencySubheading}>GUI Actions</div>
+                            <ul className={styles.transparencyListCompact}>
+                                {asArray(included.actions).map((name) => (
+                                    <li key={`action-${name}`}>
+                                        <code>{name}</code>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+
+                <div className={styles.transparencySection}>
+                    <h4 className={styles.transparencyHeading}>Excluded / Ignored</h4>
+                    <div className={styles.transparencyColumns}>
+                        <div>
+                            <div className={styles.transparencySubheading}>Ignored Event Names</div>
+                            <ul className={styles.transparencyListCompact}>
+                                {ignoredNames.map((name) => (
+                                    <li key={`ignored-name-${name}`}>
+                                        <code>{name}</code>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                        <div>
+                            <div className={styles.transparencySubheading}>Ignored Name Patterns</div>
+                            <ul className={styles.transparencyListCompact}>
+                                {ignoredPatterns.map((pattern) => (
+                                    <li key={`ignored-pattern-${pattern}`}>
+                                        <code>{pattern}</code>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+
+                <div className={styles.transparencySection}>
+                    <h4 className={styles.transparencyHeading}>Fallback Matching Patterns</h4>
+                    <div className={styles.transparencyColumns}>
+                        <div>
+                            <div className={styles.transparencySubheading}>Demos</div>
+                            <ul className={styles.transparencyListCompact}>
+                                {asArray(fallbackPatterns.demos).map((pattern) => (
+                                    <li key={`fallback-demo-${pattern}`}>
+                                        <code>{pattern}</code>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                        <div>
+                            <div className={styles.transparencySubheading}>Agent Runs</div>
+                            <ul className={styles.transparencyListCompact}>
+                                {asArray(fallbackPatterns.runs).map((pattern) => (
+                                    <li key={`fallback-run-${pattern}`}>
+                                        <code>{pattern}</code>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                        <div>
+                            <div className={styles.transparencySubheading}>GUI Actions</div>
+                            <ul className={styles.transparencyListCompact}>
+                                {asArray(fallbackPatterns.actions).map((pattern) => (
+                                    <li key={`fallback-action-${pattern}`}>
+                                        <code>{pattern}</code>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+
+                <div className={styles.transparencySection}>
+                    <h4 className={styles.transparencyHeading}>Common Telemetry Fields</h4>
+                    <div className={styles.transparencyColumns}>
+                        <div>
+                            <div className={styles.transparencySubheading}>Dashboard Reads</div>
+                            <ul className={styles.transparencyListCompact}>
+                                {asArray(model.metricsDashboardReadsOnly).map((field) => (
+                                    <li key={`dashboard-field-${field}`}>
+                                        {field}
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                        <div>
+                            <div className={styles.transparencySubheading}>Common Event Fields</div>
+                            <ul className={styles.transparencyListCompact}>
+                                {asArray(model.commonEventFields).map((field) => (
+                                    <li key={`event-field-${field}`}>
+                                        <code>{field}</code>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                        <div>
+                            <div className={styles.transparencySubheading}>Common Tags</div>
+                            <ul className={styles.transparencyListCompact}>
+                                {asArray(model.commonTags).map((tag) => (
+                                    <li key={`tag-${tag}`}>
+                                        <code>{tag}</code>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+
+                <div className={styles.transparencySection}>
+                    <h4 className={styles.transparencyHeading}>Privacy Controls</h4>
+                    <div className={styles.transparencyColumns}>
+                        <div>
+                            <div className={styles.transparencySubheading}>Never Collected</div>
+                            <ul className={styles.transparencyListCompact}>
+                                {asArray(privacy.neverCollect).map((item) => (
+                                    <li key={`never-${item}`}>{item}</li>
+                                ))}
+                            </ul>
+                        </div>
+                        <div>
+                            <div className={styles.transparencySubheading}>Automatic Scrubbing</div>
+                            <ul className={styles.transparencyListCompact}>
+                                {asArray(privacy.scrubPolicy).map((item) => (
+                                    <li key={`scrub-${item}`}>{item}</li>
+                                ))}
+                            </ul>
+                        </div>
+                        <div>
+                            <div className={styles.transparencySubheading}>Opt-Out</div>
+                            <ul className={styles.transparencyListCompact}>
+                                {asArray(privacy.optOutEnvVars).map((item) => (
+                                    <li key={`optout-${item}`}>
+                                        <code>{item}</code>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+
+                <div className={styles.transparencyLinks}>
+                    {links.privacyPolicy && (
+                        <a href={links.privacyPolicy} className={styles.transparencyLink}>
+                            Privacy policy
+                        </a>
+                    )}
+                    {links.telemetryReadme && (
+                        <a
+                            href={links.telemetryReadme}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className={styles.transparencyLink}
+                        >
+                            Telemetry README
+                        </a>
+                    )}
+                    {links.telemetryPrivacyCode && (
+                        <a
+                            href={links.telemetryPrivacyCode}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className={styles.transparencyLink}
+                        >
+                            Privacy scrubber code
+                        </a>
+                    )}
+                </div>
+            </div>
+        </details>
+    )
+}
+
 export default function AdoptionSignals({ timeRange = 'all' }) {
     const [loading, setLoading] = useState(true)
     const [refreshing, setRefreshing] = useState(false)
@@ -286,6 +525,7 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
     }, [usageAvailable, showBreakdownCards, breakdownGateEvents, coverageAgeDays])
 
     const showSkeleton = loading && !data
+    const transparency = data?.usage?.transparency || null
 
     return (
         <div className={styles.container}>
@@ -377,6 +617,7 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
                             Live refresh failed: {error}
                         </div>
                     )}
+                    <TelemetryTransparencyPanel transparency={transparency} />
                 </>
             )}
         </div>

--- a/components/AdoptionSignals.js
+++ b/components/AdoptionSignals.js
@@ -37,7 +37,25 @@ function formatMetric(value) {
     return value.toLocaleString()
 }
 
-function MetricCard({ icon, value, label, title, secondaryValue, secondaryLabel }) {
+function formatCoverageDate(value) {
+    if (!value) return null
+    const parsed = new Date(value)
+    if (Number.isNaN(parsed.getTime())) return null
+    return parsed.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+    })
+}
+
+function shouldShowSecondary(primaryValue, secondaryValue) {
+    if (secondaryValue === null || secondaryValue === undefined || Number.isNaN(secondaryValue)) return false
+    if (primaryValue === null || primaryValue === undefined || Number.isNaN(primaryValue)) return true
+    if (Number(primaryValue) === Number(secondaryValue)) return false
+    return formatMetric(primaryValue) !== formatMetric(secondaryValue)
+}
+
+function MetricCard({ icon, value, label, title, secondaryValue, secondaryLabel, showSecondary = true }) {
     return (
         <div className={styles.metricCard} title={title || ''}>
             <div className={styles.metricValue}>
@@ -45,7 +63,7 @@ function MetricCard({ icon, value, label, title, secondaryValue, secondaryLabel 
                 {formatMetric(value)}
             </div>
             <div className={styles.metricLabel}>{label}</div>
-            {secondaryValue !== null && secondaryValue !== undefined && (
+            {showSecondary && secondaryValue !== null && secondaryValue !== undefined && (
                 <div className={styles.metricSecondary}>
                     {formatMetric(secondaryValue)} {secondaryLabel}
                 </div>
@@ -167,11 +185,21 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
         ? (data?.usage?.demosRecorded90d ?? data?.usage?.demosRecorded30d)
         : data?.usage?.demosRecordedAllTime
     const secondaryLabel = isAllTime ? '90d' : 'all-time'
+    const runsShowSecondary = shouldShowSecondary(runsPrimary, runsSecondary)
+    const actionsShowSecondary = shouldShowSecondary(actionsPrimary, actionsSecondary)
+    const demosShowSecondary = shouldShowSecondary(demosPrimary, demosSecondary)
     const sourceLabel = useMemo(() => {
         if (!data?.usage?.source) return null
         if (String(data.usage.source).startsWith('posthog')) return 'Usage metrics source: PostHog'
         if (String(data.usage.source).startsWith('env_override')) return 'Usage metrics source: configured counters'
         return `Usage metrics source: ${data.usage.source}`
+    }, [data])
+    const coverageStartLabel = useMemo(() => {
+        const source = String(data?.usage?.source || '')
+        if (!source.startsWith('posthog')) return null
+        const formatted = formatCoverageDate(data?.usage?.telemetryCoverageStartDate)
+        if (!formatted) return null
+        return `Telemetry coverage starts ${formatted}.`
     }, [data])
 
     const showSkeleton = loading && !data
@@ -218,26 +246,29 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
                         <MetricCard
                             icon={faChartLine}
                             value={runsPrimary}
-                            label={isAllTime ? 'Agent Runs (All time)' : 'Agent Runs (90d)'}
+                            label="Agent Runs"
                             title="Derived from usage telemetry event volumes"
                             secondaryValue={runsSecondary}
                             secondaryLabel={secondaryLabel}
+                            showSecondary={runsShowSecondary}
                         />
                         <MetricCard
                             icon={faComputerMouse}
                             value={actionsPrimary}
-                            label={isAllTime ? 'GUI Actions (All time)' : 'GUI Actions (90d)'}
+                            label="GUI Actions"
                             title="Derived from usage telemetry event volumes"
                             secondaryValue={actionsSecondary}
                             secondaryLabel={secondaryLabel}
+                            showSecondary={actionsShowSecondary}
                         />
                         <MetricCard
                             icon={faWindowRestore}
                             value={demosPrimary}
-                            label={isAllTime ? 'Demos Recorded (All time)' : 'Demos Recorded (90d)'}
+                            label="Demos Recorded"
                             title="Derived from usage telemetry event volumes"
                             secondaryValue={demosSecondary}
                             secondaryLabel={secondaryLabel}
+                            showSecondary={demosShowSecondary}
                         />
                     </div>
 
@@ -248,6 +279,7 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
                     )}
 
                     {sourceLabel && <div className={styles.source}>{sourceLabel}</div>}
+                    {coverageStartLabel && <div className={styles.source}>{coverageStartLabel}</div>}
                     {refreshing && <div className={styles.message}>Refreshing latest metrics...</div>}
                     {showStaleNotice && !refreshing && (
                         <div className={styles.message}>

--- a/components/AdoptionSignals.js
+++ b/components/AdoptionSignals.js
@@ -80,7 +80,6 @@ function MetricCard({
     secondaryValue,
     secondaryLabel,
     showSecondary = true,
-    chipLabel = null,
 }) {
     return (
         <div className={styles.metricCard} title={title || ''}>
@@ -94,7 +93,6 @@ function MetricCard({
                     {formatMetric(secondaryValue)} {secondaryLabel}
                 </div>
             )}
-            {chipLabel && <div className={styles.metricChip}>{chipLabel}</div>}
         </div>
     )
 }
@@ -244,7 +242,7 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
     }, [data, usageSource])
     const telemetryCardSuffix = coverageShortLabel ? ` (since ${coverageShortLabel})` : ''
     const coverageAgeDays = getDaysSince(data?.usage?.telemetryCoverageStartDate)
-    const showEarlyDataChip = coverageAgeDays !== null && coverageAgeDays < 30
+    const showEarlyDataNotice = coverageAgeDays !== null && coverageAgeDays < 30
 
     const showSkeleton = loading && !data
 
@@ -256,6 +254,11 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
                     Privacy-preserving usage telemetry from OpenAdapt clients, shown as all-time and 90-day totals.
                 </p>
                 {telemetryWindowLabel && <div className={styles.windowBadge}>{telemetryWindowLabel}</div>}
+                {showEarlyDataNotice && (
+                    <div className={styles.earlyNotice}>
+                        Early data: telemetry collection started recently, so counts are still ramping.
+                    </div>
+                )}
             </div>
 
             {showSkeleton && (
@@ -284,7 +287,6 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
                             secondaryValue={runsSecondary}
                             secondaryLabel={secondaryLabel}
                             showSecondary={runsShowSecondary}
-                            chipLabel={showEarlyDataChip ? 'Early data' : null}
                         />
                         <MetricCard
                             icon={faComputerMouse}
@@ -294,7 +296,6 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
                             secondaryValue={actionsSecondary}
                             secondaryLabel={secondaryLabel}
                             showSecondary={actionsShowSecondary}
-                            chipLabel={showEarlyDataChip ? 'Early data' : null}
                         />
                         <MetricCard
                             icon={faWindowRestore}
@@ -304,7 +305,6 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
                             secondaryValue={demosSecondary}
                             secondaryLabel={secondaryLabel}
                             showSecondary={demosShowSecondary}
-                            chipLabel={showEarlyDataChip ? 'Early data' : null}
                         />
                     </div>
 

--- a/components/AdoptionSignals.js
+++ b/components/AdoptionSignals.js
@@ -30,6 +30,14 @@ function hasUsableUsageMetrics(payload) {
     return candidates.some((value) => typeof value === 'number')
 }
 
+function hasUsableGithubMetrics(payload) {
+    return typeof payload?.github?.stars === 'number' && typeof payload?.github?.forks === 'number'
+}
+
+function hasUsableCachedSnapshot(payload) {
+    return hasUsableUsageMetrics(payload) && hasUsableGithubMetrics(payload)
+}
+
 function formatMetric(value) {
     if (value === null || value === undefined || Number.isNaN(value)) return '—'
     if (value >= 1000000) return `${(value / 1000000).toFixed(1)}M`
@@ -56,6 +64,15 @@ function formatCoverageShortDate(value) {
         month: 'short',
         day: 'numeric',
     })
+}
+
+function getDaysSince(value) {
+    if (!value) return null
+    const parsed = new Date(value)
+    if (Number.isNaN(parsed.getTime())) return null
+    const diffMs = Date.now() - parsed.getTime()
+    if (!Number.isFinite(diffMs) || diffMs < 0) return 0
+    return Math.floor(diffMs / (24 * 60 * 60 * 1000))
 }
 
 function shouldShowSecondary(primaryValue, secondaryValue) {
@@ -111,6 +128,7 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
     const [showStaleNotice, setShowStaleNotice] = useState(false)
     const [error, setError] = useState(null)
     const [data, setData] = useState(null)
+    const [lastGoodGithub, setLastGoodGithub] = useState(null)
 
     useEffect(() => {
         let cancelled = false
@@ -124,9 +142,10 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
                 if (!parsed?.payload || !parsed?.savedAt) return false
                 const ageMs = Date.now() - parsed.savedAt
                 if (ageMs > METRICS_CACHE_TTL_MS) return false
-                if (!hasUsableUsageMetrics(parsed.payload)) return false
+                if (!hasUsableCachedSnapshot(parsed.payload)) return false
                 if (!cancelled) {
                     setData(parsed.payload)
+                    setLastGoodGithub(parsed.payload.github)
                     setShowStaleNotice(true)
                     setLoading(false)
                 }
@@ -152,9 +171,12 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
                 }
                 const payload = await response.json()
                 if (!cancelled) {
+                    if (hasUsableGithubMetrics(payload)) {
+                        setLastGoodGithub(payload.github)
+                    }
                     setData(payload)
                     setShowStaleNotice(false)
-                    if (typeof window !== 'undefined' && hasUsableUsageMetrics(payload)) {
+                    if (typeof window !== 'undefined' && hasUsableCachedSnapshot(payload)) {
                         window.localStorage.setItem(
                             METRICS_CACHE_KEY,
                             JSON.stringify({ payload, savedAt: Date.now() })
@@ -186,6 +208,7 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
 
     const usageAvailable = Boolean(data?.usage?.available)
     const usageSource = String(data?.usage?.source || '')
+    const githubStats = hasUsableGithubMetrics(data) ? data.github : lastGoodGithub
     const isAllTime = timeRange === 'all'
     const runsPrimary = isAllTime
         ? data?.usage?.agentRunsAllTime
@@ -205,7 +228,7 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
     const demosSecondary = isAllTime
         ? (data?.usage?.demosRecorded90d ?? data?.usage?.demosRecorded30d)
         : data?.usage?.demosRecordedAllTime
-    const secondaryLabel = isAllTime ? '90d' : 'all-time'
+    const secondaryLabel = isAllTime ? 'in last 90d' : 'all-time total'
     const runsShowSecondary = shouldShowSecondary(runsPrimary, runsSecondary)
     const actionsShowSecondary = shouldShowSecondary(actionsPrimary, actionsSecondary)
     const demosShowSecondary = shouldShowSecondary(demosPrimary, demosSecondary)
@@ -236,8 +259,8 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
         return `Telemetry window: ${formatted} - present`
     }, [data, usageSource])
     const telemetryCardSuffix = coverageShortLabel ? ` (since ${coverageShortLabel})` : ''
-    const demosAllTime = data?.usage?.demosRecordedAllTime
-    const demosEarlyData = typeof demosAllTime === 'number' && demosAllTime < 25
+    const coverageAgeDays = getDaysSince(data?.usage?.telemetryCoverageStartDate)
+    const showEarlyDataChip = coverageAgeDays !== null && coverageAgeDays < 30
 
     const showSkeleton = loading && !data
 
@@ -271,13 +294,13 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
                     <div className={styles.metricsGrid}>
                         <MetricCard
                             icon={faStar}
-                            value={data?.github?.stars}
+                            value={githubStats?.stars}
                             label="Ecosystem Stars"
                             title="Total stars across public OpenAdaptAI openadapt* repositories"
                         />
                         <MetricCard
                             icon={faCodeBranch}
-                            value={data?.github?.forks}
+                            value={githubStats?.forks}
                             label="Ecosystem Forks"
                             title="Total forks across public OpenAdaptAI openadapt* repositories"
                         />
@@ -289,6 +312,7 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
                             secondaryValue={runsSecondary}
                             secondaryLabel={secondaryLabel}
                             showSecondary={runsShowSecondary}
+                            chipLabel={showEarlyDataChip ? 'Early data' : null}
                         />
                         <MetricCard
                             icon={faComputerMouse}
@@ -298,6 +322,7 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
                             secondaryValue={actionsSecondary}
                             secondaryLabel={secondaryLabel}
                             showSecondary={actionsShowSecondary}
+                            chipLabel={showEarlyDataChip ? 'Early data' : null}
                         />
                         <MetricCard
                             icon={faWindowRestore}
@@ -307,7 +332,7 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
                             secondaryValue={demosSecondary}
                             secondaryLabel={secondaryLabel}
                             showSecondary={demosShowSecondary}
-                            chipLabel={demosEarlyData ? 'Early data' : null}
+                            chipLabel={showEarlyDataChip ? 'Early data' : null}
                         />
                     </div>
 

--- a/components/AdoptionSignals.js
+++ b/components/AdoptionSignals.js
@@ -13,6 +13,20 @@ const METRICS_CACHE_KEY = 'openadapt:adoption-signals:v1'
 const METRICS_CACHE_TTL_MS = 6 * 60 * 60 * 1000
 const FETCH_TIMEOUT_MS = 10000
 
+function hasUsableUsageMetrics(payload) {
+    const usage = payload?.usage
+    if (!usage || usage.available !== true) return false
+    const candidates = [
+        usage.agentRuns30d,
+        usage.guiActions30d,
+        usage.demosRecorded30d,
+        usage.agentRunsAllTime,
+        usage.guiActionsAllTime,
+        usage.demosRecordedAllTime,
+    ]
+    return candidates.some((value) => typeof value === 'number')
+}
+
 function formatMetric(value) {
     if (value === null || value === undefined || Number.isNaN(value)) return '—'
     if (value >= 1000000) return `${(value / 1000000).toFixed(1)}M`
@@ -69,6 +83,7 @@ export default function AdoptionSignals() {
                 if (!parsed?.payload || !parsed?.savedAt) return false
                 const ageMs = Date.now() - parsed.savedAt
                 if (ageMs > METRICS_CACHE_TTL_MS) return false
+                if (!hasUsableUsageMetrics(parsed.payload)) return false
                 if (!cancelled) {
                     setData(parsed.payload)
                     setShowStaleNotice(true)
@@ -98,7 +113,7 @@ export default function AdoptionSignals() {
                 if (!cancelled) {
                     setData(payload)
                     setShowStaleNotice(false)
-                    if (typeof window !== 'undefined') {
+                    if (typeof window !== 'undefined' && hasUsableUsageMetrics(payload)) {
                         window.localStorage.setItem(
                             METRICS_CACHE_KEY,
                             JSON.stringify({ payload, savedAt: Date.now() })

--- a/components/AdoptionSignals.js
+++ b/components/AdoptionSignals.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
+    faBolt,
     faChartLine,
     faComputerMouse,
     faWindowRestore,
@@ -10,6 +11,8 @@ import styles from './AdoptionSignals.module.css'
 const METRICS_CACHE_KEY = 'openadapt:adoption-signals:v4'
 const METRICS_CACHE_TTL_MS = 6 * 60 * 60 * 1000
 const FETCH_TIMEOUT_MS = 10000
+const BREAKDOWN_MIN_EVENTS_90D = 100
+const BREAKDOWN_MIN_DAYS = 14
 
 function hasUsableUsageMetrics(payload) {
     const usage = payload?.usage
@@ -24,6 +27,9 @@ function hasUsableUsageMetrics(payload) {
         usage.agentRunsAllTime,
         usage.guiActionsAllTime,
         usage.demosRecordedAllTime,
+        usage.totalEvents30d,
+        usage.totalEvents90d,
+        usage.totalEventsAllTime,
     ]
     return candidates.some((value) => typeof value === 'number')
 }
@@ -201,6 +207,9 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
     const demosPrimary = isAllTime
         ? data?.usage?.demosRecordedAllTime
         : (data?.usage?.demosRecorded90d ?? data?.usage?.demosRecorded30d)
+    const totalEventsPrimary = isAllTime
+        ? data?.usage?.totalEventsAllTime
+        : (data?.usage?.totalEvents90d ?? data?.usage?.totalEvents30d)
     const runsSecondary = isAllTime
         ? (data?.usage?.agentRuns90d ?? data?.usage?.agentRuns30d)
         : data?.usage?.agentRunsAllTime
@@ -210,10 +219,14 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
     const demosSecondary = isAllTime
         ? (data?.usage?.demosRecorded90d ?? data?.usage?.demosRecorded30d)
         : data?.usage?.demosRecordedAllTime
+    const totalEventsSecondary = isAllTime
+        ? (data?.usage?.totalEvents90d ?? data?.usage?.totalEvents30d)
+        : data?.usage?.totalEventsAllTime
     const secondaryLabel = isAllTime ? 'in last 90d' : 'all-time total'
     const runsShowSecondary = shouldShowSecondary(runsPrimary, runsSecondary)
     const actionsShowSecondary = shouldShowSecondary(actionsPrimary, actionsSecondary)
     const demosShowSecondary = shouldShowSecondary(demosPrimary, demosSecondary)
+    const totalEventsShowSecondary = shouldShowSecondary(totalEventsPrimary, totalEventsSecondary)
     const sourceLabel = useMemo(() => {
         if (!usageSource) return null
         if (usageSource.startsWith('posthog')) return 'Usage metrics source: PostHog'
@@ -243,6 +256,34 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
     const telemetryCardSuffix = coverageShortLabel ? ` (since ${coverageShortLabel})` : ''
     const coverageAgeDays = getDaysSince(data?.usage?.telemetryCoverageStartDate)
     const showEarlyDataNotice = coverageAgeDays !== null && coverageAgeDays < 30
+    const breakdownGateEvents = data?.usage?.totalEvents90d ?? data?.usage?.totalEvents30d
+    const hasBreakdownEventDepth = typeof breakdownGateEvents !== 'number'
+        ? true
+        : breakdownGateEvents >= BREAKDOWN_MIN_EVENTS_90D
+    const hasBreakdownCoverageDepth = coverageAgeDays === null
+        ? true
+        : coverageAgeDays >= BREAKDOWN_MIN_DAYS
+    const showBreakdownCards = usageAvailable && hasBreakdownEventDepth && hasBreakdownCoverageDepth
+    const breakdownGateMessage = useMemo(() => {
+        if (!usageAvailable || showBreakdownCards) return null
+        const requirements = []
+        if (
+            typeof breakdownGateEvents === 'number' &&
+            breakdownGateEvents < BREAKDOWN_MIN_EVENTS_90D
+        ) {
+            requirements.push(`${BREAKDOWN_MIN_EVENTS_90D.toLocaleString()}+ events in the last 90 days`)
+        }
+        if (
+            typeof coverageAgeDays === 'number' &&
+            coverageAgeDays < BREAKDOWN_MIN_DAYS
+        ) {
+            requirements.push(`${BREAKDOWN_MIN_DAYS}+ days of telemetry coverage`)
+        }
+        if (requirements.length === 0) {
+            return 'Detailed telemetry breakdown is temporarily hidden while we validate signal quality.'
+        }
+        return `Detailed telemetry breakdown unlocks after ${requirements.join(' and ')}.`
+    }, [usageAvailable, showBreakdownCards, breakdownGateEvents, coverageAgeDays])
 
     const showSkeleton = loading && !data
 
@@ -268,7 +309,7 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
                         Loading telemetry metrics...
                     </div>
                     <div className={styles.metricsGrid}>
-                        {Array.from({ length: 3 }).map((_, index) => (
+                        {Array.from({ length: 4 }).map((_, index) => (
                             <MetricSkeletonCard key={index} />
                         ))}
                     </div>
@@ -281,34 +322,48 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
                     <div className={styles.metricsGrid}>
                         <MetricCard
                             icon={faChartLine}
-                            value={runsPrimary}
-                            label={`Agent Runs${telemetryCardSuffix}`}
-                            title="Derived from usage telemetry event volumes"
-                            secondaryValue={runsSecondary}
+                            value={totalEventsPrimary}
+                            label={`Total Events${telemetryCardSuffix}`}
+                            title="All non-ignored telemetry events"
+                            secondaryValue={totalEventsSecondary}
                             secondaryLabel={secondaryLabel}
-                            showSecondary={runsShowSecondary}
+                            showSecondary={totalEventsShowSecondary}
                         />
-                        <MetricCard
-                            icon={faComputerMouse}
-                            value={actionsPrimary}
-                            label={`GUI Actions${telemetryCardSuffix}`}
-                            title="Derived from usage telemetry event volumes"
-                            secondaryValue={actionsSecondary}
-                            secondaryLabel={secondaryLabel}
-                            showSecondary={actionsShowSecondary}
-                        />
-                        <MetricCard
-                            icon={faWindowRestore}
-                            value={demosPrimary}
-                            label={`Demos Recorded${telemetryCardSuffix}`}
-                            title="Derived from usage telemetry event volumes"
-                            secondaryValue={demosSecondary}
-                            secondaryLabel={secondaryLabel}
-                            showSecondary={demosShowSecondary}
-                        />
+                        {showBreakdownCards && (
+                            <>
+                                <MetricCard
+                                    icon={faBolt}
+                                    value={runsPrimary}
+                                    label={`Agent Runs${telemetryCardSuffix}`}
+                                    title="Derived from usage telemetry event volumes"
+                                    secondaryValue={runsSecondary}
+                                    secondaryLabel={secondaryLabel}
+                                    showSecondary={runsShowSecondary}
+                                />
+                                <MetricCard
+                                    icon={faComputerMouse}
+                                    value={actionsPrimary}
+                                    label={`GUI Actions${telemetryCardSuffix}`}
+                                    title="Derived from usage telemetry event volumes"
+                                    secondaryValue={actionsSecondary}
+                                    secondaryLabel={secondaryLabel}
+                                    showSecondary={actionsShowSecondary}
+                                />
+                                <MetricCard
+                                    icon={faWindowRestore}
+                                    value={demosPrimary}
+                                    label={`Demos Recorded${telemetryCardSuffix}`}
+                                    title="Derived from usage telemetry event volumes"
+                                    secondaryValue={demosSecondary}
+                                    secondaryLabel={secondaryLabel}
+                                    showSecondary={demosShowSecondary}
+                                />
+                            </>
+                        )}
                     </div>
 
                     {usageStatusMessage && <div className={styles.message}>{usageStatusMessage}</div>}
+                    {breakdownGateMessage && <div className={styles.message}>{breakdownGateMessage}</div>}
 
                     {sourceLabel && <div className={styles.source}>{sourceLabel}</div>}
                     {refreshing && <div className={styles.message}>Refreshing latest metrics...</div>}

--- a/components/AdoptionSignals.js
+++ b/components/AdoptionSignals.js
@@ -9,6 +9,10 @@ import {
 } from '@fortawesome/free-solid-svg-icons'
 import styles from './AdoptionSignals.module.css'
 
+const METRICS_CACHE_KEY = 'openadapt:adoption-signals:v1'
+const METRICS_CACHE_TTL_MS = 6 * 60 * 60 * 1000
+const FETCH_TIMEOUT_MS = 10000
+
 function formatMetric(value) {
     if (value === null || value === undefined || Number.isNaN(value)) return '—'
     if (value >= 1000000) return `${(value / 1000000).toFixed(1)}M`
@@ -16,7 +20,7 @@ function formatMetric(value) {
     return value.toLocaleString()
 }
 
-function MetricCard({ icon, value, label, title }) {
+function MetricCard({ icon, value, label, title, secondaryValue, secondaryLabel }) {
     return (
         <div className={styles.metricCard} title={title || ''}>
             <div className={styles.metricValue}>
@@ -24,36 +28,101 @@ function MetricCard({ icon, value, label, title }) {
                 {formatMetric(value)}
             </div>
             <div className={styles.metricLabel}>{label}</div>
+            {secondaryValue !== null && secondaryValue !== undefined && (
+                <div className={styles.metricSecondary}>
+                    {formatMetric(secondaryValue)} {secondaryLabel}
+                </div>
+            )}
+        </div>
+    )
+}
+
+function MetricSkeletonCard() {
+    return (
+        <div className={`${styles.metricCard} ${styles.metricCardSkeleton}`} aria-hidden="true">
+            <div className={styles.metricValue}>
+                <span className={styles.skeletonBarLarge} />
+            </div>
+            <div className={styles.metricLabel}>
+                <span className={styles.skeletonBarSmall} />
+            </div>
         </div>
     )
 }
 
 export default function AdoptionSignals() {
     const [loading, setLoading] = useState(true)
+    const [refreshing, setRefreshing] = useState(false)
+    const [showStaleNotice, setShowStaleNotice] = useState(false)
     const [error, setError] = useState(null)
     const [data, setData] = useState(null)
 
     useEffect(() => {
         let cancelled = false
 
-        async function fetchMetrics() {
-            setLoading(true)
-            setError(null)
+        function loadCachedMetrics() {
+            if (typeof window === 'undefined') return false
             try {
-                const response = await fetch('/api/project-metrics')
+                const raw = window.localStorage.getItem(METRICS_CACHE_KEY)
+                if (!raw) return false
+                const parsed = JSON.parse(raw)
+                if (!parsed?.payload || !parsed?.savedAt) return false
+                const ageMs = Date.now() - parsed.savedAt
+                if (ageMs > METRICS_CACHE_TTL_MS) return false
+                if (!cancelled) {
+                    setData(parsed.payload)
+                    setShowStaleNotice(true)
+                    setLoading(false)
+                }
+                return true
+            } catch {
+                return false
+            }
+        }
+
+        async function fetchMetrics({ initial }) {
+            if (initial) setLoading(true)
+            setRefreshing(true)
+            setError(null)
+            const controller = new AbortController()
+            const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+            try {
+                const response = await fetch(`/api/project-metrics?ts=${Date.now()}`, {
+                    signal: controller.signal,
+                    cache: 'no-store',
+                })
                 if (!response.ok) {
                     throw new Error(`API returned ${response.status}`)
                 }
                 const payload = await response.json()
-                if (!cancelled) setData(payload)
+                if (!cancelled) {
+                    setData(payload)
+                    setShowStaleNotice(false)
+                    if (typeof window !== 'undefined') {
+                        window.localStorage.setItem(
+                            METRICS_CACHE_KEY,
+                            JSON.stringify({ payload, savedAt: Date.now() })
+                        )
+                    }
+                }
             } catch (fetchError) {
-                if (!cancelled) setError(fetchError.message || 'Failed to load metrics')
+                if (!cancelled) {
+                    const message = fetchError?.name === 'AbortError'
+                        ? `Timed out after ${FETCH_TIMEOUT_MS / 1000}s`
+                        : fetchError.message || 'Failed to load metrics'
+                    setError(message)
+                }
             } finally {
-                if (!cancelled) setLoading(false)
+                clearTimeout(timeoutId)
+                if (!cancelled) {
+                    setLoading(false)
+                    setRefreshing(false)
+                }
             }
         }
 
-        fetchMetrics()
+        const hasCachedData = loadCachedMetrics()
+        fetchMetrics({ initial: !hasCachedData })
         return () => {
             cancelled = true
         }
@@ -67,6 +136,8 @@ export default function AdoptionSignals() {
         return `Usage metrics source: ${data.usage.source}`
     }, [data])
 
+    const showSkeleton = loading && !data
+
     return (
         <div className={styles.container}>
             <div className={styles.header}>
@@ -76,10 +147,22 @@ export default function AdoptionSignals() {
                 </p>
             </div>
 
-            {loading && <div className={styles.message}>Loading adoption metrics...</div>}
-            {error && <div className={styles.error}>Unable to load adoption metrics: {error}</div>}
+            {showSkeleton && (
+                <>
+                    <div className={styles.loadingRow}>
+                        <span className={styles.spinner} />
+                        Loading adoption metrics...
+                    </div>
+                    <div className={styles.metricsGrid}>
+                        {Array.from({ length: 5 }).map((_, index) => (
+                            <MetricSkeletonCard key={index} />
+                        ))}
+                    </div>
+                </>
+            )}
+            {error && !data && <div className={styles.error}>Unable to load adoption metrics: {error}</div>}
 
-            {!loading && !error && (
+            {!showSkeleton && data && (
                 <>
                     <div className={styles.metricsGrid}>
                         <MetricCard
@@ -99,18 +182,24 @@ export default function AdoptionSignals() {
                             value={data?.usage?.agentRuns30d}
                             label="Agent Runs (30d)"
                             title="Derived from usage telemetry event volumes"
+                            secondaryValue={data?.usage?.agentRunsAllTime}
+                            secondaryLabel="all-time"
                         />
                         <MetricCard
                             icon={faComputerMouse}
                             value={data?.usage?.guiActions30d}
                             label="GUI Actions (30d)"
                             title="Derived from usage telemetry event volumes"
+                            secondaryValue={data?.usage?.guiActionsAllTime}
+                            secondaryLabel="all-time"
                         />
                         <MetricCard
                             icon={faWindowRestore}
                             value={data?.usage?.demosRecorded30d}
                             label="Demos Recorded (30d)"
                             title="Derived from usage telemetry event volumes"
+                            secondaryValue={data?.usage?.demosRecordedAllTime}
+                            secondaryLabel="all-time"
                         />
                     </div>
 
@@ -121,6 +210,17 @@ export default function AdoptionSignals() {
                     )}
 
                     {sourceLabel && <div className={styles.source}>{sourceLabel}</div>}
+                    {refreshing && <div className={styles.message}>Refreshing latest metrics...</div>}
+                    {showStaleNotice && !refreshing && (
+                        <div className={styles.message}>
+                            Showing cached snapshot while background refresh completes.
+                        </div>
+                    )}
+                    {error && (
+                        <div className={styles.error}>
+                            Live refresh failed: {error}
+                        </div>
+                    )}
                 </>
             )}
         </div>

--- a/components/AdoptionSignals.js
+++ b/components/AdoptionSignals.js
@@ -156,7 +156,7 @@ export default function AdoptionSignals() {
     return (
         <div className={styles.container}>
             <div className={styles.header}>
-                <h3 className={styles.title}>OpenAdapt Adoption Signals</h3>
+                <h3 className={styles.title}>Adoption Signals</h3>
                 <p className={styles.subtitle}>
                     Prioritizing product usage and GitHub traction; package downloads are shown separately.
                 </p>

--- a/components/AdoptionSignals.js
+++ b/components/AdoptionSignals.js
@@ -1,15 +1,13 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
-    faCodeBranch,
-    faStar,
     faChartLine,
     faComputerMouse,
     faWindowRestore,
 } from '@fortawesome/free-solid-svg-icons'
 import styles from './AdoptionSignals.module.css'
 
-const METRICS_CACHE_KEY = 'openadapt:adoption-signals:v3'
+const METRICS_CACHE_KEY = 'openadapt:adoption-signals:v4'
 const METRICS_CACHE_TTL_MS = 6 * 60 * 60 * 1000
 const FETCH_TIMEOUT_MS = 10000
 
@@ -28,14 +26,6 @@ function hasUsableUsageMetrics(payload) {
         usage.demosRecordedAllTime,
     ]
     return candidates.some((value) => typeof value === 'number')
-}
-
-function hasUsableGithubMetrics(payload) {
-    return typeof payload?.github?.stars === 'number' && typeof payload?.github?.forks === 'number'
-}
-
-function hasUsableCachedSnapshot(payload) {
-    return hasUsableUsageMetrics(payload) && hasUsableGithubMetrics(payload)
 }
 
 function formatMetric(value) {
@@ -128,7 +118,6 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
     const [showStaleNotice, setShowStaleNotice] = useState(false)
     const [error, setError] = useState(null)
     const [data, setData] = useState(null)
-    const [lastGoodGithub, setLastGoodGithub] = useState(null)
 
     useEffect(() => {
         let cancelled = false
@@ -142,10 +131,9 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
                 if (!parsed?.payload || !parsed?.savedAt) return false
                 const ageMs = Date.now() - parsed.savedAt
                 if (ageMs > METRICS_CACHE_TTL_MS) return false
-                if (!hasUsableCachedSnapshot(parsed.payload)) return false
+                if (!hasUsableUsageMetrics(parsed.payload)) return false
                 if (!cancelled) {
                     setData(parsed.payload)
-                    setLastGoodGithub(parsed.payload.github)
                     setShowStaleNotice(true)
                     setLoading(false)
                 }
@@ -171,12 +159,9 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
                 }
                 const payload = await response.json()
                 if (!cancelled) {
-                    if (hasUsableGithubMetrics(payload)) {
-                        setLastGoodGithub(payload.github)
-                    }
                     setData(payload)
                     setShowStaleNotice(false)
-                    if (typeof window !== 'undefined' && hasUsableCachedSnapshot(payload)) {
+                    if (typeof window !== 'undefined' && hasUsableUsageMetrics(payload)) {
                         window.localStorage.setItem(
                             METRICS_CACHE_KEY,
                             JSON.stringify({ payload, savedAt: Date.now() })
@@ -208,7 +193,6 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
 
     const usageAvailable = Boolean(data?.usage?.available)
     const usageSource = String(data?.usage?.source || '')
-    const githubStats = hasUsableGithubMetrics(data) ? data.github : lastGoodGithub
     const isAllTime = timeRange === 'all'
     const runsPrimary = isAllTime
         ? data?.usage?.agentRunsAllTime
@@ -267,9 +251,9 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
     return (
         <div className={styles.container}>
             <div className={styles.header}>
-                <h3 className={styles.title}>Adoption Signals</h3>
+                <h3 className={styles.title}>Product Telemetry</h3>
                 <p className={styles.subtitle}>
-                    Track OpenAdapt&apos;s all-time footprint and 90-day momentum.
+                    Privacy-preserving usage telemetry from OpenAdapt clients, shown as all-time and 90-day totals.
                 </p>
                 {telemetryWindowLabel && <div className={styles.windowBadge}>{telemetryWindowLabel}</div>}
             </div>
@@ -278,32 +262,20 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
                 <>
                     <div className={styles.loadingRow}>
                         <span className={styles.spinner} />
-                        Loading adoption metrics...
+                        Loading telemetry metrics...
                     </div>
                     <div className={styles.metricsGrid}>
-                        {Array.from({ length: 5 }).map((_, index) => (
+                        {Array.from({ length: 3 }).map((_, index) => (
                             <MetricSkeletonCard key={index} />
                         ))}
                     </div>
                 </>
             )}
-            {error && !data && <div className={styles.error}>Unable to load adoption metrics: {error}</div>}
+            {error && !data && <div className={styles.error}>Unable to load telemetry metrics: {error}</div>}
 
             {!showSkeleton && data && (
                 <>
                     <div className={styles.metricsGrid}>
-                        <MetricCard
-                            icon={faStar}
-                            value={githubStats?.stars}
-                            label="Ecosystem Stars"
-                            title="Total stars across public OpenAdaptAI openadapt* repositories"
-                        />
-                        <MetricCard
-                            icon={faCodeBranch}
-                            value={githubStats?.forks}
-                            label="Ecosystem Forks"
-                            title="Total forks across public OpenAdaptAI openadapt* repositories"
-                        />
                         <MetricCard
                             icon={faChartLine}
                             value={runsPrimary}

--- a/components/AdoptionSignals.js
+++ b/components/AdoptionSignals.js
@@ -48,6 +48,16 @@ function formatCoverageDate(value) {
     })
 }
 
+function formatCoverageShortDate(value) {
+    if (!value) return null
+    const parsed = new Date(value)
+    if (Number.isNaN(parsed.getTime())) return null
+    return parsed.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+    })
+}
+
 function shouldShowSecondary(primaryValue, secondaryValue) {
     if (secondaryValue === null || secondaryValue === undefined || Number.isNaN(secondaryValue)) return false
     if (primaryValue === null || primaryValue === undefined || Number.isNaN(primaryValue)) return true
@@ -55,7 +65,16 @@ function shouldShowSecondary(primaryValue, secondaryValue) {
     return formatMetric(primaryValue) !== formatMetric(secondaryValue)
 }
 
-function MetricCard({ icon, value, label, title, secondaryValue, secondaryLabel, showSecondary = true }) {
+function MetricCard({
+    icon,
+    value,
+    label,
+    title,
+    secondaryValue,
+    secondaryLabel,
+    showSecondary = true,
+    chipLabel = null,
+}) {
     return (
         <div className={styles.metricCard} title={title || ''}>
             <div className={styles.metricValue}>
@@ -68,6 +87,7 @@ function MetricCard({ icon, value, label, title, secondaryValue, secondaryLabel,
                     {formatMetric(secondaryValue)} {secondaryLabel}
                 </div>
             )}
+            {chipLabel && <div className={styles.metricChip}>{chipLabel}</div>}
         </div>
     )
 }
@@ -205,12 +225,19 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
         }
         return 'Usage metrics are currently unavailable.'
     }, [usageAvailable, usageSource])
-    const coverageStartLabel = useMemo(() => {
+    const coverageShortLabel = useMemo(
+        () => formatCoverageShortDate(data?.usage?.telemetryCoverageStartDate),
+        [data]
+    )
+    const telemetryWindowLabel = useMemo(() => {
         if (!usageSource.startsWith('posthog')) return null
         const formatted = formatCoverageDate(data?.usage?.telemetryCoverageStartDate)
         if (!formatted) return null
-        return `Telemetry coverage starts ${formatted}.`
+        return `Telemetry window: ${formatted} - present`
     }, [data, usageSource])
+    const telemetryCardSuffix = coverageShortLabel ? ` (since ${coverageShortLabel})` : ''
+    const demosAllTime = data?.usage?.demosRecordedAllTime
+    const demosEarlyData = typeof demosAllTime === 'number' && demosAllTime < 25
 
     const showSkeleton = loading && !data
 
@@ -221,6 +248,7 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
                 <p className={styles.subtitle}>
                     Track OpenAdapt&apos;s all-time footprint and 90-day momentum.
                 </p>
+                {telemetryWindowLabel && <div className={styles.windowBadge}>{telemetryWindowLabel}</div>}
             </div>
 
             {showSkeleton && (
@@ -256,7 +284,7 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
                         <MetricCard
                             icon={faChartLine}
                             value={runsPrimary}
-                            label="Agent Runs"
+                            label={`Agent Runs${telemetryCardSuffix}`}
                             title="Derived from usage telemetry event volumes"
                             secondaryValue={runsSecondary}
                             secondaryLabel={secondaryLabel}
@@ -265,7 +293,7 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
                         <MetricCard
                             icon={faComputerMouse}
                             value={actionsPrimary}
-                            label="GUI Actions"
+                            label={`GUI Actions${telemetryCardSuffix}`}
                             title="Derived from usage telemetry event volumes"
                             secondaryValue={actionsSecondary}
                             secondaryLabel={secondaryLabel}
@@ -274,18 +302,18 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
                         <MetricCard
                             icon={faWindowRestore}
                             value={demosPrimary}
-                            label="Demos Recorded"
+                            label={`Demos Recorded${telemetryCardSuffix}`}
                             title="Derived from usage telemetry event volumes"
                             secondaryValue={demosSecondary}
                             secondaryLabel={secondaryLabel}
                             showSecondary={demosShowSecondary}
+                            chipLabel={demosEarlyData ? 'Early data' : null}
                         />
                     </div>
 
                     {usageStatusMessage && <div className={styles.message}>{usageStatusMessage}</div>}
 
                     {sourceLabel && <div className={styles.source}>{sourceLabel}</div>}
-                    {coverageStartLabel && <div className={styles.source}>{coverageStartLabel}</div>}
                     {refreshing && <div className={styles.message}>Refreshing latest metrics...</div>}
                     {showStaleNotice && !refreshing && (
                         <div className={styles.message}>

--- a/components/AdoptionSignals.js
+++ b/components/AdoptionSignals.js
@@ -165,6 +165,7 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
     }, [])
 
     const usageAvailable = Boolean(data?.usage?.available)
+    const usageSource = String(data?.usage?.source || '')
     const isAllTime = timeRange === 'all'
     const runsPrimary = isAllTime
         ? data?.usage?.agentRunsAllTime
@@ -189,18 +190,27 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
     const actionsShowSecondary = shouldShowSecondary(actionsPrimary, actionsSecondary)
     const demosShowSecondary = shouldShowSecondary(demosPrimary, demosSecondary)
     const sourceLabel = useMemo(() => {
-        if (!data?.usage?.source) return null
-        if (String(data.usage.source).startsWith('posthog')) return 'Usage metrics source: PostHog'
-        if (String(data.usage.source).startsWith('env_override')) return 'Usage metrics source: configured counters'
-        return `Usage metrics source: ${data.usage.source}`
-    }, [data])
+        if (!usageSource) return null
+        if (usageSource.startsWith('posthog')) return 'Usage metrics source: PostHog'
+        if (usageSource.startsWith('env_override')) return 'Usage metrics source: configured counters'
+        return `Usage metrics source: ${usageSource}`
+    }, [usageSource])
+    const usageStatusMessage = useMemo(() => {
+        if (usageAvailable) return null
+        if (usageSource === 'posthog_not_configured' || usageSource === 'env_override_not_set') {
+            return 'Usage metrics are not configured yet. Set PostHog credentials or OPENADAPT_METRIC_* overrides.'
+        }
+        if (usageSource.startsWith('posthog')) {
+            return 'Usage metrics are temporarily unavailable. We will retry automatically.'
+        }
+        return 'Usage metrics are currently unavailable.'
+    }, [usageAvailable, usageSource])
     const coverageStartLabel = useMemo(() => {
-        const source = String(data?.usage?.source || '')
-        if (!source.startsWith('posthog')) return null
+        if (!usageSource.startsWith('posthog')) return null
         const formatted = formatCoverageDate(data?.usage?.telemetryCoverageStartDate)
         if (!formatted) return null
         return `Telemetry coverage starts ${formatted}.`
-    }, [data])
+    }, [data, usageSource])
 
     const showSkeleton = loading && !data
 
@@ -272,11 +282,7 @@ export default function AdoptionSignals({ timeRange = 'all' }) {
                         />
                     </div>
 
-                    {!usageAvailable && (
-                        <div className={styles.message}>
-                            Usage metrics are not configured yet. Set PostHog credentials or OPENADAPT_METRIC_* overrides.
-                        </div>
-                    )}
+                    {usageStatusMessage && <div className={styles.message}>{usageStatusMessage}</div>}
 
                     {sourceLabel && <div className={styles.source}>{sourceLabel}</div>}
                     {coverageStartLabel && <div className={styles.source}>{coverageStartLabel}</div>}

--- a/components/AdoptionSignals.js
+++ b/components/AdoptionSignals.js
@@ -9,7 +9,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons'
 import styles from './AdoptionSignals.module.css'
 
-const METRICS_CACHE_KEY = 'openadapt:adoption-signals:v2'
+const METRICS_CACHE_KEY = 'openadapt:adoption-signals:v3'
 const METRICS_CACHE_TTL_MS = 6 * 60 * 60 * 1000
 const FETCH_TIMEOUT_MS = 10000
 

--- a/components/AdoptionSignals.module.css
+++ b/components/AdoptionSignals.module.css
@@ -3,8 +3,10 @@
     border: 1px solid rgba(86, 13, 248, 0.28);
     border-radius: 16px;
     padding: 24px;
-    margin: 24px auto;
-    max-width: 1100px;
+    margin: 24px 0;
+    width: 100%;
+    max-width: none;
+    box-sizing: border-box;
 }
 
 .header {

--- a/components/AdoptionSignals.module.css
+++ b/components/AdoptionSignals.module.css
@@ -40,6 +40,14 @@
     letter-spacing: 0.2px;
 }
 
+.earlyNotice {
+    margin-top: 8px;
+    color: #fde68a;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.2px;
+}
+
 .metricsGrid {
     display: grid;
     grid-template-columns: repeat(3, minmax(180px, 1fr));
@@ -88,20 +96,6 @@
     font-size: 10px;
     text-transform: uppercase;
     letter-spacing: 0.3px;
-}
-
-.metricChip {
-    margin-top: 6px;
-    display: inline-block;
-    padding: 2px 8px;
-    border-radius: 999px;
-    border: 1px solid rgba(251, 191, 36, 0.45);
-    background: rgba(251, 191, 36, 0.15);
-    color: #fde68a;
-    font-size: 10px;
-    font-weight: 600;
-    letter-spacing: 0.3px;
-    text-transform: uppercase;
 }
 
 .message {
@@ -201,7 +195,7 @@
 
 @media (max-width: 1024px) {
     .metricsGrid {
-        grid-template-columns: repeat(2, minmax(160px, 1fr));
+        grid-template-columns: repeat(3, minmax(0, 1fr));
     }
 }
 
@@ -210,16 +204,12 @@
         padding: 16px;
     }
 
-    .metricsGrid {
-        grid-template-columns: repeat(2, minmax(140px, 1fr));
-    }
-
     .title {
         font-size: 18px;
     }
 }
 
-@media (max-width: 460px) {
+@media (max-width: 760px) {
     .metricsGrid {
         grid-template-columns: 1fr;
     }

--- a/components/AdoptionSignals.module.css
+++ b/components/AdoptionSignals.module.css
@@ -63,11 +63,48 @@
     letter-spacing: 0.4px;
 }
 
+.metricSecondary {
+    margin-top: 4px;
+    color: rgba(255, 255, 255, 0.52);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+}
+
 .message {
     margin-top: 12px;
     text-align: center;
     color: rgba(255, 255, 255, 0.7);
     font-size: 13px;
+}
+
+.loadingRow {
+    margin: 10px 0 14px 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    color: rgba(255, 255, 255, 0.74);
+    font-size: 13px;
+}
+
+.spinner {
+    width: 14px;
+    height: 14px;
+    border: 2px solid rgba(255, 255, 255, 0.22);
+    border-top-color: #93c5fd;
+    border-radius: 50%;
+    animation: adoptionSpin 0.9s linear infinite;
+}
+
+@keyframes adoptionSpin {
+    from {
+        transform: rotate(0deg);
+    }
+
+    to {
+        transform: rotate(360deg);
+    }
 }
 
 .error {
@@ -83,6 +120,50 @@
     color: rgba(255, 255, 255, 0.5);
     font-size: 11px;
     letter-spacing: 0.2px;
+}
+
+.metricCardSkeleton {
+    position: relative;
+    overflow: hidden;
+}
+
+.metricCardSkeleton::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+        90deg,
+        rgba(255, 255, 255, 0) 0%,
+        rgba(255, 255, 255, 0.06) 50%,
+        rgba(255, 255, 255, 0) 100%
+    );
+    transform: translateX(-100%);
+    animation: skeletonSweep 1.4s ease-in-out infinite;
+}
+
+.skeletonBarLarge {
+    width: 68px;
+    height: 18px;
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.12);
+}
+
+.skeletonBarSmall {
+    display: inline-block;
+    width: 88px;
+    height: 10px;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.1);
+}
+
+@keyframes skeletonSweep {
+    from {
+        transform: translateX(-100%);
+    }
+
+    to {
+        transform: translateX(100%);
+    }
 }
 
 @media (max-width: 1024px) {

--- a/components/AdoptionSignals.module.css
+++ b/components/AdoptionSignals.module.css
@@ -42,7 +42,7 @@
 
 .metricsGrid {
     display: grid;
-    grid-template-columns: repeat(5, minmax(160px, 1fr));
+    grid-template-columns: repeat(3, minmax(180px, 1fr));
     gap: 12px;
     align-items: stretch;
 }
@@ -201,7 +201,7 @@
 
 @media (max-width: 1024px) {
     .metricsGrid {
-        grid-template-columns: repeat(3, minmax(160px, 1fr));
+        grid-template-columns: repeat(2, minmax(160px, 1fr));
     }
 }
 
@@ -216,5 +216,11 @@
 
     .title {
         font-size: 18px;
+    }
+}
+
+@media (max-width: 460px) {
+    .metricsGrid {
+        grid-template-columns: 1fr;
     }
 }

--- a/components/AdoptionSignals.module.css
+++ b/components/AdoptionSignals.module.css
@@ -27,6 +27,19 @@
     font-size: 14px;
 }
 
+.windowBadge {
+    margin: 10px auto 0 auto;
+    display: inline-block;
+    padding: 6px 10px;
+    border-radius: 999px;
+    border: 1px solid rgba(147, 197, 253, 0.4);
+    background: rgba(147, 197, 253, 0.12);
+    color: #dbeafe;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.2px;
+}
+
 .metricsGrid {
     display: grid;
     grid-template-columns: repeat(5, minmax(160px, 1fr));
@@ -75,6 +88,20 @@
     font-size: 10px;
     text-transform: uppercase;
     letter-spacing: 0.3px;
+}
+
+.metricChip {
+    margin-top: 6px;
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 999px;
+    border: 1px solid rgba(251, 191, 36, 0.45);
+    background: rgba(251, 191, 36, 0.15);
+    color: #fde68a;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.3px;
+    text-transform: uppercase;
 }
 
 .message {

--- a/components/AdoptionSignals.module.css
+++ b/components/AdoptionSignals.module.css
@@ -27,8 +27,9 @@
 
 .metricsGrid {
     display: grid;
-    grid-template-columns: repeat(5, minmax(0, 1fr));
+    grid-template-columns: repeat(5, minmax(160px, 1fr));
     gap: 12px;
+    align-items: stretch;
 }
 
 .metricCard {
@@ -37,6 +38,9 @@
     border-radius: 12px;
     padding: 14px 10px;
     text-align: center;
+    width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
 }
 
 .metricValue {
@@ -168,7 +172,7 @@
 
 @media (max-width: 1024px) {
     .metricsGrid {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
+        grid-template-columns: repeat(3, minmax(160px, 1fr));
     }
 }
 
@@ -178,7 +182,7 @@
     }
 
     .metricsGrid {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
+        grid-template-columns: repeat(2, minmax(140px, 1fr));
     }
 
     .title {

--- a/components/AdoptionSignals.module.css
+++ b/components/AdoptionSignals.module.css
@@ -1,0 +1,106 @@
+.container {
+    background: linear-gradient(135deg, rgba(86, 13, 248, 0.11) 0%, rgba(0, 0, 30, 0.95) 100%);
+    border: 1px solid rgba(86, 13, 248, 0.28);
+    border-radius: 16px;
+    padding: 24px;
+    margin: 24px auto;
+    max-width: 1100px;
+}
+
+.header {
+    text-align: center;
+    margin-bottom: 16px;
+}
+
+.title {
+    margin: 0 0 6px 0;
+    color: #ffffff;
+    font-size: 21px;
+    font-weight: 600;
+}
+
+.subtitle {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.72);
+    font-size: 14px;
+}
+
+.metricsGrid {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 12px;
+}
+
+.metricCard {
+    background: rgba(0, 0, 0, 0.2);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    padding: 14px 10px;
+    text-align: center;
+}
+
+.metricValue {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    color: #93c5fd;
+    font-weight: 700;
+    font-size: 20px;
+    line-height: 1;
+}
+
+.metricIcon {
+    font-size: 14px;
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.metricLabel {
+    margin-top: 6px;
+    color: rgba(255, 255, 255, 0.67);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+}
+
+.message {
+    margin-top: 12px;
+    text-align: center;
+    color: rgba(255, 255, 255, 0.7);
+    font-size: 13px;
+}
+
+.error {
+    margin-top: 8px;
+    text-align: center;
+    color: #fca5a5;
+    font-size: 13px;
+}
+
+.source {
+    margin-top: 10px;
+    text-align: center;
+    color: rgba(255, 255, 255, 0.5);
+    font-size: 11px;
+    letter-spacing: 0.2px;
+}
+
+@media (max-width: 1024px) {
+    .metricsGrid {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 640px) {
+    .container {
+        padding: 16px;
+    }
+
+    .metricsGrid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .title {
+        font-size: 18px;
+    }
+}

--- a/components/AdoptionSignals.module.css
+++ b/components/AdoptionSignals.module.css
@@ -50,7 +50,7 @@
 
 .metricsGrid {
     display: grid;
-    grid-template-columns: repeat(3, minmax(180px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
     gap: 12px;
     align-items: stretch;
 }
@@ -195,7 +195,7 @@
 
 @media (max-width: 1024px) {
     .metricsGrid {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
     }
 }
 

--- a/components/AdoptionSignals.module.css
+++ b/components/AdoptionSignals.module.css
@@ -214,3 +214,122 @@
         grid-template-columns: 1fr;
     }
 }
+
+.transparencyPanel {
+    margin-top: 14px;
+    background: rgba(0, 0, 0, 0.18);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 12px;
+    overflow: hidden;
+}
+
+.transparencySummary {
+    cursor: pointer;
+    padding: 12px 14px;
+    font-size: 13px;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.9);
+    list-style: none;
+}
+
+.transparencySummary::-webkit-details-marker {
+    display: none;
+}
+
+.transparencySummary::before {
+    content: '▸';
+    display: inline-block;
+    margin-right: 8px;
+    color: rgba(255, 255, 255, 0.72);
+    transform: translateY(-1px);
+    transition: transform 0.15s ease;
+}
+
+.transparencyPanel[open] .transparencySummary::before {
+    transform: rotate(90deg);
+}
+
+.transparencyBody {
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 12px 14px 14px 14px;
+}
+
+.transparencyIntro {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.8);
+    font-size: 12px;
+    line-height: 1.5;
+}
+
+.transparencyMeta {
+    margin-top: 8px;
+    color: rgba(255, 255, 255, 0.62);
+    font-size: 11px;
+    letter-spacing: 0.2px;
+}
+
+.transparencySection {
+    margin-top: 12px;
+}
+
+.transparencyHeading {
+    margin: 0 0 6px 0;
+    color: #dbeafe;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.transparencySubheading {
+    margin: 0 0 4px 0;
+    color: rgba(255, 255, 255, 0.74);
+    font-size: 11px;
+    font-weight: 600;
+}
+
+.transparencyColumns {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 8px 12px;
+}
+
+.transparencyList {
+    margin: 0;
+    padding-left: 18px;
+    color: rgba(255, 255, 255, 0.78);
+    font-size: 11px;
+    line-height: 1.45;
+}
+
+.transparencyListCompact {
+    margin: 0;
+    padding-left: 18px;
+    color: rgba(255, 255, 255, 0.78);
+    font-size: 11px;
+    line-height: 1.4;
+}
+
+.transparencyList code,
+.transparencyListCompact code {
+    color: #bfdbfe;
+    font-size: 11px;
+    word-break: break-word;
+}
+
+.transparencyLinks {
+    margin-top: 14px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.transparencyLink {
+    color: #93c5fd;
+    font-size: 12px;
+    text-decoration: none;
+    border-bottom: 1px dotted rgba(147, 197, 253, 0.7);
+}
+
+.transparencyLink:hover {
+    color: #dbeafe;
+    border-bottom-color: rgba(219, 234, 254, 0.85);
+}

--- a/components/Developers.js
+++ b/components/Developers.js
@@ -149,14 +149,14 @@ export default function Developers() {
                         </div>
                     </div>
 
-                    <AdoptionSignals timeRange={insightRange} />
-
                     {/* PyPI Download Statistics */}
                     <PyPIDownloadChart
                         timeRange={insightRange}
                         onTimeRangeChange={setInsightRange}
                         hideRangeControl
                     />
+
+                    <AdoptionSignals timeRange={insightRange} />
 
                     {/* Legacy Desktop App Downloads - Disabled during transition to new architecture
                     <div className="mt-12">

--- a/components/Developers.js
+++ b/components/Developers.js
@@ -15,6 +15,7 @@ export default function Developers() {
     const [latestRelease, setLatestRelease] = useState({ version: null, date: null });
     const [downloadCount, setDownloadCount] = useState({ windows: 0, mac: 0 });
     const [buildWarnings, setBuildWarnings] = useState([]);
+    const [insightRange, setInsightRange] = useState('all');
     const macURL = latestRelease.version
         ? `https://github.com/OpenAdaptAI/OpenAdapt/releases/download/${latestRelease.version}/OpenAdapt-${latestRelease.version}.dmg`
         : '';
@@ -128,10 +129,34 @@ export default function Developers() {
                     <InstallSection />
 
                     {/* Primary trust signals: GitHub + usage telemetry */}
-                    <AdoptionSignals />
+                    <div className={styles.insightControls}>
+                        <span className={styles.insightLabel}>Window:</span>
+                        <div className={styles.insightToggleGroup}>
+                            <button
+                                className={`${styles.insightToggleBtn} ${insightRange === 'all' ? styles.insightToggleBtnActive : ''}`}
+                                onClick={() => setInsightRange('all')}
+                                type="button"
+                            >
+                                All time
+                            </button>
+                            <button
+                                className={`${styles.insightToggleBtn} ${insightRange === '90d' ? styles.insightToggleBtnActive : ''}`}
+                                onClick={() => setInsightRange('90d')}
+                                type="button"
+                            >
+                                90 days
+                            </button>
+                        </div>
+                    </div>
+
+                    <AdoptionSignals timeRange={insightRange} />
 
                     {/* PyPI Download Statistics */}
-                    <PyPIDownloadChart />
+                    <PyPIDownloadChart
+                        timeRange={insightRange}
+                        onTimeRangeChange={setInsightRange}
+                        hideRangeControl
+                    />
 
                     {/* Legacy Desktop App Downloads - Disabled during transition to new architecture
                     <div className="mt-12">

--- a/components/Developers.js
+++ b/components/Developers.js
@@ -9,6 +9,7 @@ import EmailForm from '@components/EmailForm';
 import InstallSection from '@components/InstallSection';
 import DownloadGraph from './DownloadGraph';
 import PyPIDownloadChart from './PyPIDownloadChart';
+import AdoptionSignals from './AdoptionSignals';
 
 export default function Developers() {
     const [latestRelease, setLatestRelease] = useState({ version: null, date: null });
@@ -125,6 +126,9 @@ export default function Developers() {
 
                     {/* New uv-first Installation Section */}
                     <InstallSection />
+
+                    {/* Primary trust signals: GitHub + usage telemetry */}
+                    <AdoptionSignals />
 
                     {/* PyPI Download Statistics */}
                     <PyPIDownloadChart />

--- a/components/Developers.module.css
+++ b/components/Developers.module.css
@@ -64,3 +64,54 @@
     border: 1px solid rgba(86, 13, 248, 0.5);
     z-index: 1000;
 }
+
+.insightControls {
+    margin: 8px auto 0 auto;
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 10px;
+}
+
+.insightLabel {
+    color: rgba(255, 255, 255, 0.7);
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+}
+
+.insightToggleGroup {
+    display: inline-flex;
+    gap: 8px;
+}
+
+.insightToggleBtn {
+    background: rgba(0, 0, 0, 0.22);
+    color: rgba(255, 255, 255, 0.78);
+    border: 1px solid rgba(86, 13, 248, 0.45);
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.2px;
+    padding: 6px 12px;
+    transition: all 0.2s ease;
+}
+
+.insightToggleBtn:hover {
+    color: #fff;
+    border-color: rgba(127, 76, 255, 0.7);
+}
+
+.insightToggleBtnActive {
+    background: rgba(86, 13, 248, 0.32);
+    color: #fff;
+    border-color: rgba(127, 76, 255, 0.85);
+    box-shadow: 0 0 0 1px rgba(127, 76, 255, 0.25) inset;
+}
+
+@media (max-width: 640px) {
+    .insightControls {
+        justify-content: center;
+    }
+}

--- a/components/InstallSection.js
+++ b/components/InstallSection.js
@@ -1,12 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faWindows, faApple, faLinux, faPython } from '@fortawesome/free-brands-svg-icons';
-import { faCopy, faCheck, faTerminal, faDownload } from '@fortawesome/free-solid-svg-icons';
+import { faCopy, faCheck, faTerminal } from '@fortawesome/free-solid-svg-icons';
 import styles from './InstallSection.module.css';
 import { getPyPIDownloadStats, formatDownloadCount } from 'utils/pypiStats';
 
 const platforms = {
     'macOS': {
+        oneLiner: '(command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | sh) && (uv tool install openadapt || ~/.local/bin/uv tool install openadapt) && (openadapt --help || ~/.local/bin/openadapt --help)',
         icon: faApple,
         commands: [
             'curl -LsSf https://astral.sh/uv/install.sh | sh',
@@ -16,6 +17,7 @@ const platforms = {
         note: 'Works on Intel and Apple Silicon Macs'
     },
     'Linux': {
+        oneLiner: '(command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | sh) && (uv tool install openadapt || ~/.local/bin/uv tool install openadapt) && (openadapt --help || ~/.local/bin/openadapt --help)',
         icon: faLinux,
         commands: [
             'curl -LsSf https://astral.sh/uv/install.sh | sh',
@@ -25,6 +27,7 @@ const platforms = {
         note: 'Works on most modern Linux distributions'
     },
     'Windows': {
+        oneLiner: 'powershell -NoProfile -ExecutionPolicy Bypass -Command "if (-not (Get-Command uv -ErrorAction SilentlyContinue)) { irm https://astral.sh/uv/install.ps1 | iex }; uv tool install openadapt; openadapt --help"',
         icon: faWindows,
         commands: [
             'powershell -c "irm https://astral.sh/uv/install.ps1 | iex"',
@@ -86,7 +89,7 @@ export default function InstallSection() {
     }, []);
 
     const currentPlatform = platforms[selectedPlatform];
-    const allCommands = currentPlatform.commands.join('\n');
+    const fallbackCommands = currentPlatform.commands.join('\n');
 
     return (
         <div className={styles.installSection}>
@@ -132,8 +135,24 @@ export default function InstallSection() {
             {/* Code Block */}
             <div className={styles.codeContainer}>
                 <div className={styles.codeHeader}>
-                    <span className={styles.codeTitle}>Terminal</span>
-                    <CopyButton text={allCommands} />
+                    <span className={styles.codeTitle}>One-liner (recommended)</span>
+                    <CopyButton text={currentPlatform.oneLiner} />
+                </div>
+                <pre className={styles.codeBlock}>
+                    <div className={styles.commandLine}>
+                        <span className={styles.prompt}>$</span>
+                        <code className={styles.command}>{currentPlatform.oneLiner}</code>
+                    </div>
+                </pre>
+                <div className={styles.codeFooter}>
+                    <span className={styles.note}>{currentPlatform.note}</span>
+                </div>
+            </div>
+
+            <div className={styles.fallbackSection}>
+                <div className={styles.codeHeader}>
+                    <span className={styles.codeTitle}>Fallback (step-by-step)</span>
+                    <CopyButton text={fallbackCommands} />
                 </div>
                 <pre className={styles.codeBlock}>
                     {currentPlatform.commands.map((cmd, index) => (
@@ -143,9 +162,6 @@ export default function InstallSection() {
                         </div>
                     ))}
                 </pre>
-                <div className={styles.codeFooter}>
-                    <span className={styles.note}>{currentPlatform.note}</span>
-                </div>
             </div>
 
             {/* What is uv? */}

--- a/components/InstallSection.module.css
+++ b/components/InstallSection.module.css
@@ -196,6 +196,14 @@
     font-size: 12px;
 }
 
+.fallbackSection {
+    margin-top: 12px;
+    background: #1a1a2e;
+    border-radius: 12px;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
 /* UV Info */
 .uvInfo {
     margin-top: 16px;

--- a/components/PyPIDownloadChart.js
+++ b/components/PyPIDownloadChart.js
@@ -588,10 +588,10 @@ const PyPIDownloadChart = () => {
             <div className={styles.header}>
                 <div className={styles.titleRow}>
                     <FontAwesomeIcon icon={faPython} className={styles.icon} />
-                    <h3 className={styles.title}>PyPI Download Trends</h3>
+                    <h3 className={styles.title}>PyPI Download Trends (Secondary Signal)</h3>
                 </div>
                 <p className={styles.subtitle}>
-                    Historical download statistics for OpenAdapt packages
+                    Useful for package momentum, but can be inflated by CI and dependency installs.
                 </p>
             </div>
 
@@ -778,7 +778,7 @@ const PyPIDownloadChart = () => {
                         >
                             PyPI OpenAdapt packages
                         </a>
-                        {' '}via pypistats.org API (data retained for ~180 days)
+                        {' '}via pypistats.org API (data retained for ~180 days). Treat as directional alongside usage metrics.
                     </span>
                 </div>
             </div>

--- a/components/PyPIDownloadChart.js
+++ b/components/PyPIDownloadChart.js
@@ -159,17 +159,34 @@ const packageColors = {
     },
 };
 
-const PyPIDownloadChart = () => {
+const PyPIDownloadChart = ({ timeRange: controlledTimeRange = null, onTimeRangeChange = null, hideRangeControl = false }) => {
     const [historyData, setHistoryData] = useState(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
     const [chartType, setChartType] = useState('cumulative'); // 'cumulative', 'combined', or 'packages'
     const [period, setPeriod] = useState('month');
-    const [timeRange, setTimeRange] = useState('all'); // 'all' for all available (~6 months), '3m' for 3 months
+    const [internalTimeRange, setInternalTimeRange] = useState(controlledTimeRange || 'all');
     const [growthStats, setGrowthStats] = useState(null);
     const [recentStats, setRecentStats] = useState(null);
     const [githubStats, setGithubStats] = useState(null);
     const [versionHistory, setVersionHistory] = useState([]);
+
+    const isRangeControlled = controlledTimeRange === 'all' || controlledTimeRange === '90d'
+    const timeRange = isRangeControlled ? controlledTimeRange : internalTimeRange
+
+    const setTimeRange = (nextRange) => {
+        if (isRangeControlled) {
+            onTimeRangeChange?.(nextRange)
+            return
+        }
+        setInternalTimeRange(nextRange)
+    }
+
+    useEffect(() => {
+        if (isRangeControlled && controlledTimeRange !== internalTimeRange) {
+            setInternalTimeRange(controlledTimeRange)
+        }
+    }, [controlledTimeRange, internalTimeRange, isRangeControlled])
 
     useEffect(() => {
         const fetchData = async () => {
@@ -182,7 +199,7 @@ const PyPIDownloadChart = () => {
                 if (timeRange === 'all') {
                     limit = 9999; // Get all available data (~6 months from pypistats.org)
                 } else {
-                    // 3 months of data
+                    // 90 days of data
                     limit = period === 'day' ? 90 : period === 'week' ? 13 : 3;
                 }
                 const data = await getPyPIDownloadHistoryLimited(period, limit);
@@ -725,24 +742,26 @@ const PyPIDownloadChart = () => {
                         </button>
                     </div>
                 </div>
-                <div className={styles.controlGroup}>
-                    <span className={styles.controlLabel}>Range:</span>
-                    <div className={styles.toggleGroup}>
-                        <button
-                            className={`${styles.toggleBtn} ${timeRange === 'all' ? styles.active : ''}`}
-                            onClick={() => setTimeRange('all')}
-                            title="pypistats.org retains ~180 days of data"
-                        >
-                            All Available
-                        </button>
-                        <button
-                            className={`${styles.toggleBtn} ${timeRange === '3m' ? styles.active : ''}`}
-                            onClick={() => setTimeRange('3m')}
-                        >
-                            3 Months
-                        </button>
+                {!hideRangeControl && (
+                    <div className={styles.controlGroup}>
+                        <span className={styles.controlLabel}>Range:</span>
+                        <div className={styles.toggleGroup}>
+                            <button
+                                className={`${styles.toggleBtn} ${timeRange === 'all' ? styles.active : ''}`}
+                                onClick={() => setTimeRange('all')}
+                                title="PyPI trend source retains a limited historical window."
+                            >
+                                All time
+                            </button>
+                            <button
+                                className={`${styles.toggleBtn} ${timeRange === '90d' ? styles.active : ''}`}
+                                onClick={() => setTimeRange('90d')}
+                            >
+                                90 days
+                            </button>
+                        </div>
                     </div>
-                </div>
+                )}
             </div>
 
             {/* Chart */}

--- a/components/PyPIDownloadChart.js
+++ b/components/PyPIDownloadChart.js
@@ -588,7 +588,7 @@ const PyPIDownloadChart = () => {
             <div className={styles.header}>
                 <div className={styles.titleRow}>
                     <FontAwesomeIcon icon={faPython} className={styles.icon} />
-                    <h3 className={styles.title}>PyPI Download Trends (Secondary Signal)</h3>
+                    <h3 className={styles.title}>PyPI Download Trends</h3>
                 </div>
                 <p className={styles.subtitle}>
                     Useful for package momentum, but can be inflated by CI and dependency installs.

--- a/pages/api/project-metrics.js
+++ b/pages/api/project-metrics.js
@@ -12,6 +12,7 @@ const DEFAULT_POSTHOG_PROJECT_ID = '68185'
 const MAX_EVENT_DEFINITION_PAGES = 5
 const FALLBACK_PATTERN_LIMIT = 30
 const GITHUB_ORG = 'OpenAdaptAI'
+const COVERAGE_START_EVENT_NAMES = ['demo_recorded', 'agent_run', 'action_executed']
 
 // Canonical event names from OpenAdapt codebases (legacy PostHog + shared telemetry conventions).
 const EVENT_CLASSIFICATION = {
@@ -287,13 +288,13 @@ async function fetchPosthogQueryUsageMetrics({ host, projectId, apiKey }) {
     const demosNames = uniqueNames(EVENT_CLASSIFICATION.demos.exact)
     const runsNames = uniqueNames(EVENT_CLASSIFICATION.runs.exact)
     const actionsNames = uniqueNames(EVENT_CLASSIFICATION.actions.exact)
-    const allNames = uniqueNames([...demosNames, ...runsNames, ...actionsNames])
+    const coverageStartNames = uniqueNames(COVERAGE_START_EVENT_NAMES)
 
     const [demos, runs, actions, telemetryCoverageStartDate] = await Promise.all([
         runHogQLCount({ host, projectId, apiKey, eventNames: demosNames }),
         runHogQLCount({ host, projectId, apiKey, eventNames: runsNames }),
         runHogQLCount({ host, projectId, apiKey, eventNames: actionsNames }),
-        runHogQLFirstSeen({ host, projectId, apiKey, eventNames: allNames }),
+        runHogQLFirstSeen({ host, projectId, apiKey, eventNames: coverageStartNames }),
     ])
 
     return {

--- a/pages/api/project-metrics.js
+++ b/pages/api/project-metrics.js
@@ -251,6 +251,16 @@ async function fetchPosthogUsageMetrics() {
             caveats: ['PostHog personal API key not configured on server'],
         }
     }
+    if (String(config.apiKey).startsWith('phc_')) {
+        return {
+            available: false,
+            source: 'posthog_not_configured',
+            caveats: [
+                'POSTHOG_PERSONAL_API_KEY (phx_) is required for metrics reads',
+                'Legacy POSTHOG_PUBLIC_KEY (phc_) is ingestion-only and cannot query event definitions',
+            ],
+        }
+    }
 
     const resolvedProjectId = await resolveProjectId(config)
     const definitions = await fetchAllEventDefinitions({

--- a/pages/api/project-metrics.js
+++ b/pages/api/project-metrics.js
@@ -12,7 +12,11 @@ const DEFAULT_POSTHOG_PROJECT_ID = '68185'
 const MAX_EVENT_DEFINITION_PAGES = 5
 const FALLBACK_PATTERN_LIMIT = 30
 const GITHUB_ORG = 'OpenAdaptAI'
-const COVERAGE_START_EVENT_NAMES = ['demo_recorded', 'agent_run', 'action_executed']
+const CANONICAL_USAGE_EVENTS = {
+    demos: ['demo_recorded'],
+    runs: ['agent_run'],
+    actions: ['action_executed'],
+}
 
 // Canonical event names from OpenAdapt codebases (legacy PostHog + shared telemetry conventions).
 const EVENT_CLASSIFICATION = {
@@ -285,10 +289,10 @@ async function runHogQLFirstSeen({ host, projectId, apiKey, eventNames }) {
 }
 
 async function fetchPosthogQueryUsageMetrics({ host, projectId, apiKey }) {
-    const demosNames = uniqueNames(EVENT_CLASSIFICATION.demos.exact)
-    const runsNames = uniqueNames(EVENT_CLASSIFICATION.runs.exact)
-    const actionsNames = uniqueNames(EVENT_CLASSIFICATION.actions.exact)
-    const coverageStartNames = uniqueNames(COVERAGE_START_EVENT_NAMES)
+    const demosNames = uniqueNames(CANONICAL_USAGE_EVENTS.demos)
+    const runsNames = uniqueNames(CANONICAL_USAGE_EVENTS.runs)
+    const actionsNames = uniqueNames(CANONICAL_USAGE_EVENTS.actions)
+    const coverageStartNames = uniqueNames([...demosNames, ...runsNames, ...actionsNames])
 
     const [demos, runs, actions, telemetryCoverageStartDate] = await Promise.all([
         runHogQLCount({ host, projectId, apiKey, eventNames: demosNames }),
@@ -317,7 +321,7 @@ async function fetchPosthogQueryUsageMetrics({ host, projectId, apiKey }) {
             demos.value90d > 0 ||
             runs.value90d > 0 ||
             actions.value90d > 0,
-        caveats: ['Derived from PostHog query API (exact event-name families)'],
+        caveats: ['Derived from PostHog query API (strict canonical events only)'],
     }
 }
 

--- a/pages/api/project-metrics.js
+++ b/pages/api/project-metrics.js
@@ -116,7 +116,14 @@ function getPosthogConfig() {
     const apiKey = process.env.POSTHOG_PERSONAL_API_KEY || process.env.POSTHOG_API_KEY
 
     if (!apiKey) return null
-    return { host, projectId, apiKey }
+    return { host: normalizePosthogApiHost(host), projectId, apiKey }
+}
+
+function normalizePosthogApiHost(host) {
+    if (!host) return DEFAULT_POSTHOG_HOST
+    // Private API endpoints should target app domains, not ingestion domains.
+    // e.g. us.i.posthog.com -> us.posthog.com
+    return String(host).replace('.i.posthog.com', '.posthog.com')
 }
 
 async function resolveProjectId({ host, projectId, apiKey }) {
@@ -146,6 +153,97 @@ async function resolveProjectId({ host, projectId, apiKey }) {
     return String(selected.id)
 }
 
+function uniqueNames(input) {
+    const out = new Set()
+    for (const raw of input || []) {
+        const name = String(raw || '').trim().toLowerCase()
+        if (name) out.add(name)
+    }
+    return [...out]
+}
+
+function toSqlInList(names) {
+    return names
+        .map((name) => `'${name.replaceAll("'", "''")}'`)
+        .join(', ')
+}
+
+async function runHogQLCount({ host, projectId, apiKey, eventNames, days }) {
+    const whereDays = Number.isFinite(days) && days > 0
+        ? ` AND timestamp >= now() - INTERVAL ${Math.floor(days)} DAY`
+        : ''
+    const query = `
+        SELECT count()
+        FROM events
+        WHERE event IN (${toSqlInList(eventNames)})${whereDays}
+    `.trim()
+
+    const response = await fetch(`${host}/api/projects/${projectId}/query/`, {
+        method: 'POST',
+        headers: {
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+            'User-Agent': 'OpenAdapt-Web/1.0',
+        },
+        body: JSON.stringify({
+            query: {
+                kind: 'HogQLQuery',
+                query,
+            },
+        }),
+    })
+
+    let payload = {}
+    try {
+        payload = await response.json()
+    } catch {
+        payload = {}
+    }
+
+    if (!response.ok) {
+        const detail = payload?.detail || payload?.code || `HTTP ${response.status}`
+        throw new Error(`PostHog query API returned ${response.status}: ${detail}`)
+    }
+
+    const value = Number(payload?.results?.[0]?.[0])
+    return Number.isFinite(value) ? value : 0
+}
+
+async function fetchPosthogQueryUsageMetrics({ host, projectId, apiKey }) {
+    const demosNames = uniqueNames(EVENT_CLASSIFICATION.demos.exact)
+    const runsNames = uniqueNames(EVENT_CLASSIFICATION.runs.exact)
+    const actionsNames = uniqueNames(EVENT_CLASSIFICATION.actions.exact)
+
+    const [
+        demos30d,
+        runs30d,
+        actions30d,
+        demosAllTime,
+        runsAllTime,
+        actionsAllTime,
+    ] = await Promise.all([
+        runHogQLCount({ host, projectId, apiKey, eventNames: demosNames, days: 30 }),
+        runHogQLCount({ host, projectId, apiKey, eventNames: runsNames, days: 30 }),
+        runHogQLCount({ host, projectId, apiKey, eventNames: actionsNames, days: 30 }),
+        runHogQLCount({ host, projectId, apiKey, eventNames: demosNames }),
+        runHogQLCount({ host, projectId, apiKey, eventNames: runsNames }),
+        runHogQLCount({ host, projectId, apiKey, eventNames: actionsNames }),
+    ])
+
+    return {
+        available: true,
+        source: 'posthog_query_api',
+        demosRecorded30d: demos30d,
+        agentRuns30d: runs30d,
+        guiActions30d: actions30d,
+        demosRecordedAllTime: demosAllTime,
+        agentRunsAllTime: runsAllTime,
+        guiActionsAllTime: actionsAllTime,
+        hasAnyVolume: demos30d > 0 || runs30d > 0 || actions30d > 0,
+        caveats: ['Derived from PostHog query API (exact event-name families)'],
+    }
+}
+
 async function fetchAllEventDefinitions({ host, projectId, apiKey }) {
     const all = []
     let nextUrl = `${host}/api/projects/${projectId}/event_definitions/?limit=100`
@@ -173,8 +271,10 @@ async function fetchAllEventDefinitions({ host, projectId, apiKey }) {
 }
 
 function valueFromDefinition(definition) {
-    const maybeNumber = Number(definition?.volume_30_day)
-    return Number.isFinite(maybeNumber) ? maybeNumber : 0
+    const rawValue = definition?.volume_30_day
+    if (rawValue === null || rawValue === undefined) return null
+    const maybeNumber = Number(rawValue)
+    return Number.isFinite(maybeNumber) ? maybeNumber : null
 }
 
 function normalizeEventName(name) {
@@ -193,7 +293,7 @@ function toEventEntries(definitions) {
             name: normalizeEventName(definition?.name),
             volume_30_day: valueFromDefinition(definition),
         }))
-        .filter((entry) => entry.name && entry.volume_30_day > 0 && !shouldIgnoreEvent(entry.name))
+        .filter((entry) => entry.name && entry.volume_30_day !== null && !shouldIgnoreEvent(entry.name))
 }
 
 function sumByEventNames(entries, candidateNames) {
@@ -267,10 +367,74 @@ async function fetchPosthogUsageMetrics() {
     }
 
     const resolvedProjectId = await resolveProjectId(config)
+    try {
+        const queryUsage = await fetchPosthogQueryUsageMetrics({
+            ...config,
+            projectId: resolvedProjectId,
+        })
+        return {
+            ...queryUsage,
+            caveats: [
+                ...(queryUsage.caveats || []),
+                config.projectId ? 'Using configured POSTHOG_PROJECT_ID' : 'POSTHOG_PROJECT_ID auto-resolved from API key',
+            ],
+        }
+    } catch (error) {
+        const errorMessage = formatError(error)
+        const missingQueryScope = errorMessage.includes("scope 'query:read'")
+        const fallbackCaveats = missingQueryScope
+            ? ["PostHog key missing 'query:read'; falling back to event definitions"]
+            : [`PostHog query API unavailable (${errorMessage}); falling back to event definitions`]
+
+        const fallbackUsage = await fetchPosthogUsageFromEventDefinitions({
+            ...config,
+            projectId: resolvedProjectId,
+        })
+        return {
+            ...fallbackUsage,
+            caveats: [...fallbackCaveats, ...(fallbackUsage.caveats || [])],
+        }
+    }
+}
+
+async function fetchPosthogUsageFromEventDefinitions(config) {
     const definitions = await fetchAllEventDefinitions({
         ...config,
-        projectId: resolvedProjectId,
+        projectId: config.projectId,
     })
+
+    const hasAny30dVolumeData = definitions.some((definition) => {
+        const value = valueFromDefinition(definition)
+        return value !== null
+    })
+
+    if (!hasAny30dVolumeData) {
+        return {
+            available: false,
+            source: 'posthog_event_definitions_unavailable',
+            demosRecorded30d: null,
+            agentRuns30d: null,
+            guiActions30d: null,
+            demosRecordedAllTime: null,
+            agentRunsAllTime: null,
+            guiActionsAllTime: null,
+            hasAnyVolume: false,
+            matchedEvents: {
+                demos: [],
+                runs: [],
+                actions: [],
+            },
+            strategies: {
+                demos: 'none',
+                runs: 'none',
+                actions: 'none',
+            },
+            caveats: [
+                'PostHog event_definitions API did not return usable volume_30_day values',
+                "Grant 'query:read' to POSTHOG_PERSONAL_API_KEY for accurate usage counters",
+            ],
+        }
+    }
 
     const entries = toEventEntries(definitions)
     const demos = buildCategoryMetrics(entries, EVENT_CLASSIFICATION.demos)
@@ -286,6 +450,9 @@ async function fetchPosthogUsageMetrics() {
         demosRecorded30d: demos.total,
         agentRuns30d: runs.total,
         guiActions30d: actions.total,
+        demosRecordedAllTime: null,
+        agentRunsAllTime: null,
+        guiActionsAllTime: null,
         hasAnyVolume,
         matchedEvents: {
             demos: demos.matched,
@@ -301,7 +468,6 @@ async function fetchPosthogUsageMetrics() {
         caveats: [
             'Derived from PostHog volume_30_day by exact event-name classification',
             'Falls back to guarded pattern matching only when exact mapping has no data',
-            config.projectId ? 'Using configured POSTHOG_PROJECT_ID' : 'POSTHOG_PROJECT_ID auto-resolved from API key',
         ],
     }
 }
@@ -310,15 +476,22 @@ function getEnvOverrideUsageMetrics() {
     const demos = parseIntEnv('OPENADAPT_METRIC_DEMOS_RECORDED_30D')
     const runs = parseIntEnv('OPENADAPT_METRIC_AGENT_RUNS_30D')
     const actions = parseIntEnv('OPENADAPT_METRIC_GUI_ACTIONS_30D')
+    const demosAllTime = parseIntEnv('OPENADAPT_METRIC_DEMOS_RECORDED_ALL_TIME')
+    const runsAllTime = parseIntEnv('OPENADAPT_METRIC_AGENT_RUNS_ALL_TIME')
+    const actionsAllTime = parseIntEnv('OPENADAPT_METRIC_GUI_ACTIONS_ALL_TIME')
     const apps = parseIntEnv('OPENADAPT_METRIC_APPS_AUTOMATED')
 
-    const hasAny = [demos, runs, actions, apps].some((value) => value !== null)
+    const hasAny = [demos, runs, actions, demosAllTime, runsAllTime, actionsAllTime, apps]
+        .some((value) => value !== null)
     return {
         available: hasAny,
         source: hasAny ? 'env_override' : 'env_override_not_set',
         demosRecorded30d: demos,
         agentRuns30d: runs,
         guiActions30d: actions,
+        demosRecordedAllTime: demosAllTime,
+        agentRunsAllTime: runsAllTime,
+        guiActionsAllTime: actionsAllTime,
         appsAutomated: apps,
         caveats: hasAny
             ? ['Values supplied via OPENADAPT_METRIC_* environment variables']
@@ -334,16 +507,30 @@ function mergeUsageMetrics(primary, fallback) {
             primary.agentRuns30d ?? fallback.agentRuns30d ?? null,
         guiActions30d:
             primary.guiActions30d ?? fallback.guiActions30d ?? null,
+        demosRecordedAllTime:
+            primary.demosRecordedAllTime ?? fallback.demosRecordedAllTime ?? null,
+        agentRunsAllTime:
+            primary.agentRunsAllTime ?? fallback.agentRunsAllTime ?? null,
+        guiActionsAllTime:
+            primary.guiActionsAllTime ?? fallback.guiActionsAllTime ?? null,
         appsAutomated:
             primary.appsAutomated ?? fallback.appsAutomated ?? null,
     }
 
     return {
-        available: [merged.demosRecorded30d, merged.agentRuns30d, merged.guiActions30d, merged.appsAutomated]
-            .some((value) => typeof value === 'number'),
+        available: [
+            merged.demosRecorded30d,
+            merged.agentRuns30d,
+            merged.guiActions30d,
+            merged.demosRecordedAllTime,
+            merged.agentRunsAllTime,
+            merged.guiActionsAllTime,
+            merged.appsAutomated,
+        ].some((value) => typeof value === 'number'),
         source: primary.available ? primary.source : fallback.source,
         caveats: [...(primary.caveats || []), ...(fallback.caveats || [])],
         matchedEvents: primary.matchedEvents || null,
+        strategies: primary.strategies || null,
         ...merged,
     }
 }
@@ -378,6 +565,9 @@ export default async function handler(req, res) {
                 demosRecorded30d: null,
                 agentRuns30d: null,
                 guiActions30d: null,
+                demosRecordedAllTime: null,
+                agentRunsAllTime: null,
+                guiActionsAllTime: null,
                 appsAutomated: null,
             },
             envUsage

--- a/pages/api/project-metrics.js
+++ b/pages/api/project-metrics.js
@@ -1,0 +1,228 @@
+/**
+ * Aggregated project metrics for homepage credibility signals.
+ *
+ * Priority:
+ * 1) GitHub repository stats (stars/forks/watchers/issues)
+ * 2) Usage metrics from PostHog (if configured) or env overrides
+ * 3) Explicit caveats/source metadata for transparency
+ */
+
+const DEFAULT_POSTHOG_HOST = 'https://us.posthog.com'
+const MAX_EVENT_DEFINITION_PAGES = 5
+
+function parseIntEnv(name) {
+    const raw = process.env[name]
+    if (raw === undefined || raw === null || raw === '') return null
+    const value = Number.parseInt(raw, 10)
+    return Number.isFinite(value) ? value : null
+}
+
+function formatError(error) {
+    if (!error) return 'unknown'
+    if (typeof error === 'string') return error
+    return error.message || String(error)
+}
+
+async function fetchGitHubStats() {
+    const response = await fetch('https://api.github.com/repos/OpenAdaptAI/OpenAdapt', {
+        headers: { 'User-Agent': 'OpenAdapt-Web/1.0 (https://openadapt.ai)' },
+    })
+    if (!response.ok) {
+        throw new Error(`GitHub API returned ${response.status}`)
+    }
+    const data = await response.json()
+    return {
+        stars: data.stargazers_count || 0,
+        forks: data.forks_count || 0,
+        watchers: data.subscribers_count || 0,
+        issues: data.open_issues_count || 0,
+    }
+}
+
+function getPosthogConfig() {
+    const host = process.env.POSTHOG_HOST || process.env.NEXT_PUBLIC_POSTHOG_HOST || DEFAULT_POSTHOG_HOST
+    const projectId = process.env.POSTHOG_PROJECT_ID || process.env.NEXT_PUBLIC_POSTHOG_PROJECT_ID
+    const apiKey = process.env.POSTHOG_PERSONAL_API_KEY || process.env.POSTHOG_API_KEY
+
+    if (!projectId || !apiKey) return null
+    return { host, projectId, apiKey }
+}
+
+async function fetchAllEventDefinitions({ host, projectId, apiKey }) {
+    const all = []
+    let nextUrl = `${host}/api/projects/${projectId}/event_definitions/?limit=100`
+    let pages = 0
+
+    while (nextUrl && pages < MAX_EVENT_DEFINITION_PAGES) {
+        const response = await fetch(nextUrl, {
+            headers: {
+                Authorization: `Bearer ${apiKey}`,
+                'Content-Type': 'application/json',
+                'User-Agent': 'OpenAdapt-Web/1.0',
+            },
+        })
+        if (!response.ok) {
+            throw new Error(`PostHog API returned ${response.status} for event_definitions`)
+        }
+        const data = await response.json()
+        const results = Array.isArray(data.results) ? data.results : []
+        all.push(...results)
+        nextUrl = data.next || null
+        pages += 1
+    }
+
+    return all
+}
+
+function valueFromDefinition(definition) {
+    const maybeNumber = Number(definition?.volume_30_day)
+    return Number.isFinite(maybeNumber) ? maybeNumber : 0
+}
+
+function sumByEventNames(definitions, candidateNames) {
+    const target = new Set(candidateNames.map((name) => name.toLowerCase()))
+    let total = 0
+    const matched = []
+
+    for (const definition of definitions) {
+        const name = String(definition?.name || '').toLowerCase()
+        if (!target.has(name)) continue
+        const value = valueFromDefinition(definition)
+        total += value
+        matched.push({ name: definition.name, volume_30_day: value })
+    }
+
+    return { total, matched }
+}
+
+async function fetchPosthogUsageMetrics() {
+    const config = getPosthogConfig()
+    if (!config) {
+        return {
+            available: false,
+            source: 'posthog_not_configured',
+            caveats: ['PostHog credentials not configured on server'],
+        }
+    }
+
+    const definitions = await fetchAllEventDefinitions(config)
+
+    const demos = sumByEventNames(definitions, [
+        'recording_finished',
+        'recording_completed',
+        'demo_recorded',
+        'demo_completed',
+    ])
+    const runs = sumByEventNames(definitions, [
+        'automation_run',
+        'agent_run',
+        'benchmark_run',
+        'replay_started',
+        'episode_started',
+    ])
+    const actions = sumByEventNames(definitions, [
+        'action_executed',
+        'step_executed',
+        'mouse_click',
+        'keyboard_input',
+        'ui_action',
+    ])
+
+    return {
+        available: demos.total > 0 || runs.total > 0 || actions.total > 0,
+        source: 'posthog_event_definitions',
+        demosRecorded30d: demos.total,
+        agentRuns30d: runs.total,
+        guiActions30d: actions.total,
+        matchedEvents: {
+            demos: demos.matched,
+            runs: runs.matched,
+            actions: actions.matched,
+        },
+        caveats: [
+            'Derived from PostHog volume_30_day on matched event names',
+            'Event naming consistency affects metric completeness',
+        ],
+    }
+}
+
+function getEnvOverrideUsageMetrics() {
+    const demos = parseIntEnv('OPENADAPT_METRIC_DEMOS_RECORDED_30D')
+    const runs = parseIntEnv('OPENADAPT_METRIC_AGENT_RUNS_30D')
+    const actions = parseIntEnv('OPENADAPT_METRIC_GUI_ACTIONS_30D')
+    const apps = parseIntEnv('OPENADAPT_METRIC_APPS_AUTOMATED')
+
+    const hasAny = [demos, runs, actions, apps].some((value) => value !== null)
+    return {
+        available: hasAny,
+        source: hasAny ? 'env_override' : 'env_override_not_set',
+        demosRecorded30d: demos,
+        agentRuns30d: runs,
+        guiActions30d: actions,
+        appsAutomated: apps,
+        caveats: hasAny
+            ? ['Values supplied via OPENADAPT_METRIC_* environment variables']
+            : ['No OPENADAPT_METRIC_* overrides configured'],
+    }
+}
+
+function mergeUsageMetrics(primary, fallback) {
+    const merged = {
+        demosRecorded30d:
+            primary.demosRecorded30d ?? fallback.demosRecorded30d ?? null,
+        agentRuns30d:
+            primary.agentRuns30d ?? fallback.agentRuns30d ?? null,
+        guiActions30d:
+            primary.guiActions30d ?? fallback.guiActions30d ?? null,
+        appsAutomated:
+            primary.appsAutomated ?? fallback.appsAutomated ?? null,
+    }
+
+    return {
+        available: [merged.demosRecorded30d, merged.agentRuns30d, merged.guiActions30d, merged.appsAutomated]
+            .some((value) => typeof value === 'number'),
+        source: primary.available ? primary.source : fallback.source,
+        caveats: [...(primary.caveats || []), ...(fallback.caveats || [])],
+        matchedEvents: primary.matchedEvents || null,
+        ...merged,
+    }
+}
+
+export default async function handler(req, res) {
+    res.setHeader('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=900')
+
+    const response = {
+        github: null,
+        usage: null,
+        generated_at: new Date().toISOString(),
+        warnings: [],
+    }
+
+    try {
+        response.github = await fetchGitHubStats()
+    } catch (error) {
+        response.warnings.push(`github_fetch_failed:${formatError(error)}`)
+    }
+
+    const envUsage = getEnvOverrideUsageMetrics()
+    try {
+        const posthogUsage = await fetchPosthogUsageMetrics()
+        response.usage = mergeUsageMetrics(posthogUsage, envUsage)
+    } catch (error) {
+        response.warnings.push(`posthog_fetch_failed:${formatError(error)}`)
+        response.usage = mergeUsageMetrics(
+            {
+                available: false,
+                source: 'posthog_error',
+                caveats: ['PostHog request failed'],
+                demosRecorded30d: null,
+                agentRuns30d: null,
+                guiActions30d: null,
+                appsAutomated: null,
+            },
+            envUsage
+        )
+    }
+
+    return res.status(200).json(response)
+}

--- a/pages/api/project-metrics.js
+++ b/pages/api/project-metrics.js
@@ -246,15 +246,54 @@ async function runHogQLCount({ host, projectId, apiKey, eventNames }) {
     }
 }
 
+async function runHogQLFirstSeen({ host, projectId, apiKey, eventNames }) {
+    const response = await fetchWithTimeout(`${host}/api/projects/${projectId}/query/`, {
+        method: 'POST',
+        headers: {
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+            'User-Agent': 'OpenAdapt-Web/1.0',
+        },
+        body: JSON.stringify({
+            query: {
+                kind: 'HogQLQuery',
+                query: `
+                    SELECT
+                        min(timestamp)
+                    FROM events
+                    WHERE event IN (${toSqlInList(eventNames)})
+                `.trim(),
+            },
+        }),
+    })
+
+    let payload = {}
+    try {
+        payload = await response.json()
+    } catch {
+        payload = {}
+    }
+
+    if (!response.ok) {
+        const detail = payload?.detail || payload?.code || `HTTP ${response.status}`
+        throw new Error(`PostHog first-seen query returned ${response.status}: ${detail}`)
+    }
+
+    const raw = payload?.results?.[0]?.[0]
+    return raw ? String(raw) : null
+}
+
 async function fetchPosthogQueryUsageMetrics({ host, projectId, apiKey }) {
     const demosNames = uniqueNames(EVENT_CLASSIFICATION.demos.exact)
     const runsNames = uniqueNames(EVENT_CLASSIFICATION.runs.exact)
     const actionsNames = uniqueNames(EVENT_CLASSIFICATION.actions.exact)
+    const allNames = uniqueNames([...demosNames, ...runsNames, ...actionsNames])
 
-    const [demos, runs, actions] = await Promise.all([
+    const [demos, runs, actions, telemetryCoverageStartDate] = await Promise.all([
         runHogQLCount({ host, projectId, apiKey, eventNames: demosNames }),
         runHogQLCount({ host, projectId, apiKey, eventNames: runsNames }),
         runHogQLCount({ host, projectId, apiKey, eventNames: actionsNames }),
+        runHogQLFirstSeen({ host, projectId, apiKey, eventNames: allNames }),
     ])
 
     return {
@@ -269,6 +308,7 @@ async function fetchPosthogQueryUsageMetrics({ host, projectId, apiKey }) {
         demosRecordedAllTime: demos.valueAllTime,
         agentRunsAllTime: runs.valueAllTime,
         guiActionsAllTime: actions.valueAllTime,
+        telemetryCoverageStartDate,
         hasAnyVolume:
             demos.value30d > 0 ||
             runs.value30d > 0 ||
@@ -457,6 +497,7 @@ async function fetchPosthogUsageFromEventDefinitions(config) {
             demosRecordedAllTime: null,
             agentRunsAllTime: null,
             guiActionsAllTime: null,
+            telemetryCoverageStartDate: null,
             hasAnyVolume: false,
             matchedEvents: {
                 demos: [],
@@ -495,6 +536,7 @@ async function fetchPosthogUsageFromEventDefinitions(config) {
         demosRecordedAllTime: null,
         agentRunsAllTime: null,
         guiActionsAllTime: null,
+        telemetryCoverageStartDate: null,
         hasAnyVolume,
         matchedEvents: {
             demos: demos.matched,
@@ -525,6 +567,7 @@ function getEnvOverrideUsageMetrics() {
     const runsAllTime = parseIntEnv('OPENADAPT_METRIC_AGENT_RUNS_ALL_TIME')
     const actionsAllTime = parseIntEnv('OPENADAPT_METRIC_GUI_ACTIONS_ALL_TIME')
     const apps = parseIntEnv('OPENADAPT_METRIC_APPS_AUTOMATED')
+    const telemetryCoverageStartDate = process.env.OPENADAPT_METRIC_USAGE_START_DATE || null
 
     const hasAny = [demos, demos90d, runs, runs90d, actions, actions90d, demosAllTime, runsAllTime, actionsAllTime, apps]
         .some((value) => value !== null)
@@ -541,6 +584,7 @@ function getEnvOverrideUsageMetrics() {
         agentRunsAllTime: runsAllTime,
         guiActionsAllTime: actionsAllTime,
         appsAutomated: apps,
+        telemetryCoverageStartDate,
         caveats: hasAny
             ? ['Values supplied via OPENADAPT_METRIC_* environment variables']
             : ['No OPENADAPT_METRIC_* overrides configured'],
@@ -569,6 +613,8 @@ function mergeUsageMetrics(primary, fallback) {
             primary.guiActionsAllTime ?? fallback.guiActionsAllTime ?? null,
         appsAutomated:
             primary.appsAutomated ?? fallback.appsAutomated ?? null,
+        telemetryCoverageStartDate:
+            primary.telemetryCoverageStartDate ?? fallback.telemetryCoverageStartDate ?? null,
     }
 
     return {
@@ -633,6 +679,7 @@ export default async function handler(req, res) {
                 agentRunsAllTime: null,
                 guiActionsAllTime: null,
                 appsAutomated: null,
+                telemetryCoverageStartDate: null,
             },
             envUsage
         )

--- a/pages/api/project-metrics.js
+++ b/pages/api/project-metrics.js
@@ -202,7 +202,7 @@ function toSqlInList(names) {
         .join(', ')
 }
 
-async function runHogQLCount({ host, projectId, apiKey, eventNames, days }) {
+async function runHogQLCount({ host, projectId, apiKey, eventNames }) {
     const response = await fetchWithTimeout(`${host}/api/projects/${projectId}/query/`, {
         method: 'POST',
         headers: {
@@ -215,7 +215,8 @@ async function runHogQLCount({ host, projectId, apiKey, eventNames, days }) {
                 kind: 'HogQLQuery',
                 query: `
                     SELECT
-                        countIf(event IN (${toSqlInList(eventNames)}) AND timestamp >= now() - INTERVAL ${Math.floor(days)} DAY),
+                        countIf(event IN (${toSqlInList(eventNames)}) AND timestamp >= now() - INTERVAL 30 DAY),
+                        countIf(event IN (${toSqlInList(eventNames)}) AND timestamp >= now() - INTERVAL 90 DAY),
                         countIf(event IN (${toSqlInList(eventNames)}))
                     FROM events
                 `.trim(),
@@ -236,9 +237,11 @@ async function runHogQLCount({ host, projectId, apiKey, eventNames, days }) {
     }
 
     const value30d = Number(payload?.results?.[0]?.[0])
-    const valueAllTime = Number(payload?.results?.[0]?.[1])
+    const value90d = Number(payload?.results?.[0]?.[1])
+    const valueAllTime = Number(payload?.results?.[0]?.[2])
     return {
         value30d: Number.isFinite(value30d) ? value30d : 0,
+        value90d: Number.isFinite(value90d) ? value90d : 0,
         valueAllTime: Number.isFinite(valueAllTime) ? valueAllTime : 0,
     }
 }
@@ -249,21 +252,30 @@ async function fetchPosthogQueryUsageMetrics({ host, projectId, apiKey }) {
     const actionsNames = uniqueNames(EVENT_CLASSIFICATION.actions.exact)
 
     const [demos, runs, actions] = await Promise.all([
-        runHogQLCount({ host, projectId, apiKey, eventNames: demosNames, days: 30 }),
-        runHogQLCount({ host, projectId, apiKey, eventNames: runsNames, days: 30 }),
-        runHogQLCount({ host, projectId, apiKey, eventNames: actionsNames, days: 30 }),
+        runHogQLCount({ host, projectId, apiKey, eventNames: demosNames }),
+        runHogQLCount({ host, projectId, apiKey, eventNames: runsNames }),
+        runHogQLCount({ host, projectId, apiKey, eventNames: actionsNames }),
     ])
 
     return {
         available: true,
         source: 'posthog_query_api',
         demosRecorded30d: demos.value30d,
+        demosRecorded90d: demos.value90d,
         agentRuns30d: runs.value30d,
+        agentRuns90d: runs.value90d,
         guiActions30d: actions.value30d,
+        guiActions90d: actions.value90d,
         demosRecordedAllTime: demos.valueAllTime,
         agentRunsAllTime: runs.valueAllTime,
         guiActionsAllTime: actions.valueAllTime,
-        hasAnyVolume: demos.value30d > 0 || runs.value30d > 0 || actions.value30d > 0,
+        hasAnyVolume:
+            demos.value30d > 0 ||
+            runs.value30d > 0 ||
+            actions.value30d > 0 ||
+            demos.value90d > 0 ||
+            runs.value90d > 0 ||
+            actions.value90d > 0,
         caveats: ['Derived from PostHog query API (exact event-name families)'],
     }
 }
@@ -437,8 +449,11 @@ async function fetchPosthogUsageFromEventDefinitions(config) {
             available: false,
             source: 'posthog_event_definitions_unavailable',
             demosRecorded30d: null,
+            demosRecorded90d: null,
             agentRuns30d: null,
+            agentRuns90d: null,
             guiActions30d: null,
+            guiActions90d: null,
             demosRecordedAllTime: null,
             agentRunsAllTime: null,
             guiActionsAllTime: null,
@@ -472,8 +487,11 @@ async function fetchPosthogUsageFromEventDefinitions(config) {
         available: true,
         source: 'posthog_event_definitions',
         demosRecorded30d: demos.total,
+        demosRecorded90d: null,
         agentRuns30d: runs.total,
+        agentRuns90d: null,
         guiActions30d: actions.total,
+        guiActions90d: null,
         demosRecordedAllTime: null,
         agentRunsAllTime: null,
         guiActionsAllTime: null,
@@ -498,21 +516,27 @@ async function fetchPosthogUsageFromEventDefinitions(config) {
 
 function getEnvOverrideUsageMetrics() {
     const demos = parseIntEnv('OPENADAPT_METRIC_DEMOS_RECORDED_30D')
+    const demos90d = parseIntEnv('OPENADAPT_METRIC_DEMOS_RECORDED_90D')
     const runs = parseIntEnv('OPENADAPT_METRIC_AGENT_RUNS_30D')
+    const runs90d = parseIntEnv('OPENADAPT_METRIC_AGENT_RUNS_90D')
     const actions = parseIntEnv('OPENADAPT_METRIC_GUI_ACTIONS_30D')
+    const actions90d = parseIntEnv('OPENADAPT_METRIC_GUI_ACTIONS_90D')
     const demosAllTime = parseIntEnv('OPENADAPT_METRIC_DEMOS_RECORDED_ALL_TIME')
     const runsAllTime = parseIntEnv('OPENADAPT_METRIC_AGENT_RUNS_ALL_TIME')
     const actionsAllTime = parseIntEnv('OPENADAPT_METRIC_GUI_ACTIONS_ALL_TIME')
     const apps = parseIntEnv('OPENADAPT_METRIC_APPS_AUTOMATED')
 
-    const hasAny = [demos, runs, actions, demosAllTime, runsAllTime, actionsAllTime, apps]
+    const hasAny = [demos, demos90d, runs, runs90d, actions, actions90d, demosAllTime, runsAllTime, actionsAllTime, apps]
         .some((value) => value !== null)
     return {
         available: hasAny,
         source: hasAny ? 'env_override' : 'env_override_not_set',
         demosRecorded30d: demos,
+        demosRecorded90d: demos90d ?? demos,
         agentRuns30d: runs,
+        agentRuns90d: runs90d ?? runs,
         guiActions30d: actions,
+        guiActions90d: actions90d ?? actions,
         demosRecordedAllTime: demosAllTime,
         agentRunsAllTime: runsAllTime,
         guiActionsAllTime: actionsAllTime,
@@ -527,10 +551,16 @@ function mergeUsageMetrics(primary, fallback) {
     const merged = {
         demosRecorded30d:
             primary.demosRecorded30d ?? fallback.demosRecorded30d ?? null,
+        demosRecorded90d:
+            primary.demosRecorded90d ?? fallback.demosRecorded90d ?? null,
         agentRuns30d:
             primary.agentRuns30d ?? fallback.agentRuns30d ?? null,
+        agentRuns90d:
+            primary.agentRuns90d ?? fallback.agentRuns90d ?? null,
         guiActions30d:
             primary.guiActions30d ?? fallback.guiActions30d ?? null,
+        guiActions90d:
+            primary.guiActions90d ?? fallback.guiActions90d ?? null,
         demosRecordedAllTime:
             primary.demosRecordedAllTime ?? fallback.demosRecordedAllTime ?? null,
         agentRunsAllTime:
@@ -544,8 +574,11 @@ function mergeUsageMetrics(primary, fallback) {
     return {
         available: [
             merged.demosRecorded30d,
+            merged.demosRecorded90d,
             merged.agentRuns30d,
+            merged.agentRuns90d,
             merged.guiActions30d,
+            merged.guiActions90d,
             merged.demosRecordedAllTime,
             merged.agentRunsAllTime,
             merged.guiActionsAllTime,
@@ -591,8 +624,11 @@ export default async function handler(req, res) {
                 source: 'posthog_error',
                 caveats: ['PostHog request failed'],
                 demosRecorded30d: null,
+                demosRecorded90d: null,
                 agentRuns30d: null,
+                agentRuns90d: null,
                 guiActions30d: null,
+                guiActions90d: null,
                 demosRecordedAllTime: null,
                 agentRunsAllTime: null,
                 guiActionsAllTime: null,

--- a/pages/api/project-metrics.js
+++ b/pages/api/project-metrics.js
@@ -111,8 +111,35 @@ function getPosthogConfig() {
     const projectId = process.env.POSTHOG_PROJECT_ID || process.env.NEXT_PUBLIC_POSTHOG_PROJECT_ID
     const apiKey = process.env.POSTHOG_PERSONAL_API_KEY || process.env.POSTHOG_API_KEY
 
-    if (!projectId || !apiKey) return null
+    if (!apiKey) return null
     return { host, projectId, apiKey }
+}
+
+async function resolveProjectId({ host, projectId, apiKey }) {
+    if (projectId) return projectId
+
+    const response = await fetch(`${host}/api/projects/?limit=100`, {
+        headers: {
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+            'User-Agent': 'OpenAdapt-Web/1.0',
+        },
+    })
+    if (!response.ok) {
+        throw new Error(`PostHog API returned ${response.status} for projects`)
+    }
+    const payload = await response.json()
+    const projects = Array.isArray(payload) ? payload : payload?.results || []
+
+    if (!projects.length) {
+        throw new Error('No PostHog projects returned for API key')
+    }
+
+    const preferred = projects.find((project) =>
+        String(project?.name || '').toLowerCase().includes('openadapt')
+    )
+    const selected = preferred || projects[0]
+    return String(selected.id)
 }
 
 async function fetchAllEventDefinitions({ host, projectId, apiKey }) {
@@ -221,11 +248,15 @@ async function fetchPosthogUsageMetrics() {
         return {
             available: false,
             source: 'posthog_not_configured',
-            caveats: ['PostHog credentials not configured on server'],
+            caveats: ['PostHog personal API key not configured on server'],
         }
     }
 
-    const definitions = await fetchAllEventDefinitions(config)
+    const resolvedProjectId = await resolveProjectId(config)
+    const definitions = await fetchAllEventDefinitions({
+        ...config,
+        projectId: resolvedProjectId,
+    })
 
     const entries = toEventEntries(definitions)
     const demos = buildCategoryMetrics(entries, EVENT_CLASSIFICATION.demos)
@@ -252,6 +283,7 @@ async function fetchPosthogUsageMetrics() {
         caveats: [
             'Derived from PostHog volume_30_day by exact event-name classification',
             'Falls back to guarded pattern matching only when exact mapping has no data',
+            config.projectId ? 'Using configured POSTHOG_PROJECT_ID' : 'POSTHOG_PROJECT_ID auto-resolved from API key',
         ],
     }
 }

--- a/pages/api/project-metrics.js
+++ b/pages/api/project-metrics.js
@@ -91,8 +91,23 @@ function formatError(error) {
     return error.message || String(error)
 }
 
+async function fetchWithTimeout(url, options = {}, timeoutMs = 8000) {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+    try {
+        return await fetch(url, { ...options, signal: controller.signal })
+    } catch (error) {
+        if (error?.name === 'AbortError') {
+            throw new Error(`Request timed out after ${timeoutMs}ms`)
+        }
+        throw error
+    } finally {
+        clearTimeout(timeoutId)
+    }
+}
+
 async function fetchGitHubStats() {
-    const response = await fetch('https://api.github.com/repos/OpenAdaptAI/OpenAdapt', {
+    const response = await fetchWithTimeout('https://api.github.com/repos/OpenAdaptAI/OpenAdapt', {
         headers: { 'User-Agent': 'OpenAdapt-Web/1.0 (https://openadapt.ai)' },
     })
     if (!response.ok) {
@@ -129,7 +144,7 @@ function normalizePosthogApiHost(host) {
 async function resolveProjectId({ host, projectId, apiKey }) {
     if (projectId) return projectId
 
-    const response = await fetch(`${host}/api/projects/?limit=100`, {
+    const response = await fetchWithTimeout(`${host}/api/projects/?limit=100`, {
         headers: {
             Authorization: `Bearer ${apiKey}`,
             'Content-Type': 'application/json',
@@ -169,16 +184,7 @@ function toSqlInList(names) {
 }
 
 async function runHogQLCount({ host, projectId, apiKey, eventNames, days }) {
-    const whereDays = Number.isFinite(days) && days > 0
-        ? ` AND timestamp >= now() - INTERVAL ${Math.floor(days)} DAY`
-        : ''
-    const query = `
-        SELECT count()
-        FROM events
-        WHERE event IN (${toSqlInList(eventNames)})${whereDays}
-    `.trim()
-
-    const response = await fetch(`${host}/api/projects/${projectId}/query/`, {
+    const response = await fetchWithTimeout(`${host}/api/projects/${projectId}/query/`, {
         method: 'POST',
         headers: {
             Authorization: `Bearer ${apiKey}`,
@@ -188,7 +194,12 @@ async function runHogQLCount({ host, projectId, apiKey, eventNames, days }) {
         body: JSON.stringify({
             query: {
                 kind: 'HogQLQuery',
-                query,
+                query: `
+                    SELECT
+                        countIf(event IN (${toSqlInList(eventNames)}) AND timestamp >= now() - INTERVAL ${Math.floor(days)} DAY),
+                        countIf(event IN (${toSqlInList(eventNames)}))
+                    FROM events
+                `.trim(),
             },
         }),
     })
@@ -205,8 +216,12 @@ async function runHogQLCount({ host, projectId, apiKey, eventNames, days }) {
         throw new Error(`PostHog query API returned ${response.status}: ${detail}`)
     }
 
-    const value = Number(payload?.results?.[0]?.[0])
-    return Number.isFinite(value) ? value : 0
+    const value30d = Number(payload?.results?.[0]?.[0])
+    const valueAllTime = Number(payload?.results?.[0]?.[1])
+    return {
+        value30d: Number.isFinite(value30d) ? value30d : 0,
+        valueAllTime: Number.isFinite(valueAllTime) ? valueAllTime : 0,
+    }
 }
 
 async function fetchPosthogQueryUsageMetrics({ host, projectId, apiKey }) {
@@ -214,32 +229,22 @@ async function fetchPosthogQueryUsageMetrics({ host, projectId, apiKey }) {
     const runsNames = uniqueNames(EVENT_CLASSIFICATION.runs.exact)
     const actionsNames = uniqueNames(EVENT_CLASSIFICATION.actions.exact)
 
-    const [
-        demos30d,
-        runs30d,
-        actions30d,
-        demosAllTime,
-        runsAllTime,
-        actionsAllTime,
-    ] = await Promise.all([
+    const [demos, runs, actions] = await Promise.all([
         runHogQLCount({ host, projectId, apiKey, eventNames: demosNames, days: 30 }),
         runHogQLCount({ host, projectId, apiKey, eventNames: runsNames, days: 30 }),
         runHogQLCount({ host, projectId, apiKey, eventNames: actionsNames, days: 30 }),
-        runHogQLCount({ host, projectId, apiKey, eventNames: demosNames }),
-        runHogQLCount({ host, projectId, apiKey, eventNames: runsNames }),
-        runHogQLCount({ host, projectId, apiKey, eventNames: actionsNames }),
     ])
 
     return {
         available: true,
         source: 'posthog_query_api',
-        demosRecorded30d: demos30d,
-        agentRuns30d: runs30d,
-        guiActions30d: actions30d,
-        demosRecordedAllTime: demosAllTime,
-        agentRunsAllTime: runsAllTime,
-        guiActionsAllTime: actionsAllTime,
-        hasAnyVolume: demos30d > 0 || runs30d > 0 || actions30d > 0,
+        demosRecorded30d: demos.value30d,
+        agentRuns30d: runs.value30d,
+        guiActions30d: actions.value30d,
+        demosRecordedAllTime: demos.valueAllTime,
+        agentRunsAllTime: runs.valueAllTime,
+        guiActionsAllTime: actions.valueAllTime,
+        hasAnyVolume: demos.value30d > 0 || runs.value30d > 0 || actions.value30d > 0,
         caveats: ['Derived from PostHog query API (exact event-name families)'],
     }
 }
@@ -250,7 +255,7 @@ async function fetchAllEventDefinitions({ host, projectId, apiKey }) {
     let pages = 0
 
     while (nextUrl && pages < MAX_EVENT_DEFINITION_PAGES) {
-        const response = await fetch(nextUrl, {
+        const response = await fetchWithTimeout(nextUrl, {
             headers: {
                 Authorization: `Bearer ${apiKey}`,
                 'Content-Type': 'application/json',
@@ -545,18 +550,22 @@ export default async function handler(req, res) {
         warnings: [],
     }
 
-    try {
-        response.github = await fetchGitHubStats()
-    } catch (error) {
-        response.warnings.push(`github_fetch_failed:${formatError(error)}`)
+    const envUsage = getEnvOverrideUsageMetrics()
+    const [githubResult, posthogResult] = await Promise.allSettled([
+        fetchGitHubStats(),
+        fetchPosthogUsageMetrics(),
+    ])
+
+    if (githubResult.status === 'fulfilled') {
+        response.github = githubResult.value
+    } else {
+        response.warnings.push(`github_fetch_failed:${formatError(githubResult.reason)}`)
     }
 
-    const envUsage = getEnvOverrideUsageMetrics()
-    try {
-        const posthogUsage = await fetchPosthogUsageMetrics()
-        response.usage = mergeUsageMetrics(posthogUsage, envUsage)
-    } catch (error) {
-        response.warnings.push(`posthog_fetch_failed:${formatError(error)}`)
+    if (posthogResult.status === 'fulfilled') {
+        response.usage = mergeUsageMetrics(posthogResult.value, envUsage)
+    } else {
+        response.warnings.push(`posthog_fetch_failed:${formatError(posthogResult.reason)}`)
         response.usage = mergeUsageMetrics(
             {
                 available: false,

--- a/pages/api/project-metrics.js
+++ b/pages/api/project-metrics.js
@@ -631,7 +631,10 @@ function mergeUsageMetrics(primary, fallback) {
             merged.guiActionsAllTime,
             merged.appsAutomated,
         ].some((value) => typeof value === 'number'),
-        source: primary.available ? primary.source : fallback.source,
+        source:
+            primary.available
+                ? primary.source
+                : (fallback.available ? fallback.source : (primary.source || fallback.source)),
         caveats: [...(primary.caveats || []), ...(fallback.caveats || [])],
         matchedEvents: primary.matchedEvents || null,
         strategies: primary.strategies || null,
@@ -639,9 +642,17 @@ function mergeUsageMetrics(primary, fallback) {
     }
 }
 
-export default async function handler(req, res) {
-    res.setHeader('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=900')
+function cacheControlForUsageSource(source) {
+    const normalized = String(source || '')
+    // Cache successful PostHog-backed payloads briefly.
+    if (normalized === 'posthog_query_api' || normalized === 'posthog_event_definitions') {
+        return 'public, max-age=30, s-maxage=120, stale-while-revalidate=300'
+    }
+    // Do not cache degraded/unconfigured payloads at the edge.
+    return 'no-store, max-age=0'
+}
 
+export default async function handler(req, res) {
     const response = {
         github: null,
         usage: null,
@@ -686,5 +697,7 @@ export default async function handler(req, res) {
         )
     }
 
+    res.setHeader('Cache-Control', cacheControlForUsageSource(response?.usage?.source))
+    res.setHeader('X-OpenAdapt-Metrics-Source', String(response?.usage?.source || 'unknown'))
     return res.status(200).json(response)
 }

--- a/pages/api/project-metrics.js
+++ b/pages/api/project-metrics.js
@@ -12,11 +12,6 @@ const DEFAULT_POSTHOG_PROJECT_ID = '68185'
 const MAX_EVENT_DEFINITION_PAGES = 5
 const FALLBACK_PATTERN_LIMIT = 30
 const GITHUB_ORG = 'OpenAdaptAI'
-const CANONICAL_USAGE_EVENTS = {
-    demos: ['demo_recorded'],
-    runs: ['agent_run'],
-    actions: ['action_executed'],
-}
 
 // Canonical event names from OpenAdapt codebases (legacy PostHog + shared telemetry conventions).
 const EVENT_CLASSIFICATION = {
@@ -251,6 +246,54 @@ async function runHogQLCount({ host, projectId, apiKey, eventNames }) {
     }
 }
 
+async function runHogQLTotalCounts({ host, projectId, apiKey }) {
+    const ignoredNames = uniqueNames(Array.from(IGNORED_EVENT_NAMES))
+    const ignoredClause = ignoredNames.length > 0
+        ? `event NOT IN (${toSqlInList(ignoredNames)})`
+        : '1 = 1'
+    const response = await fetchWithTimeout(`${host}/api/projects/${projectId}/query/`, {
+        method: 'POST',
+        headers: {
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+            'User-Agent': 'OpenAdapt-Web/1.0',
+        },
+        body: JSON.stringify({
+            query: {
+                kind: 'HogQLQuery',
+                query: `
+                    SELECT
+                        countIf(${ignoredClause} AND timestamp >= now() - INTERVAL 30 DAY),
+                        countIf(${ignoredClause} AND timestamp >= now() - INTERVAL 90 DAY),
+                        countIf(${ignoredClause})
+                    FROM events
+                `.trim(),
+            },
+        }),
+    })
+
+    let payload = {}
+    try {
+        payload = await response.json()
+    } catch {
+        payload = {}
+    }
+
+    if (!response.ok) {
+        const detail = payload?.detail || payload?.code || `HTTP ${response.status}`
+        throw new Error(`PostHog total-events query returned ${response.status}: ${detail}`)
+    }
+
+    const value30d = Number(payload?.results?.[0]?.[0])
+    const value90d = Number(payload?.results?.[0]?.[1])
+    const valueAllTime = Number(payload?.results?.[0]?.[2])
+    return {
+        value30d: Number.isFinite(value30d) ? value30d : 0,
+        value90d: Number.isFinite(value90d) ? value90d : 0,
+        valueAllTime: Number.isFinite(valueAllTime) ? valueAllTime : 0,
+    }
+}
+
 async function runHogQLFirstSeen({ host, projectId, apiKey, eventNames }) {
     const response = await fetchWithTimeout(`${host}/api/projects/${projectId}/query/`, {
         method: 'POST',
@@ -289,15 +332,16 @@ async function runHogQLFirstSeen({ host, projectId, apiKey, eventNames }) {
 }
 
 async function fetchPosthogQueryUsageMetrics({ host, projectId, apiKey }) {
-    const demosNames = uniqueNames(CANONICAL_USAGE_EVENTS.demos)
-    const runsNames = uniqueNames(CANONICAL_USAGE_EVENTS.runs)
-    const actionsNames = uniqueNames(CANONICAL_USAGE_EVENTS.actions)
+    const demosNames = uniqueNames(EVENT_CLASSIFICATION.demos.exact)
+    const runsNames = uniqueNames(EVENT_CLASSIFICATION.runs.exact)
+    const actionsNames = uniqueNames(EVENT_CLASSIFICATION.actions.exact)
     const coverageStartNames = uniqueNames([...demosNames, ...runsNames, ...actionsNames])
 
-    const [demos, runs, actions, telemetryCoverageStartDate] = await Promise.all([
+    const [demos, runs, actions, totals, telemetryCoverageStartDate] = await Promise.all([
         runHogQLCount({ host, projectId, apiKey, eventNames: demosNames }),
         runHogQLCount({ host, projectId, apiKey, eventNames: runsNames }),
         runHogQLCount({ host, projectId, apiKey, eventNames: actionsNames }),
+        runHogQLTotalCounts({ host, projectId, apiKey }),
         runHogQLFirstSeen({ host, projectId, apiKey, eventNames: coverageStartNames }),
     ])
 
@@ -313,6 +357,9 @@ async function fetchPosthogQueryUsageMetrics({ host, projectId, apiKey }) {
         demosRecordedAllTime: demos.valueAllTime,
         agentRunsAllTime: runs.valueAllTime,
         guiActionsAllTime: actions.valueAllTime,
+        totalEvents30d: totals.value30d,
+        totalEvents90d: totals.value90d,
+        totalEventsAllTime: totals.valueAllTime,
         telemetryCoverageStartDate,
         hasAnyVolume:
             demos.value30d > 0 ||
@@ -320,8 +367,10 @@ async function fetchPosthogQueryUsageMetrics({ host, projectId, apiKey }) {
             actions.value30d > 0 ||
             demos.value90d > 0 ||
             runs.value90d > 0 ||
-            actions.value90d > 0,
-        caveats: ['Derived from PostHog query API (strict canonical events only)'],
+            actions.value90d > 0 ||
+            totals.value30d > 0 ||
+            totals.value90d > 0,
+        caveats: ['Derived from PostHog query API (exact event-name classification + non-ignored totals)'],
     }
 }
 
@@ -502,6 +551,9 @@ async function fetchPosthogUsageFromEventDefinitions(config) {
             demosRecordedAllTime: null,
             agentRunsAllTime: null,
             guiActionsAllTime: null,
+            totalEvents30d: null,
+            totalEvents90d: null,
+            totalEventsAllTime: null,
             telemetryCoverageStartDate: null,
             hasAnyVolume: false,
             matchedEvents: {
@@ -525,7 +577,12 @@ async function fetchPosthogUsageFromEventDefinitions(config) {
     const demos = buildCategoryMetrics(entries, EVENT_CLASSIFICATION.demos)
     const runs = buildCategoryMetrics(entries, EVENT_CLASSIFICATION.runs)
     const actions = buildCategoryMetrics(entries, EVENT_CLASSIFICATION.actions)
-    const hasAnyVolume = demos.total > 0 || runs.total > 0 || actions.total > 0
+    const totalEvents30d = entries.reduce((sum, entry) => sum + entry.volume_30_day, 0)
+    const hasAnyVolume =
+        demos.total > 0 ||
+        runs.total > 0 ||
+        actions.total > 0 ||
+        totalEvents30d > 0
 
     return {
         // "available" means PostHog data source is configured/reachable, not
@@ -541,6 +598,9 @@ async function fetchPosthogUsageFromEventDefinitions(config) {
         demosRecordedAllTime: null,
         agentRunsAllTime: null,
         guiActionsAllTime: null,
+        totalEvents30d,
+        totalEvents90d: null,
+        totalEventsAllTime: null,
         telemetryCoverageStartDate: null,
         hasAnyVolume,
         matchedEvents: {
@@ -571,10 +631,18 @@ function getEnvOverrideUsageMetrics() {
     const demosAllTime = parseIntEnv('OPENADAPT_METRIC_DEMOS_RECORDED_ALL_TIME')
     const runsAllTime = parseIntEnv('OPENADAPT_METRIC_AGENT_RUNS_ALL_TIME')
     const actionsAllTime = parseIntEnv('OPENADAPT_METRIC_GUI_ACTIONS_ALL_TIME')
+    const totalEvents30d = parseIntEnv('OPENADAPT_METRIC_TOTAL_EVENTS_30D')
+    const totalEvents90d = parseIntEnv('OPENADAPT_METRIC_TOTAL_EVENTS_90D')
+    const totalEventsAllTime = parseIntEnv('OPENADAPT_METRIC_TOTAL_EVENTS_ALL_TIME')
     const apps = parseIntEnv('OPENADAPT_METRIC_APPS_AUTOMATED')
     const telemetryCoverageStartDate = process.env.OPENADAPT_METRIC_USAGE_START_DATE || null
 
-    const hasAny = [demos, demos90d, runs, runs90d, actions, actions90d, demosAllTime, runsAllTime, actionsAllTime, apps]
+    const hasAny = [
+        demos, demos90d, runs, runs90d, actions, actions90d,
+        demosAllTime, runsAllTime, actionsAllTime,
+        totalEvents30d, totalEvents90d, totalEventsAllTime,
+        apps,
+    ]
         .some((value) => value !== null)
     return {
         available: hasAny,
@@ -588,6 +656,9 @@ function getEnvOverrideUsageMetrics() {
         demosRecordedAllTime: demosAllTime,
         agentRunsAllTime: runsAllTime,
         guiActionsAllTime: actionsAllTime,
+        totalEvents30d,
+        totalEvents90d: totalEvents90d ?? totalEvents30d,
+        totalEventsAllTime,
         appsAutomated: apps,
         telemetryCoverageStartDate,
         caveats: hasAny
@@ -616,6 +687,12 @@ function mergeUsageMetrics(primary, fallback) {
             primary.agentRunsAllTime ?? fallback.agentRunsAllTime ?? null,
         guiActionsAllTime:
             primary.guiActionsAllTime ?? fallback.guiActionsAllTime ?? null,
+        totalEvents30d:
+            primary.totalEvents30d ?? fallback.totalEvents30d ?? null,
+        totalEvents90d:
+            primary.totalEvents90d ?? fallback.totalEvents90d ?? null,
+        totalEventsAllTime:
+            primary.totalEventsAllTime ?? fallback.totalEventsAllTime ?? null,
         appsAutomated:
             primary.appsAutomated ?? fallback.appsAutomated ?? null,
         telemetryCoverageStartDate:
@@ -633,6 +710,9 @@ function mergeUsageMetrics(primary, fallback) {
             merged.demosRecordedAllTime,
             merged.agentRunsAllTime,
             merged.guiActionsAllTime,
+            merged.totalEvents30d,
+            merged.totalEvents90d,
+            merged.totalEventsAllTime,
             merged.appsAutomated,
         ].some((value) => typeof value === 'number'),
         source:
@@ -703,6 +783,9 @@ export default async function handler(req, res) {
                 demosRecordedAllTime: null,
                 agentRunsAllTime: null,
                 guiActionsAllTime: null,
+                totalEvents30d: null,
+                totalEvents90d: null,
+                totalEventsAllTime: null,
                 appsAutomated: null,
                 telemetryCoverageStartDate: null,
             },

--- a/pages/api/project-metrics.js
+++ b/pages/api/project-metrics.js
@@ -12,6 +12,7 @@ const DEFAULT_POSTHOG_PROJECT_ID = '68185'
 const MAX_EVENT_DEFINITION_PAGES = 5
 const FALLBACK_PATTERN_LIMIT = 30
 const GITHUB_ORG = 'OpenAdaptAI'
+const CLASSIFICATION_VERSION = '2026-03-06'
 
 // Canonical event names from OpenAdapt codebases (legacy PostHog + shared telemetry conventions).
 const EVENT_CLASSIFICATION = {
@@ -79,6 +80,55 @@ const IGNORED_EVENT_PATTERNS = [
     /(?:^|[._:-])(startup|shutdown)(?:[._:-]|$)/i,
 ]
 
+const TELEMETRY_DATA_MODEL = {
+    sdk: 'openadapt-telemetry',
+    sdkVersion: '0.1.0',
+    metricsDashboardReadsOnly: [
+        'event name',
+        'event timestamp (aggregated windows: 30d/90d/all-time)',
+        'aggregated event count',
+    ],
+    commonEventFields: [
+        'category',
+        'timestamp',
+        'package_name',
+        'success',
+        'duration_ms',
+        'item_count',
+        'command',
+        'operation',
+    ],
+    commonTags: [
+        'internal',
+        'package',
+        'package_version',
+        'python_version',
+        'os',
+        'os_version',
+        'ci',
+    ],
+}
+
+const TELEMETRY_PRIVACY_CONTROLS = {
+    neverCollect: [
+        'screenshots or images',
+        'raw text or file contents',
+        'API keys or passwords',
+        'PII user profile fields (name/email/IP)',
+    ],
+    scrubPolicy: [
+        'PII-like keys are redacted (password/token/api_key/etc.)',
+        'emails/phones/secrets are pattern-scrubbed',
+        'file paths are sanitized to remove usernames',
+        'user IDs are anonymized before upload',
+        'send_default_pii is enforced false',
+    ],
+    optOutEnvVars: [
+        'DO_NOT_TRACK=1',
+        'OPENADAPT_TELEMETRY_ENABLED=false',
+    ],
+}
+
 function parseIntEnv(name) {
     const raw = process.env[name]
     if (raw === undefined || raw === null || raw === '') return null
@@ -90,6 +140,43 @@ function formatError(error) {
     if (!error) return 'unknown'
     if (typeof error === 'string') return error
     return error.message || String(error)
+}
+
+function _serializePattern(pattern) {
+    if (pattern instanceof RegExp) {
+        return pattern.toString()
+    }
+    return String(pattern)
+}
+
+function buildTransparencyMetadata() {
+    return {
+        classificationVersion: CLASSIFICATION_VERSION,
+        metricScope: {
+            summary: 'Homepage metrics use aggregate telemetry counts (no raw event payloads are displayed).',
+            includedMetricFamilies: ['total_events', 'agent_runs', 'gui_actions', 'demos_recorded'],
+        },
+        includedEventNames: {
+            demos: [...EVENT_CLASSIFICATION.demos.exact],
+            runs: [...EVENT_CLASSIFICATION.runs.exact],
+            actions: [...EVENT_CLASSIFICATION.actions.exact],
+        },
+        ignoredEventNames: Array.from(IGNORED_EVENT_NAMES).sort(),
+        ignoredEventPatterns: IGNORED_EVENT_PATTERNS.map(_serializePattern),
+        fallbackPatterns: {
+            demos: EVENT_CLASSIFICATION.demos.fallbackPatterns.map(_serializePattern),
+            runs: EVENT_CLASSIFICATION.runs.fallbackPatterns.map(_serializePattern),
+            actions: EVENT_CLASSIFICATION.actions.fallbackPatterns.map(_serializePattern),
+        },
+        telemetryDataModel: TELEMETRY_DATA_MODEL,
+        privacyControls: TELEMETRY_PRIVACY_CONTROLS,
+        sourceLinks: {
+            privacyPolicy: '/privacy-policy',
+            telemetryReadme: 'https://github.com/OpenAdaptAI/openadapt-telemetry#readme',
+            telemetryPrivacyCode:
+                'https://github.com/OpenAdaptAI/openadapt-telemetry/blob/main/src/openadapt_telemetry/privacy.py',
+        },
+    }
 }
 
 async function fetchWithTimeout(url, options = {}, timeoutMs = 8000) {
@@ -613,7 +700,7 @@ async function fetchPosthogUsageFromEventDefinitions(config) {
             runs: runs.strategy,
             actions: actions.strategy,
         },
-        classificationVersion: '2026-03-05',
+        classificationVersion: CLASSIFICATION_VERSION,
         caveats: [
             'Derived from PostHog volume_30_day by exact event-name classification',
             'Falls back to guarded pattern matching only when exact mapping has no data',
@@ -722,6 +809,7 @@ function mergeUsageMetrics(primary, fallback) {
         caveats: [...(primary.caveats || []), ...(fallback.caveats || [])],
         matchedEvents: primary.matchedEvents || null,
         strategies: primary.strategies || null,
+        transparency: buildTransparencyMetadata(),
         ...merged,
     }
 }

--- a/pages/api/project-metrics.js
+++ b/pages/api/project-metrics.js
@@ -9,6 +9,73 @@
 
 const DEFAULT_POSTHOG_HOST = 'https://us.posthog.com'
 const MAX_EVENT_DEFINITION_PAGES = 5
+const FALLBACK_PATTERN_LIMIT = 30
+
+// Canonical event names from OpenAdapt codebases (legacy PostHog + shared telemetry conventions).
+const EVENT_CLASSIFICATION = {
+    demos: {
+        exact: [
+            'recording_finished',
+            'recording_completed',
+            'demo_recorded',
+            'demo_completed',
+            'recording.stopped',
+            'recording.saved',
+            'record.stopped',
+            'capture.completed',
+            'capture.saved',
+        ],
+        fallbackPatterns: [
+            /(?:^|[._:-])(demo|record|recording|capture)(?:[._:-]|$)/i,
+            /(?:finished|completed|saved|recorded|stopped)$/i,
+            /^command:(capture|record)/i,
+            /^operation:(capture|record)/i,
+        ],
+    },
+    runs: {
+        exact: [
+            'automation_run',
+            'agent_run',
+            'benchmark_run',
+            'replay_started',
+            'episode_started',
+            'replay.started',
+        ],
+        fallbackPatterns: [
+            /(?:^|[._:-])(replay|benchmark|eval|episode|agent_run|automation_run)(?:[._:-]|$)/i,
+            /^command:(replay|run|eval|benchmark|execute|agent)/i,
+            /^operation:(replay|run|eval|benchmark|execute|agent)/i,
+        ],
+    },
+    actions: {
+        exact: [
+            'action_executed',
+            'step_executed',
+            'mouse_click',
+            'keyboard_input',
+            'ui_action',
+            'action_triggered',
+        ],
+        fallbackPatterns: [
+            /(?:^|[._:-])(action|step|click|keyboard|mouse|scroll|key|keypress|type|drag)(?:[._:-]|$)/i,
+            /^operation:.*(?:action|step|click|type|scroll|press|key|mouse)/i,
+        ],
+    },
+}
+
+const IGNORED_EVENT_NAMES = new Set([
+    'function_trace',
+    'get_events.started',
+    'get_events.completed',
+    'visualize.started',
+    'visualize.completed',
+])
+
+const IGNORED_EVENT_PATTERNS = [
+    /^error[:._-]/i,
+    /^exception[:._-]/i,
+    /(?:^|[._:-])(startup|shutdown)(?:[._:-]|$)/i,
+]
 
 function parseIntEnv(name) {
     const raw = process.env[name]
@@ -79,20 +146,73 @@ function valueFromDefinition(definition) {
     return Number.isFinite(maybeNumber) ? maybeNumber : 0
 }
 
-function sumByEventNames(definitions, candidateNames) {
+function normalizeEventName(name) {
+    return String(name || '').trim().toLowerCase()
+}
+
+function shouldIgnoreEvent(name) {
+    if (IGNORED_EVENT_NAMES.has(name)) return true
+    return IGNORED_EVENT_PATTERNS.some((pattern) => pattern.test(name))
+}
+
+function toEventEntries(definitions) {
+    return definitions
+        .map((definition) => ({
+            definition,
+            name: normalizeEventName(definition?.name),
+            volume_30_day: valueFromDefinition(definition),
+        }))
+        .filter((entry) => entry.name && entry.volume_30_day > 0 && !shouldIgnoreEvent(entry.name))
+}
+
+function sumByEventNames(entries, candidateNames) {
     const target = new Set(candidateNames.map((name) => name.toLowerCase()))
     let total = 0
     const matched = []
 
-    for (const definition of definitions) {
-        const name = String(definition?.name || '').toLowerCase()
-        if (!target.has(name)) continue
-        const value = valueFromDefinition(definition)
-        total += value
-        matched.push({ name: definition.name, volume_30_day: value })
+    for (const entry of entries) {
+        if (!target.has(entry.name)) continue
+        total += entry.volume_30_day
+        matched.push({ name: entry.definition.name, volume_30_day: entry.volume_30_day })
     }
 
-    return { total, matched }
+    return { total, matched, strategy: 'exact' }
+}
+
+function sumByFallbackPatterns(entries, patterns, excludedNames = new Set()) {
+    let total = 0
+    const matched = []
+
+    for (const entry of entries) {
+        if (excludedNames.has(entry.name)) continue
+        if (!patterns.some((pattern) => pattern.test(entry.name))) continue
+        total += entry.volume_30_day
+        matched.push({ name: entry.definition.name, volume_30_day: entry.volume_30_day })
+    }
+
+    matched.sort((a, b) => b.volume_30_day - a.volume_30_day)
+    const sliced = matched.slice(0, FALLBACK_PATTERN_LIMIT)
+
+    return {
+        total,
+        matched: sliced,
+        strategy: 'pattern_fallback',
+        truncated: matched.length > FALLBACK_PATTERN_LIMIT,
+    }
+}
+
+function buildCategoryMetrics(entries, config) {
+    const exact = sumByEventNames(entries, config.exact)
+    if (exact.total > 0) {
+        return exact
+    }
+
+    const fallback = sumByFallbackPatterns(entries, config.fallbackPatterns || [])
+    if (fallback.total > 0) {
+        return fallback
+    }
+
+    return { total: 0, matched: [], strategy: 'none' }
 }
 
 async function fetchPosthogUsageMetrics() {
@@ -107,26 +227,10 @@ async function fetchPosthogUsageMetrics() {
 
     const definitions = await fetchAllEventDefinitions(config)
 
-    const demos = sumByEventNames(definitions, [
-        'recording_finished',
-        'recording_completed',
-        'demo_recorded',
-        'demo_completed',
-    ])
-    const runs = sumByEventNames(definitions, [
-        'automation_run',
-        'agent_run',
-        'benchmark_run',
-        'replay_started',
-        'episode_started',
-    ])
-    const actions = sumByEventNames(definitions, [
-        'action_executed',
-        'step_executed',
-        'mouse_click',
-        'keyboard_input',
-        'ui_action',
-    ])
+    const entries = toEventEntries(definitions)
+    const demos = buildCategoryMetrics(entries, EVENT_CLASSIFICATION.demos)
+    const runs = buildCategoryMetrics(entries, EVENT_CLASSIFICATION.runs)
+    const actions = buildCategoryMetrics(entries, EVENT_CLASSIFICATION.actions)
 
     return {
         available: demos.total > 0 || runs.total > 0 || actions.total > 0,
@@ -139,9 +243,15 @@ async function fetchPosthogUsageMetrics() {
             runs: runs.matched,
             actions: actions.matched,
         },
+        strategies: {
+            demos: demos.strategy,
+            runs: runs.strategy,
+            actions: actions.strategy,
+        },
+        classificationVersion: '2026-03-05',
         caveats: [
-            'Derived from PostHog volume_30_day on matched event names',
-            'Event naming consistency affects metric completeness',
+            'Derived from PostHog volume_30_day by exact event-name classification',
+            'Falls back to guarded pattern matching only when exact mapping has no data',
         ],
     }
 }

--- a/pages/api/project-metrics.js
+++ b/pages/api/project-metrics.js
@@ -276,13 +276,17 @@ async function fetchPosthogUsageMetrics() {
     const demos = buildCategoryMetrics(entries, EVENT_CLASSIFICATION.demos)
     const runs = buildCategoryMetrics(entries, EVENT_CLASSIFICATION.runs)
     const actions = buildCategoryMetrics(entries, EVENT_CLASSIFICATION.actions)
+    const hasAnyVolume = demos.total > 0 || runs.total > 0 || actions.total > 0
 
     return {
-        available: demos.total > 0 || runs.total > 0 || actions.total > 0,
+        // "available" means PostHog data source is configured/reachable, not
+        // necessarily that recent event volume is non-zero.
+        available: true,
         source: 'posthog_event_definitions',
         demosRecorded30d: demos.total,
         agentRuns30d: runs.total,
         guiActions30d: actions.total,
+        hasAnyVolume,
         matchedEvents: {
             demos: demos.matched,
             runs: runs.matched,

--- a/pages/api/project-metrics.js
+++ b/pages/api/project-metrics.js
@@ -8,6 +8,7 @@
  */
 
 const DEFAULT_POSTHOG_HOST = 'https://us.posthog.com'
+const DEFAULT_POSTHOG_PROJECT_ID = '68185'
 const MAX_EVENT_DEFINITION_PAGES = 5
 const FALLBACK_PATTERN_LIMIT = 30
 
@@ -108,7 +109,10 @@ async function fetchGitHubStats() {
 
 function getPosthogConfig() {
     const host = process.env.POSTHOG_HOST || process.env.NEXT_PUBLIC_POSTHOG_HOST || DEFAULT_POSTHOG_HOST
-    const projectId = process.env.POSTHOG_PROJECT_ID || process.env.NEXT_PUBLIC_POSTHOG_PROJECT_ID
+    const projectId =
+        process.env.POSTHOG_PROJECT_ID ||
+        process.env.NEXT_PUBLIC_POSTHOG_PROJECT_ID ||
+        DEFAULT_POSTHOG_PROJECT_ID
     const apiKey = process.env.POSTHOG_PERSONAL_API_KEY || process.env.POSTHOG_API_KEY
 
     if (!apiKey) return null

--- a/pages/api/project-metrics.js
+++ b/pages/api/project-metrics.js
@@ -11,6 +11,7 @@ const DEFAULT_POSTHOG_HOST = 'https://us.posthog.com'
 const DEFAULT_POSTHOG_PROJECT_ID = '68185'
 const MAX_EVENT_DEFINITION_PAGES = 5
 const FALLBACK_PATTERN_LIMIT = 30
+const GITHUB_ORG = 'OpenAdaptAI'
 
 // Canonical event names from OpenAdapt codebases (legacy PostHog + shared telemetry conventions).
 const EVENT_CLASSIFICATION = {
@@ -107,18 +108,36 @@ async function fetchWithTimeout(url, options = {}, timeoutMs = 8000) {
 }
 
 async function fetchGitHubStats() {
-    const response = await fetchWithTimeout('https://api.github.com/repos/OpenAdaptAI/OpenAdapt', {
-        headers: { 'User-Agent': 'OpenAdapt-Web/1.0 (https://openadapt.ai)' },
-    })
-    if (!response.ok) {
-        throw new Error(`GitHub API returned ${response.status}`)
+    const repos = []
+    let page = 1
+    while (true) {
+        const response = await fetchWithTimeout(
+            `https://api.github.com/orgs/${GITHUB_ORG}/repos?per_page=100&page=${page}&type=public`,
+            {
+                headers: { 'User-Agent': 'OpenAdapt-Web/1.0 (https://openadapt.ai)' },
+            }
+        )
+        if (!response.ok) {
+            throw new Error(`GitHub API returned ${response.status}`)
+        }
+        const batch = await response.json()
+        if (!Array.isArray(batch) || batch.length === 0) break
+        repos.push(...batch)
+        page += 1
     }
-    const data = await response.json()
+
+    const openadaptRepos = repos.filter((repo) => {
+        const name = String(repo?.name || '').toLowerCase()
+        return !repo?.private && !repo?.archived && (name === 'openadapt' || name.startsWith('openadapt-'))
+    })
+
+    const stars = openadaptRepos.reduce((sum, repo) => sum + (repo?.stargazers_count || 0), 0)
+    const forks = openadaptRepos.reduce((sum, repo) => sum + (repo?.forks_count || 0), 0)
+
     return {
-        stars: data.stargazers_count || 0,
-        forks: data.forks_count || 0,
-        watchers: data.subscribers_count || 0,
-        issues: data.open_issues_count || 0,
+        stars,
+        forks,
+        repoCount: openadaptRepos.length,
     }
 }
 

--- a/pages/api/project-metrics.js
+++ b/pages/api/project-metrics.js
@@ -642,13 +642,22 @@ function mergeUsageMetrics(primary, fallback) {
     }
 }
 
-function cacheControlForUsageSource(source) {
+function isCacheableUsageSource(source) {
     const normalized = String(source || '')
-    // Cache successful PostHog-backed payloads briefly.
-    if (normalized === 'posthog_query_api' || normalized === 'posthog_event_definitions') {
+    return normalized === 'posthog_query_api' || normalized === 'posthog_event_definitions'
+}
+
+function hasUsableGithubPayload(github) {
+    return typeof github?.stars === 'number' && typeof github?.forks === 'number'
+}
+
+function cacheControlForResponse(response) {
+    const posthogOk = isCacheableUsageSource(response?.usage?.source)
+    const githubOk = hasUsableGithubPayload(response?.github)
+    // Only cache when both sources are healthy to avoid caching partial dashboards.
+    if (posthogOk && githubOk) {
         return 'public, max-age=30, s-maxage=120, stale-while-revalidate=300'
     }
-    // Do not cache degraded/unconfigured payloads at the edge.
     return 'no-store, max-age=0'
 }
 
@@ -697,7 +706,7 @@ export default async function handler(req, res) {
         )
     }
 
-    res.setHeader('Cache-Control', cacheControlForUsageSource(response?.usage?.source))
+    res.setHeader('Cache-Control', cacheControlForResponse(response))
     res.setHeader('X-OpenAdapt-Metrics-Source', String(response?.usage?.source || 'unknown'))
     return res.status(200).json(response)
 }

--- a/pages/api/project-metrics.js
+++ b/pages/api/project-metrics.js
@@ -12,9 +12,10 @@ const DEFAULT_POSTHOG_PROJECT_ID = '68185'
 const MAX_EVENT_DEFINITION_PAGES = 5
 const FALLBACK_PATTERN_LIMIT = 30
 const GITHUB_ORG = 'OpenAdaptAI'
-const CLASSIFICATION_VERSION = '2026-03-06'
+const CLASSIFICATION_VERSION = '2026-03-29'
 
-// Canonical event names from OpenAdapt codebases (legacy PostHog + shared telemetry conventions).
+// Canonical event names from OpenAdapt codebases.
+// Updated to include openadapt-evals training, DemoExecutor, and correction events.
 const EVENT_CLASSIFICATION = {
     demos: {
         exact: [
@@ -27,9 +28,12 @@ const EVENT_CLASSIFICATION = {
             'record.stopped',
             'capture.completed',
             'capture.saved',
+            // Correction flywheel
+            'correction_captured',
+            'correction_stored',
         ],
         fallbackPatterns: [
-            /(?:^|[._:-])(demo|record|recording|capture)(?:[._:-]|$)/i,
+            /(?:^|[._:-])(demo|record|recording|capture|correction)(?:[._:-]|$)/i,
             /(?:finished|completed|saved|recorded|stopped)$/i,
             /^command:(capture|record)/i,
             /^operation:(capture|record)/i,
@@ -43,11 +47,18 @@ const EVENT_CLASSIFICATION = {
             'replay_started',
             'episode_started',
             'replay.started',
+            // GRPO training (openadapt-evals standalone trainer)
+            'training_run',
+            'training_step_completed',
+            'rollout_collected',
+            'checkpoint_saved',
+            // DemoExecutor (tiered demo execution)
+            'demo_execution',
         ],
         fallbackPatterns: [
-            /(?:^|[._:-])(replay|benchmark|eval|episode|agent_run|automation_run)(?:[._:-]|$)/i,
-            /^command:(replay|run|eval|benchmark|execute|agent)/i,
-            /^operation:(replay|run|eval|benchmark|execute|agent)/i,
+            /(?:^|[._:-])(replay|benchmark|eval|episode|agent_run|automation_run|training|rollout|checkpoint)(?:[._:-]|$)/i,
+            /^command:(replay|run|eval|benchmark|execute|agent|train)/i,
+            /^operation:(replay|run|eval|benchmark|execute|agent|train)/i,
         ],
     },
     actions: {

--- a/utils/pypiStats.js
+++ b/utils/pypiStats.js
@@ -80,7 +80,10 @@ async function getPackageData() {
 async function getPackageList() {
     const packages = await getPackageData();
     return packages
-        .filter((p) => typeof p === 'string' || p.category === 'core')
+        .filter((p) => {
+            if (typeof p === 'string') return true;
+            return p.category === 'core' && p.on_pypi !== false;
+        })
         .map((p) => (typeof p === 'string' ? p : p.name));
 }
 

--- a/utils/pypistatsHistory.js
+++ b/utils/pypistatsHistory.js
@@ -62,7 +62,11 @@ async function getPackageList() {
         const data = await response.json();
         // Filter to core packages only, extract names for stats
         const packages = (data.packages || [])
-            .filter((p) => typeof p === 'string' || p.category === 'core')
+            .filter((p) => {
+                if (typeof p === 'string') return true;
+                // Only include core packages that are actually on PyPI
+                return p.category === 'core' && p.on_pypi !== false;
+            })
             .map((p) => (typeof p === 'string' ? p : p.name));
         cachedPackages = packages;
         cacheTimestamp = Date.now();


### PR DESCRIPTION
## Summary
This PR upgrades homepage adoption signals and install UX with production-safe defaults.

### 1) Usage metrics from PostHog (server-side)
- Added exact-first event classification for:
  - demos
  - agent runs
  - GUI actions
- Added guarded pattern fallback only when exact mappings return no hits.
- Excluded low-signal/internal events from usage counts:
  - `function_trace`
  - `get_events.started`
  - `get_events.completed`
  - `visualize.started`
  - `visualize.completed`
- Added clearer source metadata in API payload.
- Fixed availability semantics: if PostHog is reachable/configured, usage source is treated as available even when counts are zero.

### 2) PostHog config ergonomics
- `POSTHOG_PROJECT_ID` now defaults to `68185` in API logic (still overridable by env).
- Added `.env.example` for required server-side keys.
- Added explicit handling for `phc_` project token misuse:
  - returns actionable caveat that a personal API key (`phx_`) is required for reads.

### 3) Install UX
- Install section now shows a true one-liner first (per platform), with step-by-step fallback commands below.

## Runtime verification
- `npm run build` passes.
- Deploy preview endpoint now returns configured PostHog source with no warnings:
  - `/api/project-metrics` reports `source=posthog_event_definitions`
- Current usage values are `0` because PostHog event-definition 30d volumes for mapped events are currently zero.

## Notes
- `(30d)` means rolling last 30 days.
- This PR keeps env override support as fallback for manual counters.