### PR TITLE
feat: true one-line install + lightweight launch-funnel instrumentation (internal, no public counts)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Copy to .env.local and fill in to enable launch-funnel analytics.
+# Both are safe to expose client-side (NEXT_PUBLIC_*). The PostHog
+# "project API key" is a publishable, write-only key — not a secret.
+#
+# When NEXT_PUBLIC_POSTHOG_KEY is unset (local dev, CI, opt-out), the
+# analytics layer is a hard no-op: nothing loads and the build still passes.
+# See docs/ANALYTICS.md for what is tracked.
+
+# PostHog project API key (publishable client key)
+NEXT_PUBLIC_POSTHOG_KEY=
+
+# PostHog API host (default: https://us.i.posthog.com; use https://eu.i.posthog.com for EU)
+NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faArrowPointer } from '@fortawesome/free-solid-svg-icons'
 
+import { track, EVENTS } from 'utils/analytics'
 import styles from './Footer.module.css'
 
 export default function Footer() {
@@ -73,7 +74,15 @@ export default function Footer() {
                 </div>
                 <div className={styles.footerContent}>
                     <div className={`${styles.footerLinks} pt-4`}>
-                        <a href={bookHref} className={styles.link}>
+                        <a
+                            href={bookHref}
+                            className={styles.link}
+                            onClick={() =>
+                                track(EVENTS.BOOK_PILOT_CLICK, {
+                                    location: 'footer',
+                                })
+                            }
+                        >
                             Book a Call
                         </a>
                         <a href={contactHref} className={styles.link}>
@@ -109,6 +118,9 @@ export default function Footer() {
                         <a
                             href="https://docs.openadapt.ai"
                             className={styles.link}
+                            onClick={() =>
+                                track(EVENTS.DOCS_CLICK, { location: 'footer' })
+                            }
                         >
                             Docs
                         </a>
@@ -121,12 +133,22 @@ export default function Footer() {
                         <a
                             href="https://github.com/OpenAdaptAI"
                             className={styles.link}
+                            onClick={() =>
+                                track(EVENTS.GITHUB_CLICK, {
+                                    location: 'footer',
+                                })
+                            }
                         >
                             GitHub
                         </a>
                         <a
                             href="https://discord.gg/yF527cQbDG"
                             className={styles.link}
+                            onClick={() =>
+                                track(EVENTS.DISCORD_CLICK, {
+                                    location: 'footer',
+                                })
+                            }
                         >
                             Discord
                         </a>

--- a/components/InstallSection.js
+++ b/components/InstallSection.js
@@ -4,10 +4,18 @@ import { faWindows, faApple, faLinux, faPython } from '@fortawesome/free-brands-
 import { faCopy, faCheck, faTerminal, faDownload } from '@fortawesome/free-solid-svg-icons';
 import styles from './InstallSection.module.css';
 import { getPyPIDownloadStats, formatDownloadCount } from 'utils/pypiStats';
+import { track, EVENTS } from 'utils/analytics';
+
+// One line that installs the `openadapt` tool and launches it. Assumes uv
+// is present (see the "or, step by step" fallback below to install uv in one
+// command). `uv tool install` leaves a persistent `openadapt` command, so
+// this is the true one-liner for a GUI app you relaunch.
+const ONE_LINER = 'uv tool install openadapt && openadapt';
 
 const platforms = {
     'macOS': {
         icon: faApple,
+        oneLiner: ONE_LINER,
         commands: [
             'curl -LsSf https://astral.sh/uv/install.sh | sh',
             'uv tool install openadapt',
@@ -17,6 +25,7 @@ const platforms = {
     },
     'Linux': {
         icon: faLinux,
+        oneLiner: ONE_LINER,
         commands: [
             'curl -LsSf https://astral.sh/uv/install.sh | sh',
             'uv tool install openadapt',
@@ -26,6 +35,7 @@ const platforms = {
     },
     'Windows': {
         icon: faWindows,
+        oneLiner: ONE_LINER,
         commands: [
             'powershell -c "irm https://astral.sh/uv/install.ps1 | iex"',
             'uv tool install openadapt',
@@ -35,13 +45,14 @@ const platforms = {
     }
 };
 
-function CopyButton({ text, className }) {
+function CopyButton({ text, className, onCopied }) {
     const [copied, setCopied] = useState(false);
 
     const handleCopy = async () => {
         try {
             await navigator.clipboard.writeText(text);
             setCopied(true);
+            if (onCopied) onCopied();
             setTimeout(() => setCopied(false), 2000);
         } catch (err) {
             console.error('Failed to copy:', err);
@@ -129,11 +140,57 @@ export default function InstallSection() {
                 ))}
             </div>
 
-            {/* Code Block */}
+            {/* One-liner */}
             <div className={styles.codeContainer}>
                 <div className={styles.codeHeader}>
-                    <span className={styles.codeTitle}>Terminal</span>
-                    <CopyButton text={allCommands} />
+                    <span className={styles.codeTitle}>One line</span>
+                    <CopyButton
+                        text={currentPlatform.oneLiner}
+                        onCopied={() =>
+                            track(EVENTS.INSTALL_COMMAND_COPIED, {
+                                platform: selectedPlatform,
+                                variant: 'one_liner',
+                            })
+                        }
+                    />
+                </div>
+                <pre className={styles.codeBlock}>
+                    <div className={styles.commandLine}>
+                        <span className={styles.prompt}>$</span>
+                        <code className={styles.command}>
+                            {currentPlatform.oneLiner}
+                        </code>
+                    </div>
+                </pre>
+                <div className={styles.codeFooter}>
+                    <span className={styles.note}>
+                        Installs and launches OpenAdapt. Requires{' '}
+                        <a
+                            href="https://docs.astral.sh/uv/"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className={styles.uvLink}
+                        >
+                            uv
+                        </a>{' '}
+                        — install it in one command below.
+                    </span>
+                </div>
+            </div>
+
+            {/* Code Block: step-by-step fallback (installs uv first) */}
+            <div className={styles.codeContainer}>
+                <div className={styles.codeHeader}>
+                    <span className={styles.codeTitle}>or, step by step</span>
+                    <CopyButton
+                        text={allCommands}
+                        onCopied={() =>
+                            track(EVENTS.INSTALL_COMMAND_COPIED, {
+                                platform: selectedPlatform,
+                                variant: 'step_by_step',
+                            })
+                        }
+                    />
                 </div>
                 <pre className={styles.codeBlock}>
                     {currentPlatform.commands.map((cmd, index) => (

--- a/components/MastHead.js
+++ b/components/MastHead.js
@@ -3,6 +3,7 @@ import React from 'react'
 import Link from 'next/link'
 
 import ReplayHero from '@components/ReplayHero'
+import { track, EVENTS } from 'utils/analytics'
 
 import styles from './MastHead.module.css'
 
@@ -73,6 +74,11 @@ export default function Home({ githubStats }) {
                                         href="https://github.com/OpenAdaptAI/OpenAdapt"
                                         target="_blank"
                                         rel="noopener noreferrer"
+                                        onClick={() =>
+                                            track(EVENTS.GITHUB_CLICK, {
+                                                location: 'hero_stars',
+                                            })
+                                        }
                                         className="inline-flex items-center gap-2 rounded-full px-3 py-1 text-sm text-ink-2 no-underline"
                                         style={{ border: '1px solid var(--hairline)' }}
                                     >
@@ -101,12 +107,25 @@ export default function Home({ githubStats }) {
                             </div>
                             <div id="register">
                                 <div className="flex items-center justify-center gap-3 mt-6 mb-4">
-                                    <Link className="btn-ink" href="#book">
+                                    <Link
+                                        className="btn-ink"
+                                        href="#book"
+                                        onClick={() =>
+                                            track(EVENTS.HERO_CTA_CLICK, {
+                                                cta: 'book_a_demo',
+                                            })
+                                        }
+                                    >
                                         Book a demo
                                     </Link>
                                     <Link
                                         className="btn-ghost-ink"
                                         href="#how-it-works"
+                                        onClick={() =>
+                                            track(EVENTS.HERO_CTA_CLICK, {
+                                                cta: 'see_how_it_works',
+                                            })
+                                        }
                                     >
                                         See how it works
                                     </Link>

--- a/components/NavHeader.js
+++ b/components/NavHeader.js
@@ -2,7 +2,14 @@ import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 
+import { track, EVENTS } from 'utils/analytics'
 import styles from './NavHeader.module.css'
+
+// Map an external nav link to its funnel event, if any.
+const externalEvent = (href) => {
+    if (href && href.includes('github.com')) return EVENTS.GITHUB_CLICK
+    return null
+}
 
 const NAV_LINKS = [
     { label: 'Healthcare', href: '/solutions/healthcare' },
@@ -41,6 +48,10 @@ export default function NavHeader() {
                                 className={styles.link}
                                 target="_blank"
                                 rel="noopener noreferrer"
+                                onClick={() => {
+                                    const ev = externalEvent(item.href)
+                                    if (ev) track(ev, { location: 'nav' })
+                                }}
                             >
                                 {item.label}
                             </a>
@@ -65,7 +76,13 @@ export default function NavHeader() {
                 >
                     {menuOpen ? 'CLOSE' : 'MENU'}
                 </button>
-                <Link href="/#book" className={styles.cta}>
+                <Link
+                    href="/#book"
+                    className={styles.cta}
+                    onClick={() =>
+                        track(EVENTS.BOOK_PILOT_CLICK, { location: 'nav' })
+                    }
+                >
                     Book a demo
                 </Link>
             </div>
@@ -83,6 +100,10 @@ export default function NavHeader() {
                                 className={styles.mobileLink}
                                 target="_blank"
                                 rel="noopener noreferrer"
+                                onClick={() => {
+                                    const ev = externalEvent(item.href)
+                                    if (ev) track(ev, { location: 'nav_mobile' })
+                                }}
                             >
                                 {item.label}
                             </a>

--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -1,0 +1,67 @@
+# Launch-funnel analytics
+
+Lightweight, privacy-conscious instrumentation for the OpenAdapt marketing
+site. Its only purpose is to let the team see the **launch funnel** — page
+views and clicks on the load-bearing calls to action — when a launch (e.g. a
+Show HN) drives traffic.
+
+This is **marketing-site analytics only**. Nothing here is displayed publicly,
+and it never touches PHI or the OpenAdapt tool's runtime.
+
+## What is tracked
+
+Page views (captured manually on each client-side route change) plus these
+named funnel events:
+
+| Event                     | Fires when the visitor…                              | Where                                   |
+| ------------------------- | ---------------------------------------------------- | --------------------------------------- |
+| `hero_cta_click`          | clicks a hero button ("Book a demo" / "See how it works") | `components/MastHead.js`           |
+| `book_pilot_click`        | clicks a "Book a demo" / "Book a Call" CTA           | `components/NavHeader.js`, `components/Footer.js` |
+| `github_click`            | clicks a GitHub link                                 | `components/NavHeader.js`, `components/Footer.js`, `components/MastHead.js` |
+| `install_command_copied`  | copies an install command (one-liner or step-by-step) | `components/InstallSection.js`         |
+| `docs_click`              | clicks the Docs link                                 | `components/Footer.js`                  |
+| `discord_click`           | clicks the Discord link                              | `components/Footer.js`                  |
+
+Event properties are limited to non-identifying context such as the platform
+tab selected (`macOS`/`Linux`/`Windows`), the copy variant
+(`one_liner`/`step_by_step`), and the on-page `location` (`nav`, `footer`,
+`hero_stars`, …). No form contents, emails, or free-text are captured.
+
+## Privacy posture
+
+- **Cookieless.** PostHog is initialized with `persistence: 'memory'` — no
+  cookies, no `localStorage`. Nothing survives a full page reload.
+- **No profiles.** `person_profiles: 'identified_only'` means no anonymous
+  person profiles are created; we never call `identify`.
+- **No session recording**, **no autocapture** — only the named events above.
+- **Opt-out by default in dev/CI.** With no `NEXT_PUBLIC_POSTHOG_KEY` set, the
+  entire layer (`utils/analytics.js`) is a no-op; nothing loads.
+- **No PHI, ever.** This site handles no patient/customer runtime data, and the
+  tracker only sees clicks on public marketing CTAs.
+- **No public counts.** Usage numbers are never rendered on the site (pre-launch
+  they'd be zero — anti-proof). The funnel lives only in the PostHog dashboard.
+
+## Enabling it
+
+1. Create a PostHog project and copy its **project API key** (publishable,
+   client-side; not a secret).
+2. Set the env vars (see `.env.example`):
+   ```
+   NEXT_PUBLIC_POSTHOG_KEY=phc_xxx
+   NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+   ```
+   Add the same in the Vercel/Netlify project settings for production.
+
+## Reading the funnel in PostHog
+
+1. In PostHog, open **Product analytics → Funnels → New funnel**.
+2. Add steps in order, e.g.:
+   `$pageview` → `install_command_copied` → `book_pilot_click`.
+   (Or `$pageview` → `hero_cta_click` → `book_pilot_click` for the demo path.)
+3. Set the date range to the launch window to see conversion at each step.
+4. Break down `install_command_copied` by the `platform` / `variant` property
+   to see which install path visitors prefer.
+
+Because persistence is in-memory, a funnel is measured within a single page
+session (a visitor navigating the SPA), which is exactly the launch-day
+behavior we care about.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
                 "framer-motion": "^11.0.8",
                 "next": "^14.1.2",
                 "p5": "^1.9.1",
+                "posthog-js": "^1.399.2",
                 "react": "^18.2.0",
                 "react-chartjs-2": "^5.2.0",
                 "react-dom": "^18.2.0",
@@ -632,6 +633,21 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
             "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
         },
+        "node_modules/@posthog/core": {
+            "version": "1.40.2",
+            "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.40.2.tgz",
+            "integrity": "sha512-H12j7O9iHGvpK9t2ko8W4pvfbV1pBDxrsWC1LA6yp2RhzwvC4T3sWhu+AekDQJSRSrJEWlB0t/Ueq9QhPSq7FQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@posthog/types": "^1.393.0"
+            }
+        },
+        "node_modules/@posthog/types": {
+            "version": "1.393.0",
+            "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.393.0.tgz",
+            "integrity": "sha512-vzWeEJZ7ERQhFRoQYaP5jzN1JvIu46UJyHXsuv+dTGW2r3sMgREOhNxXLZjmFHwZ8/FOHQoyqqQmXTCXZSfMSg==",
+            "license": "MIT"
+        },
         "node_modules/@rushstack/eslint-patch": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz",
@@ -788,6 +804,13 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
             "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ=="
+        },
+        "node_modules/@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/@types/yauzl": {
             "version": "2.10.0",
@@ -2184,6 +2207,17 @@
             "integrity": "sha512-3DdaFaU/Zf1AnpLiFDeNCD4TOWe3Zl2RZaTzUvWiIk5ERzcCodOE20Vqq4fzCbNoHURFHT4/us/Lfq+S2zyY4w==",
             "dev": true
         },
+        "node_modules/core-js": {
+            "version": "3.49.0",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+            "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/core-js"
+            }
+        },
         "node_modules/core-util-is": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -2644,6 +2678,15 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/dompurify": {
+            "version": "3.4.12",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+            "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+            "license": "(MPL-2.0 OR Apache-2.0)",
+            "optionalDependencies": {
+                "@types/trusted-types": "^2.0.7"
             }
         },
         "node_modules/duplexer3": {
@@ -3504,6 +3547,12 @@
             "dependencies": {
                 "pend": "~1.2.0"
             }
+        },
+        "node_modules/fflate": {
+            "version": "0.4.8",
+            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+            "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+            "license": "MIT"
         },
         "node_modules/figures": {
             "version": "3.2.0",
@@ -6441,6 +6490,40 @@
             "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
         },
+        "node_modules/posthog-js": {
+            "version": "1.399.2",
+            "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.399.2.tgz",
+            "integrity": "sha512-xcvrGEgUYtIVcWPRlVfc/NkMo0IP9nwnM/dzJIAzjDOSewkdDk/9T4Vz1+gooEhXdQCPfG44jSK95mVJsoySqA==",
+            "license": "(Apache-2.0 AND MIT)",
+            "dependencies": {
+                "@posthog/core": "^1.40.1",
+                "@posthog/types": "^1.393.0",
+                "core-js": "^3.49.0",
+                "dompurify": "^3.3.2",
+                "fflate": "^0.4.8",
+                "preact": "^10.29.3",
+                "query-selector-shadow-dom": "^1.0.1",
+                "web-vitals": "^5.3.0"
+            }
+        },
+        "node_modules/preact": {
+            "version": "10.29.7",
+            "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
+            "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/preact"
+            },
+            "peerDependencies": {
+                "preact-render-to-string": ">=5"
+            },
+            "peerDependenciesMeta": {
+                "preact-render-to-string": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6560,6 +6643,12 @@
             "engines": {
                 "node": ">=0.6"
             }
+        },
+        "node_modules/query-selector-shadow-dom": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+            "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+            "license": "MIT"
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
@@ -8056,6 +8145,12 @@
                 "node": ">=8.0.0"
             }
         },
+        "node_modules/web-vitals": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+            "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+            "license": "Apache-2.0"
+        },
         "node_modules/webidl-conversions": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -8687,6 +8782,19 @@
                 }
             }
         },
+        "@posthog/core": {
+            "version": "1.40.2",
+            "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.40.2.tgz",
+            "integrity": "sha512-H12j7O9iHGvpK9t2ko8W4pvfbV1pBDxrsWC1LA6yp2RhzwvC4T3sWhu+AekDQJSRSrJEWlB0t/Ueq9QhPSq7FQ==",
+            "requires": {
+                "@posthog/types": "^1.393.0"
+            }
+        },
+        "@posthog/types": {
+            "version": "1.393.0",
+            "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.393.0.tgz",
+            "integrity": "sha512-vzWeEJZ7ERQhFRoQYaP5jzN1JvIu46UJyHXsuv+dTGW2r3sMgREOhNxXLZjmFHwZ8/FOHQoyqqQmXTCXZSfMSg=="
+        },
         "@rushstack/eslint-patch": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz",
@@ -8817,6 +8925,12 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
             "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ=="
+        },
+        "@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+            "optional": true
         },
         "@types/yauzl": {
             "version": "2.10.0",
@@ -9820,6 +9934,11 @@
             "integrity": "sha512-3DdaFaU/Zf1AnpLiFDeNCD4TOWe3Zl2RZaTzUvWiIk5ERzcCodOE20Vqq4fzCbNoHURFHT4/us/Lfq+S2zyY4w==",
             "dev": true
         },
+        "core-js": {
+            "version": "3.49.0",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+            "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg=="
+        },
         "core-util-is": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -10138,6 +10257,14 @@
             "peer": true,
             "requires": {
                 "esutils": "^2.0.2"
+            }
+        },
+        "dompurify": {
+            "version": "3.4.12",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+            "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+            "requires": {
+                "@types/trusted-types": "^2.0.7"
             }
         },
         "duplexer3": {
@@ -10801,6 +10928,11 @@
             "requires": {
                 "pend": "~1.2.0"
             }
+        },
+        "fflate": {
+            "version": "0.4.8",
+            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+            "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
         },
         "figures": {
             "version": "3.2.0",
@@ -12897,6 +13029,27 @@
             "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
         },
+        "posthog-js": {
+            "version": "1.399.2",
+            "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.399.2.tgz",
+            "integrity": "sha512-xcvrGEgUYtIVcWPRlVfc/NkMo0IP9nwnM/dzJIAzjDOSewkdDk/9T4Vz1+gooEhXdQCPfG44jSK95mVJsoySqA==",
+            "requires": {
+                "@posthog/core": "^1.40.1",
+                "@posthog/types": "^1.393.0",
+                "core-js": "^3.49.0",
+                "dompurify": "^3.3.2",
+                "fflate": "^0.4.8",
+                "preact": "^10.29.3",
+                "query-selector-shadow-dom": "^1.0.1",
+                "web-vitals": "^5.3.0"
+            }
+        },
+        "preact": {
+            "version": "10.29.7",
+            "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
+            "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
+            "requires": {}
+        },
         "prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -12992,6 +13145,11 @@
             "version": "6.5.3",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
             "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
+        },
+        "query-selector-shadow-dom": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+            "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw=="
         },
         "queue-microtask": {
             "version": "1.2.3",
@@ -14082,6 +14240,11 @@
             "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-4.0.0.tgz",
             "integrity": "sha512-kudCA8PXVQfrqv2mFTG72vDBRi8BKWxGgFLwPpzHcpZnSwZk93WMwUDVcLHWNsnm+Y0AC4Vb6MUNRgaHfyV2DQ==",
             "dev": true
+        },
+        "web-vitals": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+            "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g=="
         },
         "webidl-conversions": {
             "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "framer-motion": "^11.0.8",
         "next": "^14.1.2",
         "p5": "^1.9.1",
+        "posthog-js": "^1.399.2",
         "react": "^18.2.0",
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.2.0",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -3,10 +3,25 @@ import { config } from '@fortawesome/fontawesome-svg-core'
 import '@fortawesome/fontawesome-svg-core/styles.css'
 import Head from 'next/head'
 import Script from 'next/script'
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
 
 import NavHeader from '@components/NavHeader'
+import { initAnalytics, capturePageview } from 'utils/analytics'
 
 export default function MyApp({ Component, pageProps }) {
+    const router = useRouter()
+
+    // Initialize privacy-conscious funnel analytics (no-op without a key)
+    // and capture a pageview on every client-side route change.
+    useEffect(() => {
+        initAnalytics()
+        capturePageview(window.location.pathname + window.location.search)
+        const handleRouteChange = (url) => capturePageview(url)
+        router.events.on('routeChangeComplete', handleRouteChange)
+        return () => router.events.off('routeChangeComplete', handleRouteChange)
+    }, [router.events])
+
     return (
         <>
             {/* New pages must add their own <Head> with unique title, description, canonical, and og:* tags */}

--- a/utils/analytics.js
+++ b/utils/analytics.js
@@ -1,0 +1,91 @@
+/**
+ * Lightweight, privacy-conscious launch-funnel analytics.
+ *
+ * Wraps PostHog capture with a hard no-op fallback: if
+ * NEXT_PUBLIC_POSTHOG_KEY is not configured (local dev, CI, or an
+ * opted-out deploy) nothing loads and every call is a silent no-op, so
+ * the build and runtime are never affected.
+ *
+ * This is marketing-site analytics only. It measures the launch funnel
+ * (page views + clicks on the load-bearing CTAs). It is cookieless
+ * (in-memory persistence), creates no anonymous profiles, records no
+ * sessions, and never touches PHI or the OpenAdapt tool's runtime.
+ *
+ * Nothing here is ever displayed publicly — the founder reads the funnel
+ * in the PostHog dashboard. See docs/ANALYTICS.md.
+ */
+
+// Named funnel events. Keep this list in sync with docs/ANALYTICS.md.
+export const EVENTS = {
+    HERO_CTA_CLICK: 'hero_cta_click',
+    BOOK_PILOT_CLICK: 'book_pilot_click',
+    GITHUB_CLICK: 'github_click',
+    INSTALL_COMMAND_COPIED: 'install_command_copied',
+    DOCS_CLICK: 'docs_click',
+    DISCORD_CLICK: 'discord_click',
+}
+
+const POSTHOG_KEY =
+    typeof process !== 'undefined'
+        ? process.env.NEXT_PUBLIC_POSTHOG_KEY
+        : undefined
+const POSTHOG_HOST =
+    (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_POSTHOG_HOST) ||
+    'https://us.i.posthog.com'
+
+let client = null
+let initialized = false
+
+/** True when a PostHog key is configured and we're in the browser. */
+function isEnabled() {
+    return Boolean(POSTHOG_KEY) && typeof window !== 'undefined'
+}
+
+/**
+ * Initialize PostHog once, with a cookieless / privacy-respecting config.
+ * Safe to call repeatedly. No-op when no key is configured.
+ */
+export async function initAnalytics() {
+    if (initialized || !isEnabled()) return
+    initialized = true
+    try {
+        const posthog = (await import('posthog-js')).default
+        posthog.init(POSTHOG_KEY, {
+            api_host: POSTHOG_HOST,
+            // Privacy-respecting, local-first-friendly defaults:
+            persistence: 'memory', // no cookies, no localStorage
+            disable_session_recording: true,
+            autocapture: false, // only the named funnel events below
+            capture_pageview: false, // we capture pageviews manually on route change
+            capture_pageleave: false,
+            person_profiles: 'identified_only', // no anonymous profiles
+        })
+        client = posthog
+    } catch (err) {
+        // Never let analytics break the page.
+        // eslint-disable-next-line no-console
+        console.warn('[analytics] init skipped:', err)
+    }
+}
+
+/** Fire a named funnel event. No-op when analytics is disabled. */
+export function track(event, properties) {
+    if (!isEnabled() || !client) return
+    try {
+        client.capture(event, properties)
+    } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn('[analytics] capture skipped:', err)
+    }
+}
+
+/** Capture a page view for the given path. No-op when disabled. */
+export function capturePageview(path) {
+    if (!isEnabled() || !client) return
+    try {
+        client.capture('$pageview', path ? { $current_url: path } : undefined)
+    } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn('[analytics] pageview skipped:', err)
+    }
+}


### PR DESCRIPTION
## Summary
Two focused, small improvements to the marketing site. Learned from closed PR #134: kept it minimal, **no public usage counts** (they'd be zero pre-launch = anti-proof), and **no server-side pipeline**.

### 1. True one-line install
`components/InstallSection.js` now leads with a genuine **one-liner** per platform:

```
uv tool install openadapt && openadapt
```

- Single line that installs the `openadapt` tool and launches it. `uv tool install` leaves a persistent `openadapt` command — the right fit for a GUI app you relaunch (vs. ephemeral `uvx`).
- The previous three commands remain below as an **"or, step by step"** fallback (which installs `uv` first).
- Kept the per-platform tabs, the `openadapt` package name (unchanged), and the copy-to-clipboard button.

### 2. Launch-funnel instrumentation (internal only)
- New `utils/analytics.js`: tiny wrapper over PostHog with a **hard no-op fallback** when `NEXT_PUBLIC_POSTHOG_KEY` is unset (dev/CI/opt-out builds unaffected). Cookieless (`persistence: 'memory'`), no person profiles, no autocapture, no session recording. `posthog-js` is dynamically imported so it only loads when a key is present.
- Pageview captured on each route change in `pages/_app.js`.
- Named funnel events wired with minimal `onClick` hooks on the load-bearing CTAs:
  - `hero_cta_click` — MastHead hero buttons
  - `book_pilot_click` — NavHeader + Footer booking CTAs
  - `github_click` — NavHeader, Footer, MastHead GitHub links
  - `install_command_copied` — InstallSection copy button (with `one_liner` / `step_by_step` + platform)
  - `docs_click`, `discord_click` — Footer
- `.env.example` documents the public client key env var.
- `docs/ANALYTICS.md` explains what's tracked, the cookieless/opt-out posture, that it never touches PHI or the tool runtime, and how to read the funnel in PostHog.

### Explicitly NOT included
- No public-facing usage-count display anywhere.
- No server-side metrics pipeline.
- No PHI or tool-runtime tracking — marketing CTA clicks only.

### Package-naming note for review
The site installs the **`openadapt`** package (kept as-is per instructions). Recent product work referenced in this repo (the "full loop" block lower in InstallSection) uses **`openadapt-flow`** (`pip install openadapt-flow`). These are two different packages on the same page — flagging for you to decide whether to reconcile; I did **not** change it.

### Build
`npm run build` passes locally.

> Note: `components/InstallSection.js` was edited surgically (added the one-liner block + a copy-tracking hook) to minimize conflicts with the concurrent copy pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKrVJJy5jWVCkXAqgUqtqZ