### PR TITLE
fix: industry Get Started CTAs link to intake form, not install docs

### DIFF
--- a/components/ContactBookingSection.js
+++ b/components/ContactBookingSection.js
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Link from 'next/link'
 
 import BookingEmbed from '@components/BookingEmbed'
@@ -16,8 +16,17 @@ const INITIAL_FORM = {
 export default function ContactBookingSection({
     sectionId = 'book',
     showHomeLink = false,
+    prefill = null,
 }) {
     const [form, setForm] = useState(INITIAL_FORM)
+
+    // Seed the message from an industry card's "Get Started" click so the
+    // visitor's stated interest survives the jump to the intake form.
+    useEffect(() => {
+        if (prefill?.message) {
+            setForm((prev) => ({ ...prev, message: prefill.message }))
+        }
+    }, [prefill])
     const [isSubmitting, setIsSubmitting] = useState(false)
     const [isSubmitted, setIsSubmitted] = useState(false)
     const [error, setError] = useState('')

--- a/components/IndustriesGrid.js
+++ b/components/IndustriesGrid.js
@@ -741,7 +741,7 @@ export default function IndustriesGrid({
                         <div className="flex flex-row items-center justify-center mt-3 mb-2">
                             <Link
                                 className="px-4 py-2 rounded-lg bg-[#5a1eac] hover:bg-[#7132d4] text-white text-sm font-medium transition-all duration-200"
-                                href="#start"
+                                href="#book"
                                 onClick={() =>
                                     handleGetStartedButtonClick(grid.title)
                                 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -47,7 +47,7 @@ export default function Home() {
                 sectionRef={sectionRef}
             />
             {/* <SocialSection /> */} {/* Temporarily disabled - feeds not working */}
-            <ContactBookingSection />
+            <ContactBookingSection prefill={feedbackData} />
             <Footer />
         </div>
     )


### PR DESCRIPTION
Every industry card's **Get Started** button pointed at `#start` — the developer pip-install section — instead of `#book`, the intake form. Confirmed live in production HTML (all 9 cards link to `/#start`).

**Changes**
- `components/IndustriesGrid.js`: the shared card CTA now links to `#book`.
- `pages/index.js` + `components/ContactBookingSection.js`: the industry-specific interest message (already captured on click, but previously routed to an orphaned component) now prefills the intake form's message field via a new `prefill` prop.

**Verified:** `next build` passes; no form/field names changed (Netlify Forms schema untouched); anchors `#book`/`#industries` unchanged for existing backlinks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FmaqQy1TJ3M9FbGf6hEhbg