### PR TITLE
fix: tighten website copy per the human-writing guide (de-AI-tell, fewer em-dashes, contractions)

### DIFF
--- a/components/ContactBookingSection.js
+++ b/components/ContactBookingSection.js
@@ -92,8 +92,8 @@ export default function ContactBookingSection({
                     Book a 15-minute automation fit call
                 </h2>
                 <p className="mt-3 text-sm text-ink-2 md:text-base">
-                    Tell us your highest-friction workflow and we will map what
-                    can be automated first.
+                    Tell us your highest-friction workflow and we&apos;ll map
+                    what can be automated first.
                 </p>
 
                 {!isSubmitted ? (

--- a/components/Developers.js
+++ b/components/Developers.js
@@ -77,7 +77,7 @@ export default function Developers() {
                     )}
                     <p className="mt-2 mb-6 mx-auto text-center max-w-2xl text-sm text-ink-2">
                         OpenAdapt is an open-source demonstration compiler for desktop automation.
-                        Record a workflow once and it compiles into a deterministic, self-healing automation that runs on your own machines.
+                        Record a workflow once and it compiles into a self-healing automation that runs on your own machines with no per-run model calls.
                     </p>
 
                     {/* uv-first Installation Section */}

--- a/components/Faq.js
+++ b/components/Faq.js
@@ -1,19 +1,19 @@
 export const faqItems = [
     {
         question: 'What is OpenAdapt?',
-        answer: 'OpenAdapt is an open-source demonstration compiler for desktop automation. You record yourself doing a task once, and OpenAdapt compiles that recording into a deterministic, self-healing script that runs on your own machines. Healthy runs make no cloud model calls, so each run costs nothing.',
+        answer: 'OpenAdapt is an open-source demonstration compiler for desktop automation. You record yourself doing a task once, and OpenAdapt compiles that recording into a self-healing script that runs on your own machines. Healthy runs make no cloud model calls, so each run costs nothing.',
     },
     {
         question: 'How is OpenAdapt different from RPA tools like UiPath?',
-        answer: 'Traditional RPA makes you hand-author brittle selectors and flowcharts, and the bot breaks when the UI changes. OpenAdapt compiles the automation from a demonstration instead — no selector authoring — and when the UI drifts it heals itself, proposing the fix as a reviewable diff. It also runs entirely on your machines.',
+        answer: 'Traditional RPA makes you hand-author brittle selectors and flowcharts, and the bot breaks when the UI changes. OpenAdapt compiles the automation from a demonstration instead, with no selector authoring, and when the UI drifts it heals itself and proposes the fix as a reviewable diff. It also runs entirely on your machines.',
     },
     {
         question: 'How is OpenAdapt different from AI computer-use agents?',
-        answer: "Computer-use agents re-reason through your task with a large model on every run, so they are slow, non-deterministic, and bill you per run. OpenAdapt compiles the task once and replays it deterministically for free. A model is only invoked to heal the script when the UI drifts.",
+        answer: "Computer-use agents re-reason through your task with a large model on every run, so they're slow, non-deterministic, and bill you per run. OpenAdapt compiles the task once and replays it locally for free, with no per-run model calls. A model is only invoked to heal the script when the UI drifts.",
     },
     {
         question: 'Does my data leave my machines?',
-        answer: 'No. OpenAdapt is local-first by architecture: recordings, compiled scripts, and replays all stay on your own infrastructure. Nothing is uploaded to run an automation. PII/PHI scrubbing tooling is included for teams that need to sanitize captured data before anyone — human or model — sees it.',
+        answer: 'No. OpenAdapt is local-first by architecture: recordings, compiled scripts, and replays all stay on your own infrastructure. Nothing is uploaded to run an automation. PII/PHI scrubbing tooling is included for teams that need to sanitize captured data before anyone (human or model) sees it.',
     },
     {
         question: 'Is OpenAdapt free?',

--- a/components/HowItWorks.js
+++ b/components/HowItWorks.js
@@ -17,7 +17,7 @@ const steps = [
         number: '3.0',
         name: 'Run',
         description:
-            'Deterministic replay in milliseconds, locally, no per-run model calls.',
+            'Compiled replay in milliseconds, locally, with no per-run model calls.',
     },
     {
         number: '4.0',
@@ -40,7 +40,7 @@ export default function HowItWorks() {
                 <p className={styles.eyebrow}>Process</p>
                 <h2 className={styles.heading}>How it works</h2>
                 <p className={styles.subheading}>
-                    A demonstration compiler: one recording in, a deterministic
+                    A demonstration compiler: one recording in, a runnable
                     automation out.
                 </p>
                 <ol className={styles.steps}>

--- a/components/IndustriesGrid.js
+++ b/components/IndustriesGrid.js
@@ -34,7 +34,7 @@ export default function IndustriesGrid({
             title: 'Healthcare clinics',
             href: '/solutions/healthcare',
             descriptions:
-                'Referral and fax intake, EMR data entry and extraction — desktop and VDI EMRs included. PHI handling stays fully local.',
+                'Referral and fax intake, EMR data entry and extraction, desktop and VDI EMRs included. PHI handling stays fully local.',
             logo: '/images/noun-healthcare.svg',
         },
         {
@@ -48,7 +48,7 @@ export default function IndustriesGrid({
             title: 'Other regulated back-offices',
             href: '#book',
             descriptions:
-                'Document-heavy, compliance-bound workflows — tell us yours.',
+                'Document-heavy, compliance-bound workflows. Tell us yours.',
             logo: '/images/noun-law.svg',
         },
     ]
@@ -93,7 +93,7 @@ export default function IndustriesGrid({
                 </h2>
                 <p className={styles.p}>
                     Record the workflow once and OpenAdapt compiles it into an
-                    automation your team can review, run, and audit — entirely
+                    automation your team can review, run, and audit, entirely
                     on your own machines. No brittle selectors to hand-author.
                     No per-run model costs.
                     <br />

--- a/components/InstallSection.js
+++ b/components/InstallSection.js
@@ -92,7 +92,7 @@ export default function InstallSection() {
         <div className={styles.installSection}>
             <div className={styles.header}>
                 <FontAwesomeIcon icon={faTerminal} className={styles.terminalIcon} />
-                <h3 className={styles.title}>Install in 30 Seconds</h3>
+                <h3 className={styles.title}>Install in 30 seconds</h3>
             </div>
 
             <p className={styles.subtitle}>
@@ -170,7 +170,7 @@ export default function InstallSection() {
                 </h4>
                 <p className={styles.note} style={{ marginBottom: '0.75rem' }}>
                     Try record → compile → replay → heal right now against the
-                    bundled demo app — no account, no cloud, nothing leaves
+                    bundled demo app. No account, no cloud, nothing leaves
                     your machine.
                 </p>
                 <div className={styles.commandGrid}>
@@ -194,7 +194,7 @@ export default function InstallSection() {
                     </div>
                     <div className={styles.commandItem}>
                         <code>openadapt-flow replay bundle</code>
-                        <span>Replay: deterministic, local, zero model calls</span>
+                        <span>Replay: local, with zero model calls</span>
                     </div>
                     <div className={styles.commandItem}>
                         <code>openadapt-flow replay bundle --drift theme</code>

--- a/components/MastHead.js
+++ b/components/MastHead.js
@@ -10,7 +10,7 @@ const CarouselSection = () => {
     const [currentIndex, setCurrentIndex] = useState(0);
     const carouselItems = [
         "Show it once. It runs forever. On your premises.",
-        "Deterministic replay. Zero per-run model cost.",
+        "Compiled replay. Zero per-run model cost.",
         "Self-healing: UI drift becomes a reviewable diff.",
         "Your data never leaves the building.",
     ];
@@ -89,9 +89,9 @@ export default function Home({ githubStats }) {
                             </h1>
                             <p className="mt-0 mb-6 mx-auto max-w-3xl font-sans font-normal text-base md:text-lg text-ink-2">
                                 OpenAdapt compiles a recorded demonstration into
-                                a deterministic, self-healing automation — open
-                                source, auditable, and running entirely on your
-                                own machines.
+                                a self-healing automation. It&apos;s open source
+                                and auditable, and it runs entirely on your own
+                                machines.
                             </p>
                             <div className="flex flex-col align-center justify-center px-4 min-w-0 max-w-full overflow-hidden">
                                 <ReplayHero />

--- a/components/ProofBand.js
+++ b/components/ProofBand.js
@@ -16,7 +16,7 @@ const stats = [
     },
     {
         figure: '0 vs ~24',
-        caption: 'model calls per run — the replay is deterministic',
+        caption: 'model calls per run: the hot path is model-free',
     },
 ]
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -15,7 +15,7 @@ export default function MyApp({ Component, pageProps }) {
                 <title>OpenAdapt — Record once. Compiled, self-healing desktop automation that runs on your premises.</title>
                 <meta
                     name="description"
-                    content="OpenAdapt compiles a recorded demonstration into a deterministic, self-healing automation. Healthy runs make no cloud model calls; your data never leaves your machines. Open source, MIT licensed."
+                    content="OpenAdapt compiles a recorded demonstration into a self-healing automation that replays on your own machines. Healthy runs make no cloud model calls; your data never leaves your machines. Open source, MIT licensed."
                 />
                 <link
                     rel="apple-touch-icon"
@@ -47,7 +47,7 @@ export default function MyApp({ Component, pageProps }) {
                 <meta property="og:type" content="website" />
                 <meta property="og:site_name" content="OpenAdapt.AI" />
                 <meta property="og:title" content="OpenAdapt — Show it once. It runs forever. On your premises." />
-                <meta property="og:description" content="OpenAdapt compiles a recorded demonstration into a deterministic, self-healing automation that runs on your own machines. Open source, MIT licensed." />
+                <meta property="og:description" content="OpenAdapt compiles a recorded demonstration into a self-healing automation that runs on your own machines. Open source, MIT licensed." />
                 <meta property="og:image" content="https://openadapt.ai/og.png" />
                 <meta property="og:image:type" content="image/png" />
                 <meta property="og:image:width" content="1024" />
@@ -58,7 +58,7 @@ export default function MyApp({ Component, pageProps }) {
                 <meta name="twitter:card" content="summary_large_image" />
                 <meta name="twitter:site" content="@OpenAdaptAI" />
                 <meta name="twitter:title" content="OpenAdapt — Show it once. It runs forever. On your premises." />
-                <meta name="twitter:description" content="Record a workflow once. OpenAdapt compiles it into a deterministic, self-healing automation that runs on your own machines. MIT licensed." />
+                <meta name="twitter:description" content="Record a workflow once. OpenAdapt compiles it into a self-healing automation that runs on your own machines. MIT licensed." />
                 <meta name="twitter:image" content="https://openadapt.ai/og.png" />
 
                 {/* Google tag (gtag.js) */}

--- a/pages/about.js
+++ b/pages/about.js
@@ -16,7 +16,7 @@ const organizationSchema = {
         height: 512,
     },
     description:
-        'MLDSAI Inc. builds OpenAdapt, an open-source demonstration compiler for desktop automation: record a workflow once and it compiles into a deterministic, self-healing script that runs on your own machines.',
+        'MLDSAI Inc. builds OpenAdapt, an open-source demonstration compiler for desktop automation: record a workflow once and it compiles into a self-healing script that runs on your own machines with no per-run model calls.',
     foundingDate: '2023',
     address: {
         '@type': 'PostalAddress',
@@ -92,8 +92,8 @@ export default function AboutPage() {
                 <p className="mt-5 max-w-3xl text-base text-ink-2 md:text-lg">
                     OpenAdapt is an open-source demonstration compiler for
                     desktop automation. You record yourself doing a task once,
-                    and it compiles that recording into a deterministic script
-                    that replays on your own machines. Healthy runs make no
+                    and it compiles that recording into a script that replays
+                    on your own machines. Healthy runs make no
                     cloud model calls; a model is only invoked to heal the
                     script when the UI drifts, and the fix is proposed as a
                     reviewable diff. That&#39;s the whole idea, and everything

--- a/pages/compare.js
+++ b/pages/compare.js
@@ -9,7 +9,7 @@ const webPageSchema = {
     name: 'How OpenAdapt compares',
     url: 'https://openadapt.ai/compare',
     description:
-        'We built a harness that measures how often self-healing GUI automation tools silently write to the wrong record under UI drift, red-teamed our own engine seven times, then ran the same instrument across the category. How OpenAdapt compares to RPA, AI computer-use agents, and browser recorders on safety first, then cost and coverage.',
+        'We built the tooling that measures how often self-healing GUI automation tools silently write to the wrong record under UI drift, red-teamed our own engine seven times, then ran the same test across the category. How OpenAdapt compares to RPA, AI computer-use agents, and browser recorders on safety first, then cost and coverage.',
     isPartOf: {
         '@type': 'WebSite',
         name: 'OpenAdapt.AI',
@@ -33,7 +33,7 @@ const rows = [
     },
     {
         dimension: 'Cost per run',
-        openadapt: 'None on healthy runs (deterministic local replay)',
+        openadapt: 'None on healthy runs (model-free on the hot path)',
         rpa: 'Licensed per robot or per seat',
         agents: 'Metered model calls on every run',
         browser: 'Varies; cloud inference is metered',
@@ -75,13 +75,13 @@ export default function ComparePage() {
                 <title>How OpenAdapt compares to RPA, AI agents, and browser recorders | OpenAdapt</title>
                 <meta
                     name="description"
-                    content="We built the harness that measures how often self-healing GUI automation tools silently write wrong state under UI drift — pointed at our own engine first, then the category. See how OpenAdapt compares to RPA, computer-use agents, and browser recorders — on measured silent wrong-action rate first, then cost, coverage, and where your data goes."
+                    content="We built the tooling that measures how often self-healing GUI automation tools silently write wrong state under UI drift, and pointed it at our own engine first, then the category. See how OpenAdapt compares to RPA, computer-use agents, and browser recorders on measured silent wrong-action rate first, then cost, coverage, and where your data goes."
                 />
                 <link rel="canonical" href="https://openadapt.ai/compare" />
                 <meta property="og:title" content="How OpenAdapt compares | OpenAdapt" />
                 <meta
                     property="og:description"
-                    content="Self-healing GUI bots can silently write to the wrong record under UI drift. We measured it on our own engine — five adversarial rounds — and compare on safety first, then cost and coverage."
+                    content="Self-healing GUI bots can silently write to the wrong record under UI drift. We measured it on our own engine across seven adversarial rounds, and compare on safety first, then cost and coverage."
                 />
                 <meta property="og:url" content="https://openadapt.ai/compare" />
                 <script
@@ -102,29 +102,28 @@ export default function ComparePage() {
                 <p className="mt-5 max-w-3xl text-base text-ink-2 md:text-lg">
                     Start with the failure mode nobody in this category
                     publishes a number for. Every self-healing replay tool
-                    &mdash; record a workflow, replay it, let it repair itself
-                    when the UI moves &mdash; can resolve the wrong on-screen
-                    target under data drift, act on it, and report success. In
-                    an EMR that is a note saved to the wrong patient&#39;s
-                    chart, with a green checkmark. The tools verify that{' '}
-                    <em>something</em> saved; almost none verify <em>whose</em>{' '}
-                    record it landed in. So we built the harness that measures
-                    it, and red-teamed our own engine seven times &mdash; the
-                    last two surfacing a limit of OCR itself, not a bug we could
-                    patch. That measurement &mdash; not speed &mdash; is how
-                    we think this comparison should be led.
+                    (record a workflow, replay it, let it repair itself when the
+                    UI moves) can resolve the wrong on-screen target under data
+                    drift, act on it, and report success. In an EMR that&#39;s a
+                    note saved to the wrong patient&#39;s chart, with a green
+                    checkmark. The tools verify that <em>something</em> saved;
+                    almost none verify <em>whose</em> record it landed in. So we
+                    built the tooling that measures it, and red-teamed our own
+                    engine seven times. The last two rounds surfaced a limit of
+                    OCR itself, not a bug we could patch. That measurement, not
+                    speed, is how we think this comparison should be led.
                 </p>
                 <p className="mt-4 max-w-3xl text-base text-ink-2 md:text-lg">
                     There are three common ways to automate desktop work today:
                     traditional RPA platforms, AI agents that operate a
                     computer with a large model, and browser recording tools.
                     OpenAdapt takes a fourth approach. It compiles a recorded
-                    demonstration into a deterministic script that replays for
-                    free, heals itself when the UI drifts, and{' '}
-                    <strong>halts instead of guessing</strong> when it cannot
+                    demonstration into a script that replays for free, heals
+                    itself when the UI drifts, and{' '}
+                    <strong>halts instead of guessing</strong> when it can&#39;t
                     verify the target&#39;s identity. Each approach wins
-                    somewhere, so here&#39;s the honest version &mdash; safety
-                    first, then cost and coverage.
+                    somewhere, so here&#39;s the honest version: safety first,
+                    then cost and coverage.
                 </p>
 
                 <div className="mt-10 rounded-2xl border-2 border-ink bg-panel p-6 md:p-8">
@@ -135,7 +134,7 @@ export default function ComparePage() {
                     <p className="mt-3 text-sm leading-relaxed text-ink-2 md:text-base">
                         The single most dangerous thing a GUI replayer can do
                         is the wrong write, silently. So we tried to make ours
-                        do exactly that. It reopened seven times &mdash;
+                        do exactly that. It reopened seven times:
                         pixel-lookalike rows, residue-blind coverage,
                         near-name siblings (&ldquo;Belford, Phil&rdquo; vs
                         &ldquo;Belford, Philip&rdquo;), a blind spot shared by
@@ -151,10 +150,10 @@ export default function ComparePage() {
                         the same glyph before any check runs, so at the text
                         layer a wrong-patient match on an identifier alone
                         can&#39;t be caught at all. That&#39;s a limit of the
-                        substrate, not a bug to patch &mdash; which is why we
-                        verify identity on the fields OCR reads reliably (the
-                        patient&#39;s name and date of birth) and halt when
-                        identity would rest on a look-alike identifier alone.
+                        substrate, not a bug to patch. So we verify identity on
+                        the fields OCR reads reliably (the patient&#39;s name and
+                        date of birth), and halt when identity would rest on a
+                        look-alike identifier alone.
                     </p>
                     <div className="mt-5 grid gap-6 sm:grid-cols-2">
                         <div>
@@ -163,8 +162,8 @@ export default function ComparePage() {
                             </p>
                             <p className="mt-1 text-sm text-ink-2">
                                 identity is verified on the signal OCR reads
-                                reliably &mdash; names and dates carry redundancy
-                                a single mis-read character doesn&#39;t collapse
+                                reliably: names and dates carry redundancy a
+                                single mis-read character doesn&#39;t collapse
                             </p>
                         </div>
                         <div>
@@ -174,8 +173,8 @@ export default function ComparePage() {
                             <p className="mt-1 text-sm text-ink-2">
                                 when two records differ only by a look-alike
                                 identifier OCR can&#39;t tell apart, it stops and
-                                writes nothing &mdash; a substrate limit we
-                                disclose and are closing
+                                writes nothing, a substrate limit we disclose
+                                and are closing
                             </p>
                         </div>
                     </div>
@@ -183,23 +182,23 @@ export default function ComparePage() {
                         The honest exception, published against ourselves: on a
                         stable browser DOM, an identity-keyed selector matches
                         our safety (0 wrong-actions) and beats us on
-                        availability &mdash; while a positional selector wrote
+                        availability. A positional selector, by contrast, wrote
                         the wrong patient 8/8. The wrong-action vector is spec
                         underspecification, and a demonstration captures target
                         identity for free. That comparison exists only where a
-                        DOM does; on desktop, VDI, or Citrix there is no
+                        DOM does; on desktop, VDI, or Citrix there&#39;s no
                         selector to write.
                     </p>
                     <p className="mt-4 text-xs leading-relaxed text-ink-3">
-                        &ldquo;Provably zero&rdquo; is an asymptote &mdash; each
-                        of those seven rounds began from a system we believed was
-                        correct. The product is not &ldquo;we don&#39;t make
-                        mistakes&rdquo;; it is measured, disclosed, and
+                        &ldquo;Provably zero&rdquo; is an asymptote. Each of
+                        those seven rounds began from a system we believed was
+                        correct. The product isn&#39;t &ldquo;we don&#39;t make
+                        mistakes&rdquo;; it&#39;s measured, disclosed, and
                         fail-closed, with the adversary log public. The open
-                        problems that remain &mdash; cosmetic zoom/display-scale
-                        drift is 0% replayability today, icon-only targets
-                        proceed flagged rather than verified, small sample sizes
-                        on the agent arms &mdash; are written down, not hidden.
+                        problems that remain are written down, not hidden:
+                        cosmetic zoom/display-scale drift is 0% replayability
+                        today, icon-only targets proceed flagged rather than
+                        verified, and the agent arms run on small sample sizes.
                     </p>
                     <div className="mt-4 flex flex-wrap gap-x-6 gap-y-1">
                         <a
@@ -255,9 +254,9 @@ export default function ComparePage() {
                 </p>
                 <p className="mt-3 text-sm leading-relaxed text-ink-2 md:text-base">
                     OpenAdapt uses a model at compile time and at heal time,
-                    never on a healthy run. A healthy run is a deterministic
-                    local replay: same steps, same order, no model calls, no
-                    per-run bill. Your screen stays on your machines.
+                    never on a healthy run. A healthy run is a compiled local
+                    replay: same steps, same order, no model calls, no per-run
+                    bill. Your screen stays on your machines.
                 </p>
 
                 <div className="mt-6 rounded-2xl border border-hairline bg-panel p-6 md:p-8">
@@ -272,8 +271,8 @@ export default function ComparePage() {
                         judged by one arm-independent OCR check, with a distinct
                         parameterized note per run. Both arms succeeded every
                         time: 20/20 compiled, 10/10 for a Claude computer-use
-                        agent. The agent doesn&#39;t fail here &mdash; the
-                        difference is what each run costs.
+                        agent. The agent doesn&#39;t fail here. The difference
+                        is what each run costs.
                     </p>
                     <div className="mt-5 grid gap-6 sm:grid-cols-3">
                         <div>
@@ -345,17 +344,16 @@ export default function ComparePage() {
                         as the benchmark anyone can rerun deterministically:
                         100 compiled replays against 20 agent runs, both arms
                         100%, 4.9s vs 37.5s median, $0 vs $0.27 per run at
-                        list price. Same orchestrator, same agent harness,
+                        list price. Same orchestrator, same agent setup,
                         same style of OCR check.
                     </p>
                     <p className="mt-3 text-sm leading-relaxed text-ink-2 md:text-base">
-                        On the same harness under injected UI drift, a hybrid
-                        mode &mdash; compiled replay first, agent fallback
-                        only on a detected halt &mdash; matched agent
-                        reliability (20/20) at roughly one-eighth the
-                        agent&#39;s cost per successful run. Details and
-                        caveats (synthetic detected-halt drift, assumed drift
-                        mix) in the repo.
+                        On the same setup under injected UI drift, a hybrid
+                        mode (compiled replay first, agent fallback only on a
+                        detected halt) matched agent reliability (20/20) at
+                        roughly one-eighth the agent&#39;s cost per successful
+                        run. Details and caveats (synthetic detected-halt
+                        drift, assumed drift mix) in the repo.
                     </p>
                     <div className="mt-3 flex flex-wrap gap-x-6 gap-y-1">
                         <a
@@ -455,7 +453,7 @@ export default function ComparePage() {
                         exploratory work like researching something across a
                         dozen unfamiliar sites. OpenAdapt is built for the
                         opposite case: work your team does the same way, over
-                        and over, where determinism and cost matter more than
+                        and over, where repeatability and cost matter more than
                         improvisation.
                     </p>
                 </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -26,7 +26,7 @@ const organizationSchema = {
         height: 512,
     },
     description:
-        'Open-source demonstration compiler for desktop automation. Record a workflow once and OpenAdapt compiles it into a deterministic, self-healing automation that runs entirely on your own machines.',
+        'Open-source demonstration compiler for desktop automation. Record a workflow once and OpenAdapt compiles it into a self-healing automation that runs entirely on your own machines with no per-run model calls.',
     foundingDate: '2023',
     sameAs: [
         'https://github.com/OpenAdaptAI/OpenAdapt',
@@ -54,7 +54,7 @@ const softwareSchema = {
     applicationCategory: 'DeveloperApplication',
     operatingSystem: 'Windows, macOS, Linux',
     description:
-        'Open-source demonstration compiler for desktop automation. Record a workflow once and OpenAdapt compiles it into a deterministic, self-healing script that replays locally with no per-run model calls. A model is only used to heal the script when the UI drifts, and the fix is proposed as a reviewable diff.',
+        'Open-source demonstration compiler for desktop automation. Record a workflow once and OpenAdapt compiles it into a self-healing script that replays locally with no per-run model calls. A model is only used to heal the script when the UI drifts, and the fix is proposed as a reviewable diff.',
     url: 'https://openadapt.ai',
     downloadUrl: 'https://pypi.org/project/openadapt/',
     author: {
@@ -72,8 +72,8 @@ const softwareSchema = {
     },
     featureList: [
         'Record a desktop workflow once as a demonstration',
-        'Compile demonstrations into deterministic, editable automation scripts',
-        'Deterministic local replay with zero per-run model cost',
+        'Compile demonstrations into editable automation scripts',
+        'Local replay with zero per-run model cost',
         'Self-healing: UI drift is repaired via a fallback ladder and proposed as a reviewable diff',
         'Local-first: recordings, scripts, and replays stay on your infrastructure',
         'PII/PHI data scrubbing for sensitive workflows',
@@ -89,7 +89,7 @@ const websiteSchema = {
     alternateName: 'OpenAdapt',
     url: 'https://openadapt.ai',
     description:
-        'Open-source demonstration compiler: record a desktop workflow once and it compiles into a deterministic, self-healing automation that runs on your premises.',
+        'Open-source demonstration compiler: record a desktop workflow once and it compiles into a self-healing automation that runs on your premises with no per-run model calls.',
     publisher: {
         '@type': 'Organization',
         name: 'OpenAdapt.AI',

--- a/pages/solutions/healthcare.js
+++ b/pages/solutions/healthcare.js
@@ -28,12 +28,12 @@ export default function HealthcarePage() {
                     EMR. OpenAdapt does the retyping.
                 </h1>
                 <p className="mt-5 max-w-3xl text-base text-ink-2 md:text-lg">
-                    Record the intake workflow once — open the referral, read
-                    the fields, enter them into the EMR — and OpenAdapt
-                    compiles it into a deterministic automation your clinic
-                    runs on its own machines. Healthy runs make no cloud model
-                    calls, and when the EMR&#39;s screens change, the fix
-                    arrives as a reviewable diff, not a support ticket.
+                    Record the intake workflow once (open the referral, read
+                    the fields, enter them into the EMR) and OpenAdapt
+                    compiles it into an automation your clinic runs on its own
+                    machines. Healthy runs make no cloud model calls, and when
+                    the EMR&#39;s screens change, the fix arrives as a
+                    reviewable diff, not a support ticket.
                 </p>
                 <div className="mt-7 flex flex-wrap gap-3">
                     <Link

--- a/pages/solutions/lending.js
+++ b/pages/solutions/lending.js
@@ -29,12 +29,12 @@ export default function LendingPage() {
                     once.
                 </h1>
                 <p className="mt-5 max-w-3xl text-base text-ink-2 md:text-lg">
-                    Record one pass of the task — open the loan documents,
-                    find the fields, enter them into the LOS — and OpenAdapt
-                    compiles it into a deterministic automation that runs on
-                    your own machines. Healthy runs make no cloud model calls,
-                    and when an LOS screen changes, the fix is proposed as a
-                    reviewable diff.
+                    Record one pass of the task (open the loan documents,
+                    find the fields, enter them into the LOS) and OpenAdapt
+                    compiles it into an automation that runs on your own
+                    machines. Healthy runs make no cloud model calls, and when
+                    an LOS screen changes, the fix is proposed as a reviewable
+                    diff.
                 </p>
                 <div className="mt-7 flex flex-wrap gap-3">
                     <Link
@@ -65,8 +65,8 @@ export default function LendingPage() {
                         scripts, and replays never leave your infrastructure,
                         and PII scrubbing tooling is included. Because it
                         works from the screen, it operates desktop LOS
-                        software like Encompass directly — no API integration
-                        project required.
+                        software like Encompass directly, with no API
+                        integration project required.
                     </p>
                 </div>
 


### PR DESCRIPTION
Writing-quality pass over user-facing site copy, applying the project's HUMAN_WRITING_GUIDE.md. **No thesis, factual claim, number, benchmark result, or safety caveat was changed, and no overstated claim was reintroduced.** `npm run build` passes.

## Classes of change

**Banned words**
- `harness` → `tooling` / `setup` / `test` in `/compare` prose, JSON-LD `description`, and meta descriptions. (The only Tier-1 banned word present in scoped copy.)

**Em-dash overuse** (guide flags >1 per paragraph as an AI tell)
- `/compare` went from 18 em-dashes to ~0 in prose; also trimmed SafetyBand, Faq, IndustriesGrid, MastHead, HowItWorks, InstallSection, and the solution pages. Replaced with commas, parentheses, colons, or a full stop + new sentence. Remaining em-dashes are ≤1 per paragraph or SEO `<title>` separators.

**Contractions** added where natural: `it's`, `can't`, `they're`, `we'll`, `isn't`, `there's`.

**Burstiness / rule-of-three**: broke a few uniform runs into short + long sentences; split one tripled attribute list in the hero.

**Headings**: `Install in 30 Seconds` → `Install in 30 seconds` (sentence case).

**Accuracy nudge (external review)**: softened blanket `deterministic replay` guarantee language to the sharper terms the product actually supports — `compiled`, `model-free on the hot path`. This aligns with the "demonstration compiler" framing and *reduces* the strength of the claim. Preserved: `zero`/`no per-run model calls`, and the qualified `rerun deterministically` describing the reproducible MockMed benchmark.

**One number reconciled**: the `/compare` `og:description` said "five adversarial rounds" while every visible instance and the adversary log say **seven**. Corrected the stale meta to seven for consistency. This is the only numeric edit; no benchmark figure changed.

## Explicitly preserved
39.2s vs 70.4s · $0 vs $0.55 · 0 vs ~24 model calls · 20/20, 10/10, 8/8 · ~6,900 pairs · 0% replayability · MockMed 100 vs 20 / 4.9s vs 37.5s / $0.27 · hybrid one-eighth cost · seven adversarial rounds · name+DOB identity, halt-on-ambiguity, OCR-substrate limitation · LIMITS.md / VALIDATION.md / adversary-log links · "what it gets wrong today". No "0.000%", no "never wrong-writes", no blanket determinism guarantee added.

Please review the diff before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKrVJJy5jWVCkXAqgUqtqZ