### PR TITLE
feat: Homebrew-style one-line install (drop step-by-step block)

### DIFF
--- a/components/InstallSection.js
+++ b/components/InstallSection.js
@@ -6,43 +6,29 @@ import styles from './InstallSection.module.css';
 import { getPyPIDownloadStats, formatDownloadCount } from 'utils/pypiStats';
 import { track, EVENTS } from 'utils/analytics';
 
-// One line that installs the `openadapt` tool and launches it. Assumes uv
-// is present (see the "or, step by step" fallback below to install uv in one
-// command). `uv tool install` leaves a persistent `openadapt` command, so
-// this is the true one-liner for a GUI app you relaunch.
-const ONE_LINER = 'uv tool install openadapt && openadapt';
-
+// One self-contained line, Homebrew-style. The hosted install script
+// (public/install.sh, served at openadapt.ai/install.sh) bootstraps uv if
+// it's missing, then installs OpenAdapt as a persistent `openadapt` command —
+// so there's no separate "install uv first" step to show.
 const platforms = {
     'macOS': {
         icon: faApple,
-        oneLiner: ONE_LINER,
-        commands: [
-            'curl -LsSf https://astral.sh/uv/install.sh | sh',
-            'uv tool install openadapt',
-            'openadapt --help'
-        ],
-        note: 'Works on Intel and Apple Silicon Macs'
+        install: 'curl -fsSL https://openadapt.ai/install.sh | sh',
+        script: '/install.sh',
+        note: 'Intel and Apple Silicon Macs',
     },
     'Linux': {
         icon: faLinux,
-        oneLiner: ONE_LINER,
-        commands: [
-            'curl -LsSf https://astral.sh/uv/install.sh | sh',
-            'uv tool install openadapt',
-            'openadapt --help'
-        ],
-        note: 'Works on most modern Linux distributions'
+        install: 'curl -fsSL https://openadapt.ai/install.sh | sh',
+        script: '/install.sh',
+        note: 'Most modern Linux distributions',
     },
     'Windows': {
         icon: faWindows,
-        oneLiner: ONE_LINER,
-        commands: [
-            'powershell -c "irm https://astral.sh/uv/install.ps1 | iex"',
-            'uv tool install openadapt',
-            'openadapt --help'
-        ],
-        note: 'Run in PowerShell (not Command Prompt)'
-    }
+        install: 'powershell -c "irm https://openadapt.ai/install.ps1 | iex"',
+        script: '/install.ps1',
+        note: 'Run in PowerShell (not Command Prompt)',
+    },
 };
 
 function CopyButton({ text, className, onCopied }) {
@@ -97,7 +83,6 @@ export default function InstallSection() {
     }, []);
 
     const currentPlatform = platforms[selectedPlatform];
-    const allCommands = currentPlatform.commands.join('\n');
 
     return (
         <div className={styles.installSection}>
@@ -140,16 +125,15 @@ export default function InstallSection() {
                 ))}
             </div>
 
-            {/* One-liner */}
+            {/* One self-contained line (Homebrew-style) */}
             <div className={styles.codeContainer}>
                 <div className={styles.codeHeader}>
-                    <span className={styles.codeTitle}>One line</span>
+                    <span className={styles.codeTitle}>Install</span>
                     <CopyButton
-                        text={currentPlatform.oneLiner}
+                        text={currentPlatform.install}
                         onCopied={() =>
                             track(EVENTS.INSTALL_COMMAND_COPIED, {
                                 platform: selectedPlatform,
-                                variant: 'one_liner',
                             })
                         }
                     />
@@ -158,66 +142,24 @@ export default function InstallSection() {
                     <div className={styles.commandLine}>
                         <span className={styles.prompt}>$</span>
                         <code className={styles.command}>
-                            {currentPlatform.oneLiner}
+                            {currentPlatform.install}
                         </code>
                     </div>
                 </pre>
                 <div className={styles.codeFooter}>
                     <span className={styles.note}>
-                        Installs and launches OpenAdapt. Requires{' '}
+                        Installs uv and OpenAdapt, then you run{' '}
+                        <code>openadapt</code>. {currentPlatform.note}.{' '}
                         <a
-                            href="https://docs.astral.sh/uv/"
+                            href={currentPlatform.script}
                             target="_blank"
                             rel="noopener noreferrer"
                             className={styles.uvLink}
                         >
-                            uv
-                        </a>{' '}
-                        — install it in one command below.
+                            View the script
+                        </a>
                     </span>
                 </div>
-            </div>
-
-            {/* Code Block: step-by-step fallback (installs uv first) */}
-            <div className={styles.codeContainer}>
-                <div className={styles.codeHeader}>
-                    <span className={styles.codeTitle}>or, step by step</span>
-                    <CopyButton
-                        text={allCommands}
-                        onCopied={() =>
-                            track(EVENTS.INSTALL_COMMAND_COPIED, {
-                                platform: selectedPlatform,
-                                variant: 'step_by_step',
-                            })
-                        }
-                    />
-                </div>
-                <pre className={styles.codeBlock}>
-                    {currentPlatform.commands.map((cmd, index) => (
-                        <div key={index} className={styles.commandLine}>
-                            <span className={styles.prompt}>$</span>
-                            <code className={styles.command}>{cmd}</code>
-                        </div>
-                    ))}
-                </pre>
-                <div className={styles.codeFooter}>
-                    <span className={styles.note}>{currentPlatform.note}</span>
-                </div>
-            </div>
-
-            {/* What is uv? */}
-            <div className={styles.uvInfo}>
-                <p>
-                    <a
-                        href="https://docs.astral.sh/uv/"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className={styles.uvLink}
-                    >
-                        What is uv?
-                    </a>
-                    {' '}- uv is a fast Python package manager that automatically installs Python and manages dependencies.
-                </p>
             </div>
 
             {/* Quick Start: the full loop */}

--- a/public/install.ps1
+++ b/public/install.ps1
@@ -1,0 +1,30 @@
+# OpenAdapt installer — https://openadapt.ai
+#
+#   powershell -c "irm https://openadapt.ai/install.ps1 | iex"
+#
+# Installs uv (a fast Python toolchain) if you don't have it, then installs
+# OpenAdapt as a persistent `openadapt` command. Safe to re-run: it upgrades
+# in place. Read the script first if you like — it's served in the clear.
+$ErrorActionPreference = 'Stop'
+
+function Info($msg) { Write-Host "==> $msg" -ForegroundColor Cyan }
+
+if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
+    Info "Installing uv (fast Python package manager)…"
+    powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
+    # uv installs to %USERPROFILE%\.local\bin by default.
+    $env:Path = "$env:USERPROFILE\.local\bin;$env:Path"
+}
+
+if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
+    Write-Host "Error: uv was installed but isn't on your PATH yet." -ForegroundColor Red
+    Write-Host "Open a new PowerShell window and re-run this command." -ForegroundColor Red
+    exit 1
+}
+
+Info "Installing OpenAdapt…"
+uv tool install --upgrade openadapt
+uv tool update-shell | Out-Null
+
+Info "OpenAdapt is installed. Launch it with:  openadapt"
+Info "If PowerShell can't find it yet, open a new window first."

--- a/public/install.sh
+++ b/public/install.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# OpenAdapt installer — https://openadapt.ai
+#
+#   curl -fsSL https://openadapt.ai/install.sh | sh
+#
+# Installs uv (a fast Python toolchain) if you don't have it, then installs
+# OpenAdapt as a persistent `openadapt` command. Safe to re-run: it upgrades
+# in place. Nothing runs with elevated privileges; read the script first if
+# you like — that's why it's served in the clear over HTTPS.
+set -eu
+
+info() { printf '\033[1;36m==>\033[0m %s\n' "$1"; }
+err()  { printf '\033[1;31mError:\033[0m %s\n' "$1" >&2; }
+
+if ! command -v curl >/dev/null 2>&1; then
+    err "curl is required but not installed."
+    exit 1
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+    info "Installing uv (fast Python package manager)…"
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    # uv installs to ~/.local/bin by default; make it visible to this script.
+    export PATH="$HOME/.local/bin:$PATH"
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+    err "uv was installed but isn't on your PATH yet."
+    err "Open a new terminal and re-run this command, or add ~/.local/bin to PATH."
+    exit 1
+fi
+
+info "Installing OpenAdapt…"
+uv tool install --upgrade openadapt
+
+# Make sure the installed `openadapt` command is on PATH in future shells.
+uv tool update-shell >/dev/null 2>&1 || true
+
+info "OpenAdapt is installed. Launch it with:"
+printf '\n    openadapt\n\n'
+info "If your shell can't find it yet, open a new terminal first."


### PR DESCRIPTION
## What
Replaces the install section's redundant **"One line"** (assumed `uv`) + **"or, step by step"** (installed `uv` first) pair with a single self-contained line, modelled on Homebrew / rustup / uv:

```
curl -fsSL https://openadapt.ai/install.sh | sh                  # macOS / Linux
powershell -c "irm https://openadapt.ai/install.ps1 | iex"       # Windows
```

## How
- New hosted scripts `public/install.sh` + `public/install.ps1` (served at `openadapt.ai/install.sh`) bootstrap `uv` if it's missing, then `uv tool install --upgrade openadapt` and put the command on PATH. Re-runnable (upgrades in place), no elevated privileges.
- Section collapses to one command per platform. Footer links **View the script** for curl-pipe-sh transparency (served in the clear over HTTPS).
- Keeps the copy-button funnel event (`install_command_copied`); drops the now-moot `variant` field.
- The separate "full loop, in five commands" block (the `openadapt-flow` compiler demo) is unchanged.

## Notes
- `sh -n` clean; `npm run build` passes.
- Preview deploy will serve `/install.sh` — worth a quick click-through on the preview URL before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKrVJJy5jWVCkXAqgUqtqZ