### PR TITLE
feat: global nav header, buyer-first homepage, measured proof band

### DIFF
--- a/components/Developers.js
+++ b/components/Developers.js
@@ -1,51 +1,39 @@
 import React, { useEffect, useState } from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faWindows, faApple } from '@fortawesome/free-brands-svg-icons';
-import { faLink } from '@fortawesome/free-solid-svg-icons';
-import Link from 'next/link';
 import styles from './Developers.module.css';
-import { getReleasesDownloadCount } from 'utils/githubStats';
-import EmailForm from '@components/EmailForm';
 import InstallSection from '@components/InstallSection';
-import DownloadGraph from './DownloadGraph';
 import PyPIDownloadChart from './PyPIDownloadChart';
 
+const ecosystemLinks = [
+    {
+        label: 'All repositories',
+        href: 'https://github.com/OpenAdaptAI',
+    },
+    {
+        label: 'openadapt-flow',
+        href: 'https://github.com/OpenAdaptAI/openadapt-flow',
+    },
+    {
+        label: 'Docs',
+        href: 'https://docs.openadapt.ai',
+    },
+    {
+        label: 'Blog',
+        href: 'https://blog.openadapt.ai',
+    },
+    {
+        label: 'Discord',
+        href: 'https://discord.gg/yF527cQbDG',
+    },
+    {
+        label: 'Report an issue',
+        href: 'https://github.com/OpenAdaptAI/OpenAdapt/issues/new/choose',
+    },
+];
+
 export default function Developers() {
-    const [latestRelease, setLatestRelease] = useState({ version: null, date: null });
-    const [downloadCount, setDownloadCount] = useState({ windows: 0, mac: 0 });
     const [buildWarnings, setBuildWarnings] = useState([]);
-    const macURL = latestRelease.version
-        ? `https://github.com/OpenAdaptAI/OpenAdapt/releases/download/${latestRelease.version}/OpenAdapt-${latestRelease.version}.dmg`
-        : '';
-    const windowsURL = latestRelease.version
-        ? `https://github.com/OpenAdaptAI/OpenAdapt/releases/download/${latestRelease.version}/OpenAdapt_Installer-${latestRelease.version}.exe`
-        : '';
 
     useEffect(() => {
-        // Fetch the latest release information
-        fetch('https://api.github.com/repos/OpenAdaptAI/OpenAdapt/releases/latest')
-            .then(response => response.json())
-            .then(data => {
-                const releaseDate = new Date(data.published_at).toLocaleString('en-US', {
-                    year: 'numeric', month: 'numeric', day: 'numeric',
-                    hour: '2-digit', minute: '2-digit', second: '2-digit',
-                    hour12: false, timeZoneName: 'short'
-                });
-                setLatestRelease({
-                    version: data.name,
-                    date: releaseDate
-                });
-            });
-
-        // Fetch download counts
-        getReleasesDownloadCount().then(({ windowsDownloadCount, macDownloadCount }) => {
-            setDownloadCount({
-                windows: windowsDownloadCount,
-                mac: macDownloadCount,
-            });
-            console.log("Download counts:", { windowsDownloadCount, macDownloadCount });
-        });
-
         // Fetch issues labeled "main-broken"
         fetch('https://api.github.com/repos/OpenAdaptAI/OpenAdapt/issues?state=open&labels=main-broken')
             .then(response => response.json())
@@ -57,48 +45,16 @@ export default function Developers() {
             });
     }, []);
 
-    const handleDownloadClick = (os, url) => {
-        const fileName = url.split('/').pop();
-        window.gtag('event', 'download_start', {
-            event_category: 'Software Downloads',
-            event_action: `Download Initiated ${os}`,
-            event_label: fileName,
-            value: 1
-        });
-        downloadFile(url, os, fileName);
-    }
-
-    const downloadFile = async (url, os, fileName) => {
-        try {
-            const response = await fetch(url);
-            if (response.ok) {
-                window.gtag('event', 'download_success', {
-                    event_category: 'Software Downloads',
-                    event_action: `Download Successful ${os}`,
-                    event_label: fileName,
-                    value: 1
-                });
-            } else {
-                throw new Error('Network response was not ok.');
-            }
-        } catch (error) {
-            console.error('Download failed:', error);
-            window.gtag('event', 'download_failure', {
-                event_category: 'Software Downloads',
-                event_action: `Download Failed ${os}`,
-                event_label: fileName,
-                value: 0
-            });
-        }
-    }
-
     return (
-        <div className={styles.row} id="start">
+        <div className={styles.row} id="open-source">
+            {/* Legacy anchors kept for existing inbound links */}
+            <span id="start" />
+            <span id="developers" />
             <div className="relative flex items-center justify-center mx-4 sm:mx-8 md:mx-12 lg:mx-20 max-w-5xl">
                 <div className="grid grid-cols-1 break-words w-full">
-                    <p className="eyebrow text-center mt-8 mb-2">Developers</p>
+                    <p className="eyebrow text-center mt-8 mb-2">Open source</p>
                     <h2 className="font-display text-xl mb-4 font-semibold text-center tracking-tight text-ink">
-                        Getting Started
+                        MIT licensed. Install it and read the code.
                     </h2>
                     {buildWarnings.length > 0 && (
                         <div className="bg-amber-100 border border-amber-700/40 text-amber-900 text-center p-4 rounded-lg">
@@ -124,147 +80,25 @@ export default function Developers() {
                         Record a workflow once and it compiles into a deterministic, self-healing automation that runs on your own machines.
                     </p>
 
-                    {/* New uv-first Installation Section */}
+                    {/* uv-first Installation Section */}
                     <InstallSection />
 
                     {/* PyPI Download Statistics */}
                     <PyPIDownloadChart />
 
-                    {/* Legacy Desktop App Downloads - Disabled during transition to new architecture
-                    <div className="mt-12">
-                        <h3 className="text-xl font-light text-center mb-2">
-                            Or Download Desktop App (Legacy)
-                        </h3>
-                        <p className="text-sm text-center text-gray-400 mb-4">
-                            A new desktop app is in development. For now, we recommend using the CLI above.
-                        </p>
-                        {latestRelease.version && (
-                            <div className="text-center mb-4">
-                                <div className="inline-block bg-transparent p-3 shadow-lg rounded-lg">
-                                    <table className="table-auto border-separate border-spacing-y-2">
-                                        <tbody>
-                                            <tr>
-                                                <td className="bg-gray-800 px-4 py-2 rounded-l text-sm font-semibold text-white w-40 border-r border-gray-800">Current Version:</td>
-                                                <td className="bg-white bg-opacity-50 px-4 py-2 rounded-r text-lg font-bold text-white border-l border-transparent">{latestRelease.version}</td>
-                                            </tr>
-                                            <tr className="mt-2">
-                                                <td className="bg-gray-800 px-4 py-2 rounded-l text-sm font-semibold text-white w-40 border-r border-gray-800">Released on:</td>
-                                                <td className="bg-white bg-opacity-50 px-4 py-2 rounded-r text-lg text-white border-l border-transparent">{latestRelease.date}</td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                            </div>
-                        )}
-                        <div className="flex flex-col gap-10 justify-center items-center sm:flex-row">
-                            <Link
-                                className="w-fit flex flex-col gap-y-6 h-fit btn btn-primary hover:no-underline mb-6 py-8"
-                                href={windowsURL}
-                                onClick={() => handleDownloadClick('Windows', windowsURL)}
+                    <div className="mt-8 mb-2 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-center">
+                        {ecosystemLinks.map((link) => (
+                            <a
+                                key={link.label}
+                                href={link.href}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-sm"
                             >
-                                <FontAwesomeIcon
-                                    icon={faWindows}
-                                    className="text-[96px]"
-                                />
-                                <span className="text-2xl">
-                                    Download for Windows
-                                </span>
-                                {downloadCount.windows > 0 && (
-                                    <span className="text-lg">
-                                        {downloadCount.windows.toLocaleString()} downloads
-                                        <a
-                                            href="https://github.com/OpenAdaptAI/OpenAdapt/releases"
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            className={styles.sourceLink}
-                                            aria-label="View GitHub releases"
-                                        >
-                                            <FontAwesomeIcon icon={faLink} className={styles.sourceLinkIcon} />
-                                            <span className={styles.sourceLinkTooltip}>View data source</span>
-                                        </a>
-                                    </span>
-                                )}
-                            </Link>
-                            <Link
-                                className="px-8 w-fit flex flex-col gap-y-6 h-fit btn btn-primary hover:no-underline mb-6 py-8 sm:px-6"
-                                href={macURL}
-                                onClick={() => handleDownloadClick('MacOS', macURL)}
-                            >
-                                <FontAwesomeIcon
-                                    icon={faApple}
-                                    style={{ fontSize: 96 }}
-                                />
-                                <span className="text-2xl">Download for MacOS</span>
-                                {downloadCount.mac > 0 && (
-                                    <span className="text-lg">
-                                        {downloadCount.mac.toLocaleString()} downloads
-                                        <a
-                                            href="https://github.com/OpenAdaptAI/OpenAdapt/releases"
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            className={styles.sourceLink}
-                                            aria-label="View GitHub releases"
-                                        >
-                                            <FontAwesomeIcon icon={faLink} className={styles.sourceLinkIcon} />
-                                            <span className={styles.sourceLinkTooltip}>View data source</span>
-                                        </a>
-                                    </span>
-                                )}
-                            </Link>
-                        </div>
+                                {link.label}
+                            </a>
+                        ))}
                     </div>
-                    <DownloadGraph />
-                    */}
-                    <EmailForm />
-
-                    <h2 className="font-display text-xl mt-8 font-semibold text-center tracking-tight text-ink">What's Next?</h2>
-                    <ul className={`${styles.noBullets} mt-3 font-light text-center`}>
-                        <li className="mt-2">
-                            <a
-                                className="btn-ghost-ink"
-                                href="https://docs.openadapt.ai"
-                            >
-                                Read the Docs
-                            </a>
-                        </li>
-                        <li className="mt-2">
-                            <a
-                                className="btn-ghost-ink"
-                                href="https://blog.openadapt.ai"
-                            >
-                                Read the Blog
-                            </a>
-                        </li>
-                        <li className="mt-2">
-                            <a
-                                className="btn-ghost-ink"
-                                href="https://discord.gg/yF527cQbDG"
-                            >
-                                Join our Discord
-                            </a>
-                        </li>
-                        <li className="mt-2">
-                            <a
-                                className="btn-ghost-ink"
-                                href="https://github.com/OpenAdaptAI/OpenAdapt#installation"
-                            >
-                                View README
-                            </a>
-                        </li>
-                    </ul>
-                    <h2 className="font-display text-xl mt-8 font-semibold text-center tracking-tight text-ink">
-                        Troubleshooting
-                    </h2>
-                    <ul className={`${styles.noBullets} mt-3 font-light text-center`}>
-                        <li className="mt-2">
-                            <a
-                                className="btn-ghost-ink"
-                                href="https://github.com/OpenAdaptAI/OpenAdapt/issues/new/choose"
-                            >
-                                Please submit a GitHub Issue
-                            </a>
-                        </li>
-                    </ul>
                 </div>
             </div>
         </div>

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -40,14 +40,37 @@ export default function Footer() {
                         />
                     </div>
                 </div>
-                <iframe
-                    src="https://github.com/sponsors/OpenAdaptAI/button"
-                    title="Sponsor OpenAdaptAI"
-                    height="32"
-                    width="114"
-                    style={{ border: '0', borderRadius: '6px' }}
-                    className="mx-auto mb-4"
-                ></iframe>
+                <div className="flex flex-wrap items-center justify-center gap-2 mb-4">
+                    <iframe
+                        src="https://github.com/sponsors/OpenAdaptAI/button"
+                        title="Sponsor OpenAdaptAI"
+                        height="32"
+                        width="114"
+                        style={{ border: '0', borderRadius: '6px' }}
+                    ></iframe>
+                    <a
+                        className="github-button"
+                        href="https://github.com/OpenAdaptAI/OpenAdapt"
+                        data-color-scheme="no-preference: light; light: light; dark: light;"
+                        data-icon="octicon-star"
+                        data-size="large"
+                        data-show-count="true"
+                        aria-label="Star OpenAdaptAI/OpenAdapt on GitHub"
+                    >
+                        Star
+                    </a>
+                    <a
+                        className="github-button"
+                        href="https://github.com/OpenAdaptAI/OpenAdapt/fork"
+                        data-color-scheme="no-preference: light; light: light; dark: light;"
+                        data-icon="octicon-repo-forked"
+                        data-size="large"
+                        data-show-count="true"
+                        aria-label="Fork OpenAdaptAI/OpenAdapt on GitHub"
+                    >
+                        Fork
+                    </a>
+                </div>
                 <div className={styles.footerContent}>
                     <div className={`${styles.footerLinks} pt-4`}>
                         <a href={bookHref} className={styles.link}>

--- a/components/MastHead.js
+++ b/components/MastHead.js
@@ -1,17 +1,8 @@
 import { useEffect, useState } from 'react'
 import React from 'react'
 import Link from 'next/link'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faBook, faPen } from '@fortawesome/free-solid-svg-icons'
-import {
-    faLinkedin,
-    faDiscord,
-    faGithub,
-    faXTwitter,
-} from '@fortawesome/free-brands-svg-icons'
 
 import ReplayHero from '@components/ReplayHero'
-import EmailForm from '@components/EmailForm'
 
 import styles from './MastHead.module.css'
 
@@ -66,24 +57,24 @@ export default function Home() {
                 <div className="relative z-30 py-4 px-4 text-xl w-full max-w-5xl mx-auto">
                     <div className="text-center pt-6">
                         <div className="grid grid-flow-row auto-rows-max gap-0">
-                            <h1 className="font-display text-4xl mb-4 sm:text-5xl md:text-6xl tracking-tight text-ink">
+                            <div className="font-display text-4xl mb-4 sm:text-5xl md:text-6xl tracking-tight text-ink">
                                 <span className="font-extralight">Open</span><span className="font-semibold">Adapt</span>
                                 <span className="font-extralight">.AI</span>
-                            </h1>
+                            </div>
                             <div className="mb-4">
                                 <span className={styles.heroPill}>
                                     LOCAL-FIRST · MIT OPEN SOURCE
                                 </span>
                             </div>
-                            <h2 className="font-display text-2xl md:text-3xl mt-0 mb-4 font-semibold tracking-tight text-ink">
+                            <h1 className="font-display text-2xl md:text-3xl mt-0 mb-4 font-semibold tracking-tight text-ink">
                                 Show it once. It runs forever. On your premises.
-                            </h2>
-                            <h3 className="mt-0 mb-6 mx-auto max-w-3xl font-sans font-normal text-base md:text-lg text-ink-2">
+                            </h1>
+                            <p className="mt-0 mb-6 mx-auto max-w-3xl font-sans font-normal text-base md:text-lg text-ink-2">
                                 OpenAdapt compiles a recorded demonstration into
                                 a deterministic, self-healing automation — open
                                 source, auditable, and running entirely on your
                                 own machines.
-                            </h3>
+                            </p>
                             <div className="flex flex-col align-center justify-center px-4 min-w-0 max-w-full overflow-hidden">
                                 <ReplayHero />
                             </div>
@@ -103,95 +94,7 @@ export default function Home() {
                                     </Link>
                                 </div>
                             </div>
-                            <EmailForm />
                         </div>
-                    </div>
-                </div>
-                <div className="fixed top-0 right-0 z-50 flex flex-nowrap items-center justify-end gap-2 p-2">
-                    {/* Docs Icon */}
-                    <div className="relative z-50">
-                        <a href="https://docs.openadapt.ai" aria-label="Documentation" title="Documentation" className="text-ink hover:text-accent">
-                            <FontAwesomeIcon
-                                icon={faBook}
-                                className="text-xl sm:text-2xl"
-                            />
-                        </a>
-                    </div>
-                    {/* Blog Icon */}
-                    <div className="relative z-50">
-                        <a href="https://blog.openadapt.ai" aria-label="Blog" title="Blog" className="text-ink hover:text-accent">
-                            <FontAwesomeIcon
-                                icon={faPen}
-                                className="text-xl sm:text-2xl"
-                            />
-                        </a>
-                    </div>
-                    {/* Github Icon */}
-                    <div className="relative z-50">
-                        <a href="https://github.com/OpenAdaptAI/OpenAdapt" aria-label="Join us on Github" title="Join us on Github" className="text-ink hover:text-accent">
-                            <FontAwesomeIcon
-                                icon={faGithub}
-                                className="text-xl sm:text-2xl"
-                            />
-                        </a>
-                    </div>
-                    {/* Discord Icon */}
-                    <div className="relative z-50">
-                        <a href="https://discord.gg/yF527cQbDG" aria-label="Join us on Discord" title="Join us on Discord" className="text-ink hover:text-accent">
-                            <FontAwesomeIcon
-                                icon={faDiscord}
-                                className="text-xl sm:text-2xl"
-                            />
-                        </a>
-                    </div>
-                    {/* X Icon */}
-                    <div className="relative z-50">
-                        <a href="https://x.com/OpenAdaptAI" aria-label="Join us on X" title="Join us on X" className="text-ink hover:text-accent">
-                            <FontAwesomeIcon
-                                icon={faXTwitter}
-                                className="text-xl sm:text-2xl"
-                            />
-                        </a>
-                    </div>
-                    {/* LinkedIn Icon */}
-                    <div className="relative z-50">
-                        <a
-                            href="https://www.linkedin.com/company/95677624"
-                            aria-label="Join us on LinkedIn" title="Join us on LinkedIn"
-                            className="text-ink hover:text-accent"
-                        >
-                            <FontAwesomeIcon
-                                icon={faLinkedin}
-                                className="text-xl sm:text-2xl"
-                            />
-                        </a>
-                    </div>
-                    {/* Github Fork/Star buttons */}
-                    <div className="relative z-50">
-                        <a
-                            className="github-button mr-2"
-                            href="https://github.com/OpenAdaptAI/OpenAdapt/fork"
-                            data-color-scheme="no-preference: light; light: light; dark: light;"
-                            data-icon="octicon-repo-forked"
-                            data-size="large"
-                            data-show-count="true"
-                            aria-label="Fork OpenAdaptAI/OpenAdapt on GitHub"
-                        >
-                            Fork
-                        </a>
-                    </div>
-                    <div className="relative z-50">
-                        <a
-                            className="github-button"
-                            href="https://github.com/OpenAdaptAI/OpenAdapt"
-                            data-color-scheme="no-preference: light; light: light; dark: light;"
-                            data-icon="octicon-star"
-                            data-size="large"
-                            data-show-count="true"
-                            aria-label="Star OpenAdaptAI/OpenAdapt on GitHub"
-                        >
-                            Star
-                        </a>
                     </div>
                 </div>
             </div>

--- a/components/NavHeader.js
+++ b/components/NavHeader.js
@@ -1,0 +1,103 @@
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+
+import styles from './NavHeader.module.css'
+
+const NAV_LINKS = [
+    { label: 'Healthcare', href: '/solutions/healthcare' },
+    { label: 'Lending', href: '/solutions/lending' },
+    { label: 'Compare', href: '/compare' },
+    { label: 'About', href: '/about' },
+    {
+        label: 'Open source',
+        href: 'https://github.com/OpenAdaptAI/OpenAdapt',
+        external: true,
+    },
+]
+
+export default function NavHeader() {
+    const router = useRouter()
+    const [menuOpen, setMenuOpen] = useState(false)
+
+    // Close the mobile menu whenever the route changes.
+    useEffect(() => {
+        setMenuOpen(false)
+    }, [router.asPath])
+
+    return (
+        <header className={styles.header}>
+            <div className={styles.inner}>
+                <Link href="/" className={styles.wordmark}>
+                    <span className="font-extralight">Open</span>
+                    <span className="font-semibold">Adapt</span>
+                </Link>
+                <nav className={styles.links} aria-label="Primary">
+                    {NAV_LINKS.map((item) =>
+                        item.external ? (
+                            <a
+                                key={item.label}
+                                href={item.href}
+                                className={styles.link}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                {item.label}
+                            </a>
+                        ) : (
+                            <Link
+                                key={item.label}
+                                href={item.href}
+                                className={styles.link}
+                            >
+                                {item.label}
+                            </Link>
+                        )
+                    )}
+                </nav>
+                <button
+                    type="button"
+                    className={styles.menuButton}
+                    aria-expanded={menuOpen}
+                    aria-controls="nav-mobile-menu"
+                    aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+                    onClick={() => setMenuOpen((open) => !open)}
+                >
+                    {menuOpen ? 'CLOSE' : 'MENU'}
+                </button>
+                <Link href="/#book" className={styles.cta}>
+                    Book a demo
+                </Link>
+            </div>
+            {menuOpen && (
+                <nav
+                    id="nav-mobile-menu"
+                    className={styles.mobilePanel}
+                    aria-label="Primary mobile"
+                >
+                    {NAV_LINKS.map((item) =>
+                        item.external ? (
+                            <a
+                                key={item.label}
+                                href={item.href}
+                                className={styles.mobileLink}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                {item.label}
+                            </a>
+                        ) : (
+                            <Link
+                                key={item.label}
+                                href={item.href}
+                                className={styles.mobileLink}
+                            >
+                                {item.label}
+                            </Link>
+                        )
+                    )}
+                </nav>
+            )}
+        </header>
+    )
+}

--- a/components/NavHeader.module.css
+++ b/components/NavHeader.module.css
@@ -1,0 +1,127 @@
+.header {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background: var(--panel);
+    border-bottom: 1px solid var(--hairline);
+}
+
+.inner {
+    max-width: 72rem;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    height: 60px;
+    padding: 0 16px;
+}
+
+.wordmark {
+    font-family: var(--font-display);
+    font-size: 18px;
+    letter-spacing: -0.01em;
+    color: var(--ink);
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.wordmark:hover {
+    color: var(--ink);
+    text-decoration: none;
+}
+
+.links {
+    display: flex;
+    align-items: center;
+    gap: 22px;
+    margin-left: auto;
+}
+
+.link {
+    font-size: 13.5px;
+    color: var(--ink);
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.link:hover {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+.cta {
+    display: inline-block;
+    padding: 7px 16px;
+    border-radius: 9999px;
+    background: var(--ink);
+    color: var(--ground);
+    border: 1.5px solid var(--ink);
+    font-size: 13px;
+    font-weight: 500;
+    text-decoration: none;
+    white-space: nowrap;
+    transition: background-color 0.2s ease;
+}
+
+.cta:hover {
+    background: #3a4133;
+    border-color: #3a4133;
+    color: var(--ground);
+    text-decoration: none;
+}
+
+.menuButton {
+    display: none;
+    background: transparent;
+    border: 1px solid var(--hairline);
+    border-radius: 6px;
+    padding: 6px 10px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--ink);
+    line-height: 1;
+}
+
+.mobilePanel {
+    display: none;
+}
+
+@media (max-width: 767px) {
+    .links {
+        display: none;
+    }
+
+    .menuButton {
+        display: inline-block;
+        margin-left: auto;
+    }
+
+    .cta {
+        margin-left: 0;
+    }
+
+    .mobilePanel {
+        display: flex;
+        flex-direction: column;
+        background: var(--panel);
+        border-bottom: 1px solid var(--hairline);
+        padding: 6px 16px 12px;
+    }
+
+    .mobileLink {
+        font-size: 15px;
+        color: var(--ink);
+        text-decoration: none;
+        padding: 10px 0;
+        border-bottom: 1px dotted var(--hairline-dotted);
+    }
+
+    .mobileLink:last-child {
+        border-bottom: none;
+    }
+
+    .mobileLink:hover {
+        color: var(--accent);
+        text-decoration: none;
+    }
+}

--- a/components/ProofBand.js
+++ b/components/ProofBand.js
@@ -1,0 +1,50 @@
+import Link from 'next/link'
+
+import styles from './ProofBand.module.css'
+
+const BENCHMARK_URL =
+    'https://github.com/OpenAdaptAI/openadapt-flow/blob/main/benchmark/BENCHMARK.md'
+
+const stats = [
+    {
+        figure: '4.9s vs 37.5s',
+        caption: 'median run, compiled vs computer-use agent',
+    },
+    {
+        figure: '$0 vs $0.27',
+        caption: 'model cost per run',
+    },
+    {
+        figure: '100/100',
+        caption: 'compiled replays succeeded (agent: 20/20)',
+    },
+]
+
+export default function ProofBand() {
+    return (
+        <section className={styles.section}>
+            <div className={styles.inner}>
+                <p className="eyebrow">Measured 2026-07-08</p>
+                <div className={styles.grid}>
+                    {stats.map((stat) => (
+                        <div key={stat.figure} className={styles.card}>
+                            <div className={styles.figure}>{stat.figure}</div>
+                            <div className={styles.caption}>{stat.caption}</div>
+                        </div>
+                    ))}
+                </div>
+                <p className={styles.note}>Same task, same success check.</p>
+                <div className={styles.links}>
+                    <Link href="/compare">How we measured it →</Link>
+                    <a
+                        href={BENCHMARK_URL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Full methodology on GitHub
+                    </a>
+                </div>
+            </div>
+        </section>
+    )
+}

--- a/components/ProofBand.module.css
+++ b/components/ProofBand.module.css
@@ -1,0 +1,62 @@
+.section {
+    background: var(--ground);
+    border-bottom: 1px solid var(--hairline);
+    padding: 48px 16px;
+}
+
+.inner {
+    max-width: 64rem;
+    margin: 0 auto;
+    text-align: center;
+}
+
+.grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 14px;
+    margin-top: 20px;
+}
+
+@media (max-width: 767px) {
+    .grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+.card {
+    background: var(--panel);
+    border: 1px solid var(--hairline);
+    border-radius: 12px;
+    padding: 22px 18px;
+}
+
+.figure {
+    font-family: var(--font-display);
+    font-size: 26px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    color: var(--ink);
+    line-height: 1.2;
+}
+
+.caption {
+    margin-top: 8px;
+    font-size: 13px;
+    color: var(--ink-2);
+    line-height: 1.45;
+}
+
+.note {
+    margin-top: 18px;
+    font-size: 13.5px;
+    color: var(--ink-2);
+}
+
+.links {
+    margin-top: 6px;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 6px 20px;
+    font-size: 13.5px;
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -4,6 +4,8 @@ import '@fortawesome/fontawesome-svg-core/styles.css'
 import Head from 'next/head'
 import Script from 'next/script'
 
+import NavHeader from '@components/NavHeader'
+
 export default function MyApp({ Component, pageProps }) {
     return (
         <>
@@ -75,6 +77,7 @@ export default function MyApp({ Component, pageProps }) {
                     }}
                 />
             </Head>
+            <NavHeader />
             <main className="font-sans">
                 <Component {...pageProps} />
             </main>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,16 +1,15 @@
 import { useRef, useState } from 'react'
 import Head from 'next/head'
 
-import BenchmarkSection from '@components/BenchmarkSection'
 import ContactBookingSection from '@components/ContactBookingSection'
 import Developers from '@components/Developers'
-import DevToolsSection from '@components/DevToolsSection'
-import EcosystemSection from '@components/EcosystemSection'
+import EmailForm from '@components/EmailForm'
 import Faq, { faqItems } from '@components/Faq'
 import Footer from '@components/Footer'
 import HowItWorks from '@components/HowItWorks'
 import IndustriesGrid from '@components/IndustriesGrid'
 import MastHead from '@components/MastHead'
+import ProofBand from '@components/ProofBand'
 // import SocialSection from '@components/SocialSection' // Temporarily disabled - feeds not working
 
 const organizationSchema = {
@@ -150,6 +149,12 @@ export default function Home() {
             </Head>
             <MastHead />
             <HowItWorks />
+            <ProofBand />
+            <IndustriesGrid
+                feedbackData={feedbackData}
+                setFeedbackData={setFeedbackData}
+                sectionRef={sectionRef}
+            />
             <div style={{
                 background: 'var(--panel)',
                 textAlign: 'center',
@@ -169,17 +174,10 @@ export default function Home() {
                 </p>
             </div>
             <Developers />
-            <EcosystemSection />
-            <DevToolsSection />
-            <BenchmarkSection />
-            <IndustriesGrid
-                feedbackData={feedbackData}
-                setFeedbackData={setFeedbackData}
-                sectionRef={sectionRef}
-            />
             {/* <SocialSection /> */} {/* Temporarily disabled - feeds not working */}
             <Faq />
             <ContactBookingSection prefill={feedbackData} />
+            <EmailForm />
             <Footer />
         </div>
     )


### PR DESCRIPTION
## What changed

### Global nav (new)
- `components/NavHeader.js`: sticky ~60px header on every page (rendered from `_app.js`), panel background with hairline bottom border. Links: Healthcare, Lending, Compare, About, Open source (GitHub), plus a "Book a demo" ink pill. Under 768px the links collapse behind a MENU button (plain useState toggle, no new deps); the pill stays visible.
- Removed MastHead's fixed top-right icon strip. Footer already had Docs/Blog/GitHub/Discord/X/LinkedIn text links, so nothing was re-added there; the GitHub Star/Fork buttons moved into the Footer next to the Sponsor button.

### Buyer-first homepage order
Hero → How it works → proof band → Industries → status banner → Open source → FAQ → Booking → email form → Footer.

### Proof band (new)
`components/ProofBand.js`, three panel cards with the measured numbers from the 2026-07-08 benchmark run:
- 4.9s vs 37.5s — median run, compiled vs computer-use agent
- $0 vs $0.27 — model cost per run
- 100/100 — compiled replays succeeded (agent: 20/20)

Same task, same success check. Links to /compare and the [methodology](https://github.com/OpenAdaptAI/openadapt-flow/blob/main/benchmark/BENCHMARK.md).

### Open source consolidation
Developers + EcosystemSection + DevToolsSection + BenchmarkSection are now one "Open source" section (`components/Developers.js`): install/quickstart and PyPI chart kept, ecosystem/devtools folded into a compact link row. BenchmarkSection showed Windows Agent Arena agent-evaluation content that contradicts the compiled-replay positioning, so it's off the page (component file left in place). Legacy `#start` / `#developers` anchors still resolve; section id is `open-source`.

### MastHead
Thesis line ("Show it once. It runs forever. On your premises.") is now the H1; the brand wordmark is a decorated div since the nav carries the brand. EmailForm moved out of the hero to just above the Footer.

## Verification
- `npx next build` passes
- Playwright checks at 1440 and 375: zero horizontal overflow on home and /solutions/healthcare (including with mobile menu open)
- Anchors #book, #industries, #faq, #how-it-works, #open-source, #start, #developers all resolve
- Netlify form names untouched (`email` form unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)