### PR TITLE
feat: native benchmark charts on /compare (generated from real results)

### DIFF
--- a/components/BenchmarkCharts.js
+++ b/components/BenchmarkCharts.js
@@ -1,0 +1,328 @@
+import { useId } from 'react'
+
+/*
+ * Native inline-SVG benchmark charts for /compare.
+ *
+ * Every number rendered here comes from data/benchmark.json, which is copied
+ * verbatim from the openadapt-flow results.json files (see provenance in that
+ * file). Nothing is hand-typed into the markup, so the published charts cannot
+ * drift from the measured results.
+ *
+ * Colors are driven entirely by the site's CSS design tokens (var(--accent),
+ * var(--ink), var(--ink-2), var(--ink-3), var(--hairline)), so the charts
+ * follow the site theme rather than hardcoding light/dark values.
+ */
+
+const COMPILED = 'var(--accent)' // OpenAdapt compiled replay — the win
+const AGENT = 'var(--ink-2)' // computer-use agent — muted
+const TRACK = 'var(--hairline)'
+const CAPTION = 'var(--ink-3)'
+const INK = 'var(--ink)'
+
+const numStyle = { fontVariantNumeric: 'tabular-nums' }
+
+function fmtSec(s) {
+    return `${s.toFixed(1)}s`
+}
+
+function fmtCost(c) {
+    return c === 0 ? '$0' : `$${c.toFixed(2)}`
+}
+
+// Horizontal latency chart: one row per arm. A light track runs to p95, a
+// solid bar runs to p50, and a tick marks p95 — so both percentiles read at a
+// glance on a single shared axis.
+function LatencyChart({ compiled, agent, titleId, descId }) {
+    const max = Math.max(compiled.wall_s_p95, agent.wall_s_p95)
+    const x0 = 6
+    const x1 = 330
+    const W = x1 - x0
+    const scale = (v) => (v / max) * W
+    const barH = 15
+    const rows = [
+        { name: 'Compiled', data: compiled, color: COMPILED, y: 30 },
+        { name: 'Agent', data: agent, color: AGENT, y: 78 },
+    ]
+    const axisY = 118
+    return (
+        <svg
+            viewBox="0 0 336 136"
+            width="100%"
+            role="img"
+            aria-labelledby={`${titleId} ${descId}`}
+            style={{ display: 'block' }}
+        >
+            <title id={titleId}>Latency per run: compiled replay vs computer-use agent</title>
+            <desc id={descId}>
+                Median run {fmtSec(compiled.wall_s_p50)} compiled versus{' '}
+                {fmtSec(agent.wall_s_p50)} for the agent; 95th percentile{' '}
+                {fmtSec(compiled.wall_s_p95)} versus {fmtSec(agent.wall_s_p95)}.
+            </desc>
+            {rows.map((row) => {
+                const p50w = scale(row.data.wall_s_p50)
+                const p95w = scale(row.data.wall_s_p95)
+                return (
+                    <g key={row.name}>
+                        <text
+                            x={x0}
+                            y={row.y - 6}
+                            fontSize="11"
+                            fontWeight="600"
+                            fill={INK}
+                            style={{ fontFamily: 'var(--font-display)' }}
+                        >
+                            {row.name}
+                        </text>
+                        {/* p95 in a fixed right column — never overflows */}
+                        <text
+                            x={x1}
+                            y={row.y - 6}
+                            fontSize="9.5"
+                            fill={CAPTION}
+                            textAnchor="end"
+                            style={numStyle}
+                        >
+                            p95 {fmtSec(row.data.wall_s_p95)}
+                        </text>
+                        {/* p95 track */}
+                        <rect
+                            x={x0}
+                            y={row.y}
+                            width={p95w}
+                            height={barH}
+                            rx="2"
+                            fill={row.color}
+                            fillOpacity="0.16"
+                        />
+                        {/* p50 solid bar */}
+                        <rect
+                            x={x0}
+                            y={row.y}
+                            width={p50w}
+                            height={barH}
+                            rx="2"
+                            fill={row.color}
+                        />
+                        {/* p95 tick */}
+                        <line
+                            x1={x0 + p95w}
+                            x2={x0 + p95w}
+                            y1={row.y - 2}
+                            y2={row.y + barH + 2}
+                            stroke={row.color}
+                            strokeWidth="1.5"
+                        />
+                        {/* p50 value */}
+                        <text
+                            x={x0 + p50w + 6}
+                            y={row.y + barH - 3}
+                            fontSize="12"
+                            fontWeight="700"
+                            fill={INK}
+                            style={{ ...numStyle, fontFamily: 'var(--font-display)' }}
+                        >
+                            {fmtSec(row.data.wall_s_p50)}
+                        </text>
+                    </g>
+                )
+            })}
+            {/* axis */}
+            <line
+                x1={x0}
+                x2={x1}
+                y1={axisY}
+                y2={axisY}
+                stroke={TRACK}
+                strokeWidth="1"
+            />
+            <text x={x0} y={axisY + 12} fontSize="9.5" fill={CAPTION} style={numStyle}>
+                0s
+            </text>
+            <text
+                x={x1}
+                y={axisY + 12}
+                fontSize="9.5"
+                fill={CAPTION}
+                textAnchor="end"
+                style={numStyle}
+            >
+                {fmtSec(max)}
+            </text>
+            <text
+                x={(x0 + x1) / 2}
+                y={axisY + 12}
+                fontSize="9.5"
+                fill={CAPTION}
+                textAnchor="middle"
+            >
+                solid = median (p50) · tick = p95
+            </text>
+        </svg>
+    )
+}
+
+// Cost chart: agent cost per run as a bar, compiled pinned at an emphasized
+// zero endpoint. The zero is the point — a filled dot and a "$0" that stays $0
+// on every run, forever.
+function CostChart({ compiled, agent, runs, titleId, descId }) {
+    const x0 = 6
+    const x1 = 300
+    const W = x1 - x0
+    const barH = 20
+    const agentW = W // agent is the only nonzero cost, so it fills the plot
+    const compiledY = 26
+    const agentY = 66
+    const agent500 = Math.round(agent.cost_usd_per_run * runs)
+    return (
+        <svg
+            viewBox="0 0 336 120"
+            width="100%"
+            role="img"
+            aria-labelledby={`${titleId} ${descId}`}
+            style={{ display: 'block' }}
+        >
+            <title id={titleId}>Model cost per run: compiled replay vs computer-use agent</title>
+            <desc id={descId}>
+                Compiled replay costs {fmtCost(compiled.cost_usd_per_run)} per run;
+                the agent costs {fmtCost(agent.cost_usd_per_run)} per run at list
+                price. Over {runs} runs that is $0 versus about ${agent500}.
+            </desc>
+            {/* Compiled row: emphasized zero endpoint */}
+            <text
+                x={x0}
+                y={compiledY - 6}
+                fontSize="11"
+                fontWeight="600"
+                fill={INK}
+                style={{ fontFamily: 'var(--font-display)' }}
+            >
+                Compiled
+            </text>
+            {/* zero baseline stub + emphasized dot */}
+            <rect x={x0} y={compiledY} width="10" height={barH} rx="2" fill={COMPILED} />
+            <circle cx={x0 + 5} cy={compiledY + barH / 2} r="5.5" fill={COMPILED} />
+            <circle cx={x0 + 5} cy={compiledY + barH / 2} r="2.25" fill="var(--panel)" />
+            <text
+                x={x0 + 22}
+                y={compiledY + barH - 4}
+                fontSize="15"
+                fontWeight="700"
+                fill={COMPILED}
+                style={{ ...numStyle, fontFamily: 'var(--font-display)' }}
+            >
+                {fmtCost(compiled.cost_usd_per_run)}
+            </text>
+            <text
+                x={x0 + 52}
+                y={compiledY + barH - 5}
+                fontSize="10"
+                fill={CAPTION}
+            >
+                every run, forever
+            </text>
+            {/* Agent row */}
+            <text
+                x={x0}
+                y={agentY - 6}
+                fontSize="11"
+                fontWeight="600"
+                fill={INK}
+                style={{ fontFamily: 'var(--font-display)' }}
+            >
+                Agent
+            </text>
+            <rect x={x0} y={agentY} width={agentW} height={barH} rx="2" fill={AGENT} />
+            <text
+                x={x0 + agentW - 8}
+                y={agentY + barH - 5}
+                fontSize="13"
+                fontWeight="700"
+                fill="var(--panel)"
+                textAnchor="end"
+                style={{ ...numStyle, fontFamily: 'var(--font-display)' }}
+            >
+                {fmtCost(agent.cost_usd_per_run)} / run
+            </text>
+            <text x={x0} y={112} fontSize="9.5" fill={CAPTION} style={numStyle}>
+                at {runs} runs: $0 vs ~${agent500} · list price, model cost only
+            </text>
+        </svg>
+    )
+}
+
+// A stat readout that mirrors the site's existing "big number + caption" cards.
+function Stat({ value, label }) {
+    return (
+        <div>
+            <p
+                className="font-display text-2xl font-semibold text-ink"
+                style={numStyle}
+            >
+                {value}
+            </p>
+            <p className="mt-1 text-sm text-ink-2">{label}</p>
+        </div>
+    )
+}
+
+export default function BenchmarkCharts({ dataset, runs = 500 }) {
+    const { compiled, agent } = dataset
+    const ids = {
+        latT: useId(),
+        latD: useId(),
+        costT: useId(),
+        costD: useId(),
+    }
+    const speedup = (agent.wall_s_p50 / compiled.wall_s_p50).toFixed(1)
+    return (
+        <div className="mt-5">
+            <div className="grid gap-6 sm:grid-cols-3">
+                <Stat
+                    value={`${speedup}× faster`}
+                    label={`median run: ${fmtSec(compiled.wall_s_p50)} compiled vs ${fmtSec(
+                        agent.wall_s_p50
+                    )} agent`}
+                />
+                <Stat
+                    value={`${fmtCost(compiled.cost_usd_per_run)} vs ${fmtCost(
+                        agent.cost_usd_per_run
+                    )}`}
+                    label="model cost per run, at list price"
+                />
+                <Stat
+                    value={`${compiled.model_calls_per_run} vs ~${agent.model_calls_per_run}`}
+                    label="model calls per run"
+                />
+            </div>
+            <div className="mt-6 grid gap-x-8 gap-y-6 md:grid-cols-2">
+                <figure className="rounded-xl border border-hairline bg-ground/60 p-4">
+                    <figcaption className="eyebrow mb-3">
+                        Latency per run
+                    </figcaption>
+                    <LatencyChart
+                        compiled={compiled}
+                        agent={agent}
+                        titleId={ids.latT}
+                        descId={ids.latD}
+                    />
+                </figure>
+                <figure className="rounded-xl border border-hairline bg-ground/60 p-4">
+                    <figcaption className="eyebrow mb-3">
+                        Model cost per run
+                    </figcaption>
+                    <CostChart
+                        compiled={compiled}
+                        agent={agent}
+                        runs={runs}
+                        titleId={ids.costT}
+                        descId={ids.costD}
+                    />
+                    <p className="sr-only">
+                        Compiled {fmtCost(compiled.cost_usd_per_run)} per run;
+                        agent {fmtCost(agent.cost_usd_per_run)} per run.
+                    </p>
+                </figure>
+            </div>
+        </div>
+    )
+}

--- a/data/benchmark.json
+++ b/data/benchmark.json
@@ -1,0 +1,76 @@
+{
+    "_comment": "Figures copied VERBATIM from the openadapt-flow benchmark results.json files. Do NOT hand-edit values here; regenerate from source. The /compare charts render from this file so the published numbers cannot silently drift from the measured results.",
+    "provenance": {
+        "source_repo": "OpenAdaptAI/openadapt-flow",
+        "commit": "cbec44c2c2f355d5cc04a72ea9267e2d6ea68ac6",
+        "committed": "2026-07-09",
+        "model": "claude-sonnet-5",
+        "computer_tool": "computer_20251124",
+        "beta_header": "computer-use-2025-11-24",
+        "platform": "macOS-15.7.3-arm64-arm-64bit",
+        "pricing_note": "Model cost computed at list price ($3/$15 per Mtok in/out); an introductory $2/$10 rate applies through 2026-08-31.",
+        "sources": [
+            {
+                "file": "benchmark/openemr/results.json",
+                "generated_at": "2026-07-08T22:46:39Z",
+                "url": "https://github.com/OpenAdaptAI/openadapt-flow/blob/main/benchmark/openemr/results.json"
+            },
+            {
+                "file": "benchmark/results.json",
+                "generated_at": "2026-07-08T15:46:40Z",
+                "url": "https://github.com/OpenAdaptAI/openadapt-flow/blob/main/benchmark/results.json"
+            }
+        ]
+    },
+    "openemr": {
+        "label": "OpenEMR (real app, live demo)",
+        "task": "18-step add-patient-note workflow on the official OpenEMR public demo: log in, search the demo patient, open the chart, scroll to the Messages card, add a parameterized note, save.",
+        "workflow_steps": 18,
+        "methodology_url": "https://github.com/OpenAdaptAI/openadapt-flow/blob/main/benchmark/openemr/BENCHMARK.md",
+        "results_url": "https://github.com/OpenAdaptAI/openadapt-flow/blob/main/benchmark/openemr/results.json",
+        "compiled": {
+            "n": 20,
+            "success_count": 20,
+            "wall_s_p50": 39.170917561999886,
+            "wall_s_p95": 41.04867044315233,
+            "cost_usd_per_run": 0.0,
+            "model_calls_per_run": 0,
+            "actions_mean": 18.0
+        },
+        "agent": {
+            "n": 10,
+            "success_count": 10,
+            "wall_s_p50": 70.44607112499943,
+            "wall_s_p95": 82.59687604810188,
+            "cost_usd_per_run": 0.552150765,
+            "model_calls_per_run": 24,
+            "actions_mean": 23.8
+        },
+        "caveats": "The OpenEMR demo is a shared public instance that anyone can modify and that resets daily, so this is a field result, not a CI-reproducible one. The agent arm is N=10 (agent runs cost real money and load on a shared service), so its 100% carries wide error bars. Success is judged by one arm-independent OCR check for both arms, never self-report. Pinned to claude-sonnet-5 with the computer_20251124 tool on 2026-07-08; newer models will differ."
+    },
+    "mockmed": {
+        "label": "MockMed (CI-reproducible anchor)",
+        "task": "MockMed triage: log in, open the first referral, create a Triage encounter, enter the note, save. Ships with openadapt-flow, so anyone can rerun it deterministically.",
+        "methodology_url": "https://github.com/OpenAdaptAI/openadapt-flow/blob/main/benchmark/BENCHMARK.md",
+        "results_url": "https://github.com/OpenAdaptAI/openadapt-flow/blob/main/benchmark/results.json",
+        "compiled": {
+            "n": 100,
+            "success_count": 100,
+            "wall_s_p50": 4.9309526044999075,
+            "wall_s_p95": 5.055971199399937,
+            "cost_usd_per_run": 0.0,
+            "model_calls_per_run": 0,
+            "actions_mean": 11.0
+        },
+        "agent": {
+            "n": 20,
+            "success_count": 20,
+            "wall_s_p50": 37.492187666500286,
+            "wall_s_p95": 43.44962514519993,
+            "cost_usd_per_run": 0.27155505,
+            "model_calls_per_run": 24,
+            "actions_mean": 12.0
+        },
+        "caveats": "Deterministic and CI-reproducible: 100 compiled replays vs 20 agent runs. Same orchestrator, same agent setup, same style of arm-independent OCR check as OpenEMR. Both arms succeed 100% of the time; the difference is cost and latency per run. Parity on success is not a capability claim — the agent does not fail here."
+    }
+}

--- a/pages/compare.js
+++ b/pages/compare.js
@@ -2,6 +2,8 @@ import Head from 'next/head'
 import Link from 'next/link'
 
 import Footer from '@components/Footer'
+import BenchmarkCharts from '@components/BenchmarkCharts'
+import benchmark from '../data/benchmark.json'
 
 const webPageSchema = {
     '@context': 'https://schema.org',
@@ -274,32 +276,10 @@ export default function ComparePage() {
                         agent. The agent doesn&#39;t fail here. The difference
                         is what each run costs.
                     </p>
-                    <div className="mt-5 grid gap-6 sm:grid-cols-3">
-                        <div>
-                            <p className="font-display text-2xl font-semibold text-ink">
-                                1.8&times; faster
-                            </p>
-                            <p className="mt-1 text-sm text-ink-2">
-                                median run: 39.2s compiled vs 70.4s agent
-                            </p>
-                        </div>
-                        <div>
-                            <p className="font-display text-2xl font-semibold text-ink">
-                                $0 vs $0.55
-                            </p>
-                            <p className="mt-1 text-sm text-ink-2">
-                                model cost per run, at list price
-                            </p>
-                        </div>
-                        <div>
-                            <p className="font-display text-2xl font-semibold text-ink">
-                                0 vs ~24
-                            </p>
-                            <p className="mt-1 text-sm text-ink-2">
-                                model calls per run
-                            </p>
-                        </div>
-                    </div>
+                    <BenchmarkCharts
+                        dataset={benchmark.openemr}
+                        runs={500}
+                    />
                     <p className="mt-5 text-sm leading-relaxed text-ink-2 md:text-base">
                         Run the task 500 times and the ratios compound: about
                         $275 and ten hours of wall clock through the agent,
@@ -343,9 +323,16 @@ export default function ComparePage() {
                         the demo clinic app that ships with openadapt-flow,
                         as the benchmark anyone can rerun deterministically:
                         100 compiled replays against 20 agent runs, both arms
-                        100%, 4.9s vs 37.5s median, $0 vs $0.27 per run at
-                        list price. Same orchestrator, same agent setup,
-                        same style of OCR check.
+                        100%. Same orchestrator, same agent setup, same style
+                        of OCR check. The same shape of result, on a substrate
+                        you can reproduce:
+                    </p>
+                    <BenchmarkCharts
+                        dataset={benchmark.mockmed}
+                        runs={500}
+                    />
+                    <p className="mt-4 text-xs leading-relaxed text-ink-3">
+                        {benchmark.mockmed.caveats}
                     </p>
                     <p className="mt-3 text-sm leading-relaxed text-ink-2 md:text-base">
                         On the same setup under injected UI drift, a hybrid


### PR DESCRIPTION
## What

Upgrades `/compare` from **stating** the benchmark numbers as static prose to **showing** them as native inline-SVG charts wired to the real measured results, so the published figures can't silently drift from what was benchmarked.

## Charts added

Two chart types, for both the **OpenEMR lead result** (real live app) and the **MockMed CI-reproducible anchor**:

- **Latency per run** — horizontal bars, compiled vs computer-use agent, on a shared axis. Solid bar = median (p50), light track + tick = p95.
- **Model cost per run** — `$0` pinned at an emphasized zero endpoint ("every run, forever") vs the agent's `$/run` bar, with a `×500 runs` compounding caption.

Plus the existing headline stat readouts (`1.8× faster`, `$0 vs $0.55`, `0 vs ~24`) kept and now computed from data.

## Real data + provenance

All figures come from the **openadapt-flow** benchmark results, copied verbatim into the new `data/benchmark.json` (never hand-typed into markup):

- `benchmark/openemr/results.json` — OpenEMR: 39.2s/70.4s p50, 41.0s/82.6s p95, `$0`/`$0.55`, 20/20 vs 10/10
- `benchmark/results.json` — MockMed: 4.9s/37.5s p50, `$0`/`$0.27`, 100/100 vs 20/20

Provenance (source repo, commit `cbec44c`, `claude-sonnet-5` + `computer_20251124` pins, list-price note) and the honest caveats text are recorded alongside the figures in the data file.

## Honest caveats retained

The existing caveats are kept and **foregrounded next to the charts**, not dropped: small-n agent arms, OpenEMR being a live shared field result (not CI-reproducible), list-vs-intro pricing, and parity-on-success is not a capability claim. This is the "we show, not claim" upgrade — no new claims added.

## Quality

- `npm run build` passes; `/compare` = 9.3 kB (light, inline SVG only — no base64 / heavy assets).
- Charts are accessible (`role="img"` + `<title>`/`<desc>`), use `tabular-nums`, and are **theme-aware** (every color is a CSS design token, verified rendering correctly under both light and a dark `:root`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKrVJJy5jWVCkXAqgUqtqZ