### PR TITLE
fix: correct desktop/VDI/RDP/Encompass capability claims to match the compare page (in-progress, not shipped)

### DIFF
--- a/components/Faq.js
+++ b/components/Faq.js
@@ -21,7 +21,7 @@ export const faqItems = [
     },
     {
         question: 'What software does OpenAdapt work with?',
-        answer: "Anything with a screen. Because OpenAdapt watches pixels and inputs rather than APIs or browser internals, it works with desktop applications, web apps, and software delivered over VDI or RDP — including EMRs and loan origination systems that cloud automation tools can't reach.",
+        answer: "OpenAdapt works from pixels and inputs rather than APIs or browser internals. Today it runs web apps, including web EMRs. Because the runtime is vision-based, the same approach extends to desktop applications and software delivered over VDI or RDP as adapters, not rewrites — and those adapters are in progress. The aim is to reach the desktop EMRs and loan origination systems that cloud automation tools can't, without an API integration project.",
     },
 ]
 

--- a/components/IndustriesGrid.js
+++ b/components/IndustriesGrid.js
@@ -34,14 +34,14 @@ export default function IndustriesGrid({
             title: 'Healthcare clinics',
             href: '/solutions/healthcare',
             descriptions:
-                'Referral and fax intake, EMR data entry and extraction, desktop and VDI EMRs included. PHI handling stays fully local.',
+                'Referral and fax intake, EMR data entry and extraction; web EMRs today, desktop and VDI EMRs on the roadmap. PHI handling stays fully local.',
             logo: '/images/noun-healthcare.svg',
         },
         {
             title: 'Mortgage & lending ops',
             href: '/solutions/lending',
             descriptions:
-                'Loan-file data extraction and entry in desktop LOS software like Encompass. Borrower data stays in your environment.',
+                'Loan-file data extraction and entry; desktop LOS like Encompass on the roadmap. Borrower data stays in your environment.',
             logo: '/images/noun-finance.svg',
         },
         {

--- a/pages/solutions/healthcare.js
+++ b/pages/solutions/healthcare.js
@@ -11,7 +11,7 @@ export default function HealthcarePage() {
                 <title>Healthcare Clinic Automation — Referral Intake & EMR Data Entry | OpenAdapt</title>
                 <meta
                     name="description"
-                    content="OpenAdapt compiles a recorded demonstration of referral intake or EMR data entry into a self-healing automation that runs inside your clinic. PHI never leaves your machines; desktop and VDI EMRs included."
+                    content="OpenAdapt compiles a recorded demonstration of referral intake or EMR data entry into a self-healing automation that runs inside your clinic. PHI never leaves your machines. Web EMRs today, with desktop and VDI adapters in progress."
                 />
                 <link rel="canonical" href="https://openadapt.ai/solutions/healthcare" />
                 <meta property="og:title" content="Healthcare Clinic Automation | OpenAdapt" />
@@ -64,8 +64,10 @@ export default function HealthcarePage() {
                         replays all stay on your own infrastructure, and
                         PII/PHI scrubbing tooling is included. Because it
                         works from the screen rather than browser internals,
-                        it operates desktop and VDI EMRs that cloud automation
-                        tools can&#39;t reach.
+                        the same vision-based approach is designed to reach the
+                        desktop and VDI EMRs that cloud automation tools
+                        can&#39;t. Web EMRs are supported today, and those
+                        desktop and VDI adapters are in progress.
                     </p>
                 </div>
 

--- a/pages/solutions/lending.js
+++ b/pages/solutions/lending.js
@@ -8,10 +8,10 @@ export default function LendingPage() {
     return (
         <div className="min-h-screen bg-ground text-ink">
             <Head>
-                <title>Mortgage & Lending Automation — Loan-File Data Entry in Encompass | OpenAdapt</title>
+                <title>Mortgage & Lending Automation — Loan-File Data Entry | OpenAdapt</title>
                 <meta
                     name="description"
-                    content="OpenAdapt compiles a recorded demonstration of loan-file data entry into a self-healing automation that runs in your own environment. Works with desktop LOS software like Encompass; borrower data stays with you."
+                    content="OpenAdapt compiles a recorded demonstration of loan-file data entry into a self-healing automation that runs in your own environment. Vision-based and designed to reach desktop LOS software like Encompass; borrower data stays with you."
                 />
                 <link rel="canonical" href="https://openadapt.ai/solutions/lending" />
                 <meta property="og:title" content="Mortgage & Lending Automation | OpenAdapt" />
@@ -25,8 +25,8 @@ export default function LendingPage() {
                 </p>
                 <h1 className="font-display mt-3 text-3xl font-semibold tracking-tight text-ink md:text-4xl">
                     Your team copies the same loan-file data between documents
-                    and Encompass all day. OpenAdapt compiles that workflow
-                    once.
+                    and Encompass all day. OpenAdapt is built to compile that
+                    workflow once.
                 </h1>
                 <p className="mt-5 max-w-3xl text-base text-ink-2 md:text-lg">
                     Record one pass of the task (open the loan documents,
@@ -64,9 +64,11 @@ export default function LendingPage() {
                         local-first by architecture: recordings, compiled
                         scripts, and replays never leave your infrastructure,
                         and PII scrubbing tooling is included. Because it
-                        works from the screen, it operates desktop LOS
-                        software like Encompass directly, with no API
-                        integration project required.
+                        works from the screen rather than an API, the same
+                        vision-based approach is designed to reach desktop LOS
+                        software like Encompass without an API integration
+                        project. Web workflows are supported today, and that
+                        desktop adapter is in progress.
                     </p>
                 </div>
 
@@ -80,8 +82,8 @@ export default function LendingPage() {
                         LOS screens.
                     </li>
                     <li className="rounded-xl border border-hairline bg-panel p-4 text-sm leading-relaxed text-ink-2 md:text-base">
-                        Extract fields from loan documents into Encompass —
-                        and pull data back out for disclosures, portals, and
+                        Extract fields from loan documents into your LOS — and
+                        pull data back out for disclosures, portals, and
                         spreadsheets.
                     </li>
                     <li className="rounded-xl border border-hairline bg-panel p-4 text-sm leading-relaxed text-ink-2 md:text-base">


### PR DESCRIPTION
## Problem

An adversarial capability audit found the marketing site used **present-tense** claims for desktop / VDI / RDP / Encompass capabilities the product does **not** ship today:

- **RDP** has only just decoded its first live frame in a spike (not production)
- **Desktop** scored 0% under drift in a bench
- **VDI** has no backend
- **No Encompass run exists**

These claims also **contradicted the site's own `compare.js`**, which already frames coverage honestly: *"Desktop, web, and VDI/RDP (vision-based; adapters in progress)"* and *"adapters for these are in progress."* The README agrees. This is a design-partner + public liability.

## Fix

Reframe every present-tense overclaim to match the compare page's honest framing. Web is shipped and stays present-tense; desktop/VDI/RDP/Encompass become clearly in-progress / roadmap / aspirational. The true architectural point (vision-from-the-screen means these are **adapters, not rewrites**) is preserved.

| File | Before | After |
|------|--------|-------|
| `components/Faq.js` | "it works with desktop applications, web apps, and software delivered over VDI or RDP — including EMRs and loan origination systems that cloud automation tools can't reach" | "Today it runs web apps, including web EMRs… the same approach extends to desktop applications and software delivered over VDI or RDP as adapters, not rewrites — and those adapters are in progress. The aim is to reach the desktop EMRs and loan origination systems…" |
| `pages/solutions/healthcare.js` (meta) | "desktop and VDI EMRs included" | "Web EMRs today, with desktop and VDI adapters in progress" |
| `pages/solutions/healthcare.js` (body) | "it operates desktop and VDI EMRs that cloud automation tools can't reach" | "the same vision-based approach is designed to reach the desktop and VDI EMRs… Web EMRs are supported today, and those desktop and VDI adapters are in progress" |
| `pages/solutions/lending.js` (title) | "Loan-File Data Entry in Encompass" | "Loan-File Data Entry" |
| `pages/solutions/lending.js` (meta) | "Works with desktop LOS software like Encompass" | "Vision-based and designed to reach desktop LOS software like Encompass" |
| `pages/solutions/lending.js` (h1) | "OpenAdapt compiles that workflow once" | "OpenAdapt is built to compile that workflow once" |
| `pages/solutions/lending.js` (body) | "it operates desktop LOS software like Encompass directly, with no API integration project required" | "the same vision-based approach is designed to reach desktop LOS software like Encompass without an API integration project… that desktop adapter is in progress" |
| `pages/solutions/lending.js` (list) | "Extract fields from loan documents into Encompass" | "Extract fields from loan documents into your LOS" |
| `components/IndustriesGrid.js` (healthcare) | "desktop and VDI EMRs included" | "web EMRs today, desktop and VDI EMRs on the roadmap" |
| `components/IndustriesGrid.js` (lending) | "entry in desktop LOS software like Encompass" | "entry; desktop LOS like Encompass on the roadmap" |

## Guardrails honored

- No overcorrection into self-deprecation — the vision-only-so-these-are-adapters point is stated as the real roadmap.
- All shipped/honest claims preserved: web EMR, compiled-replay benchmarks, identity safety, local-first architecture.
- Bar met: no present-tense claim that a capability *works* unless shipped.

## Verification

`npm run build` passes (all 11 pages generated, including `/solutions/healthcare`, `/solutions/lending`, `/compare`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKrVJJy5jWVCkXAqgUqtqZ