### PR TITLE
feat: refresh landing copy — proof band, safety section, GitHub proof, pilot CTA

### DIFF
--- a/components/MastHead.js
+++ b/components/MastHead.js
@@ -50,7 +50,10 @@ const CarouselSection = () => {
     );
 };
 
-export default function Home() {
+const formatStars = (n) =>
+    n >= 1000 ? `${(n / 1000).toFixed(1).replace(/\.0$/, '')}k` : String(n)
+
+export default function Home({ githubStats }) {
     return (
         <div className={styles.section}>
             <div className="relative flex items-center justify-center">
@@ -61,10 +64,25 @@ export default function Home() {
                                 <span className="font-extralight">Open</span><span className="font-semibold">Adapt</span>
                                 <span className="font-extralight">.AI</span>
                             </div>
-                            <div className="mb-4">
+                            <div className="mb-4 flex flex-wrap items-center justify-center gap-3">
                                 <span className={styles.heroPill}>
                                     LOCAL-FIRST · MIT OPEN SOURCE
                                 </span>
+                                {githubStats && githubStats.stars > 0 && (
+                                    <a
+                                        href="https://github.com/OpenAdaptAI/OpenAdapt"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="inline-flex items-center gap-2 rounded-full px-3 py-1 text-sm text-ink-2 no-underline"
+                                        style={{ border: '1px solid var(--hairline)' }}
+                                    >
+                                        <span aria-hidden="true">★</span>
+                                        {formatStars(githubStats.stars)} on GitHub
+                                        <span className="text-ink-3">
+                                            · {githubStats.forks} forks
+                                        </span>
+                                    </a>
+                                )}
                             </div>
                             <h1 className="font-display text-2xl md:text-3xl mt-0 mb-4 font-semibold tracking-tight text-ink">
                                 Show it once. It runs forever. On your premises.

--- a/components/ProofBand.js
+++ b/components/ProofBand.js
@@ -3,20 +3,20 @@ import Link from 'next/link'
 import styles from './ProofBand.module.css'
 
 const BENCHMARK_URL =
-    'https://github.com/OpenAdaptAI/openadapt-flow/blob/main/benchmark/BENCHMARK.md'
+    'https://github.com/OpenAdaptAI/openadapt-flow/blob/main/benchmark/openemr/BENCHMARK.md'
 
 const stats = [
     {
-        figure: '4.9s vs 37.5s',
-        caption: 'median run, compiled vs computer-use agent',
+        figure: '39s vs 70s',
+        caption: 'median run, compiled replay vs computer-use agent',
     },
     {
-        figure: '$0 vs $0.27',
+        figure: '$0 vs $0.55',
         caption: 'model cost per run',
     },
     {
-        figure: '100/100',
-        caption: 'compiled replays succeeded (agent: 20/20)',
+        figure: '0 vs ~24',
+        caption: 'model calls per run — the replay is deterministic',
     },
 ]
 
@@ -24,7 +24,7 @@ export default function ProofBand() {
     return (
         <section className={styles.section}>
             <div className={styles.inner}>
-                <p className="eyebrow">Measured 2026-07-08</p>
+                <p className="eyebrow">Real EMR · measured 2026-07-08</p>
                 <div className={styles.grid}>
                     {stats.map((stat) => (
                         <div key={stat.figure} className={styles.card}>
@@ -33,7 +33,11 @@ export default function ProofBand() {
                         </div>
                     ))}
                 </div>
-                <p className={styles.note}>Same task, same success check.</p>
+                <p className={styles.note}>
+                    Same 18-step task on the live OpenEMR demo, one success
+                    check for both. Both finished every run; the difference is
+                    what each run costs you.
+                </p>
                 <div className={styles.links}>
                     <Link href="/compare">How we measured it →</Link>
                     <a

--- a/components/SafetyBand.js
+++ b/components/SafetyBand.js
@@ -1,0 +1,49 @@
+import Link from 'next/link'
+
+const LIMITS_URL =
+    'https://github.com/OpenAdaptAI/openadapt-flow/blob/main/docs/LIMITS.md'
+const VALIDATION_URL =
+    'https://github.com/OpenAdaptAI/openadapt-flow/blob/main/docs/validation/VALIDATION.md'
+
+export default function SafetyBand() {
+    return (
+        <section
+            style={{
+                background: 'var(--panel)',
+                borderTop: '1px solid var(--hairline)',
+                borderBottom: '1px solid var(--hairline)',
+            }}
+        >
+            <div className="mx-auto max-w-3xl px-6 py-12 text-center">
+                <p className="eyebrow mb-2">Safety</p>
+                <h2 className="font-display text-2xl md:text-3xl font-semibold tracking-tight text-ink mb-4">
+                    It halts instead of guessing.
+                </h2>
+                <p className="mx-auto max-w-2xl text-base md:text-lg text-ink-2">
+                    When the UI drifts and a step gets ambiguous, OpenAdapt
+                    stops and flags a person rather than writing to the wrong
+                    record. We built an adversarial test suite to measure how
+                    often it could still pick the wrong target, put our own
+                    engine through five rounds of it, and publish every
+                    result — including what it gets wrong today.
+                </p>
+                <div className="mt-6 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm">
+                    <a
+                        href={LIMITS_URL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Read what it doesn&apos;t do yet →
+                    </a>
+                    <a
+                        href={VALIDATION_URL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        See how we test it →
+                    </a>
+                </div>
+            </div>
+        </section>
+    )
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -10,6 +10,7 @@ import HowItWorks from '@components/HowItWorks'
 import IndustriesGrid from '@components/IndustriesGrid'
 import MastHead from '@components/MastHead'
 import ProofBand from '@components/ProofBand'
+import SafetyBand from '@components/SafetyBand'
 // import SocialSection from '@components/SocialSection' // Temporarily disabled - feeds not working
 
 const organizationSchema = {
@@ -110,7 +111,32 @@ const faqSchema = {
     })),
 }
 
-export default function Home() {
+export async function getStaticProps() {
+    // Fetch real GitHub social proof at build time so the number is accurate
+    // on each deploy without a client-side request. Falls back to a known-good
+    // floor if the build host has no network.
+    let githubStats = { stars: 1636, forks: 257 }
+    try {
+        const res = await fetch(
+            'https://api.github.com/repos/OpenAdaptAI/OpenAdapt',
+            { headers: { Accept: 'application/vnd.github+json' } }
+        )
+        if (res.ok) {
+            const data = await res.json()
+            if (typeof data.stargazers_count === 'number') {
+                githubStats = {
+                    stars: data.stargazers_count,
+                    forks: data.forks_count,
+                }
+            }
+        }
+    } catch (err) {
+        // keep the fallback floor
+    }
+    return { props: { githubStats }, revalidate: 86400 }
+}
+
+export default function Home({ githubStats }) {
     const [feedbackData, setFeedbackData] = useState({
         email: '',
         message: '',
@@ -147,9 +173,10 @@ export default function Home() {
                     }}
                 />
             </Head>
-            <MastHead />
+            <MastHead githubStats={githubStats} />
             <HowItWorks />
             <ProofBand />
+            <SafetyBand />
             <IndustriesGrid
                 feedbackData={feedbackData}
                 setFeedbackData={setFeedbackData}
@@ -158,20 +185,42 @@ export default function Home() {
             <div style={{
                 background: 'var(--panel)',
                 textAlign: 'center',
-                padding: '10px 16px',
+                padding: '28px 16px',
                 borderTop: '1px solid var(--hairline)',
                 borderBottom: '1px solid var(--hairline)',
             }}>
                 <p style={{
-                    color: 'var(--ink-3)',
-                    fontSize: '13px',
-                    margin: 0,
-                    letterSpacing: '0.02em',
+                    color: 'var(--ink)',
+                    fontSize: '17px',
+                    fontWeight: 600,
+                    margin: '0 auto 6px',
+                    maxWidth: '640px',
                 }}>
-                    OpenAdapt v1 is open source and under active development.
-                    Commercial <a href="#book" style={{ color: 'var(--accent)' }}>pilots</a> for healthcare and
-                    lending are open.
+                    Running the same workflow hundreds of times on software you
+                    can&apos;t API into?
                 </p>
+                <p style={{
+                    color: 'var(--ink-2)',
+                    fontSize: '14px',
+                    margin: '0 auto 14px',
+                    maxWidth: '560px',
+                }}>
+                    We&apos;re taking a small number of healthcare and lending
+                    pilots. OpenAdapt v1 is open source and under active
+                    development.
+                </p>
+                <a href="#book" style={{
+                    display: 'inline-block',
+                    background: 'var(--accent)',
+                    color: 'var(--on-accent, #fff)',
+                    fontSize: '15px',
+                    fontWeight: 600,
+                    padding: '10px 22px',
+                    borderRadius: '8px',
+                    textDecoration: 'none',
+                }}>
+                    Book a pilot →
+                </a>
             </div>
             <Developers />
             {/* <SocialSection /> */} {/* Temporarily disabled - feeds not working */}


### PR DESCRIPTION
Implements the landing-page copy review. Draft for visual review (Vercel preview).

## Changes

**Proof band** — the `100/100 compiled (agent: 20/20)` stat was the weakest of the three: both arms hit 100%, so it read as a wash and even invited "if the agent also nails it, why do I need you?" Replaced with the real differentiator and moved to the real-EMR (OpenEMR) numbers for credibility:
- `39s vs 70s` median run · `$0 vs $0.55` per run · **`0 vs ~24` model calls per run — the replay is deterministic**
- The note now turns "both finished every run" into the cost argument instead of dropping it.

**Safety section (new)** — the differentiated story ("it halts instead of guessing; we measure the wrong-action rate and publish it") was absent from the page. Added as a band with links to `LIMITS.md` and `VALIDATION.md`. Copy is deliberately non-overclaiming: fail-closed + measured, never "never wrong."

**GitHub social proof** — a stars/forks chip in the hero, fetched at build via `getStaticProps` from the main OpenAdapt repo (1.6k ★ / 257 forks) with a fallback floor so it never goes stale-empty. Subtle, beside the pill.

**Pilot CTA** — the thin gray strip becomes a real CTA, headlined by the qualifying question and a Book-a-pilot button.

## Not done (deliberately)
- Did **not** add a record→compile→replay quickstart: the Developers section already has a working `uv tool install openadapt` quickstart, and I won't put unverified CLI commands on the live site.
- Left the hero carousel as-is (low-priority, subjective).

## Verify
`npm run build` passes; `/` builds as SSG/ISR (24h revalidate) with the GitHub fetch at build time.