### PR TITLE
feat: API-less-compiler positioning + verify /compare and /safety fidelity

### DIFF
--- a/components/MastHead.js
+++ b/components/MastHead.js
@@ -95,9 +95,16 @@ export default function Home({ githubStats }) {
                             </h1>
                             <p className="mt-0 mb-6 mx-auto max-w-3xl font-sans font-normal text-base md:text-lg text-ink-2">
                                 OpenAdapt compiles a recorded demonstration into
-                                a self-healing automation. It&apos;s open source
-                                and auditable, and it runs entirely on your own
-                                machines.
+                                a self-healing automation that halts rather than
+                                guessing. It&apos;s open source and auditable, and
+                                it runs entirely on your own machines.
+                            </p>
+                            <p className="mt-0 mb-6 mx-auto max-w-3xl font-sans font-normal text-base md:text-lg text-ink-3">
+                                Think of it as an API compiler for the API-less
+                                long tail &mdash; the legacy EMRs and Citrix
+                                estates a real integration never reached. Where a
+                                real API already exists, use it; that&apos;s the
+                                better tool.
                             </p>
                             <div className="flex flex-col align-center justify-center px-4 min-w-0 max-w-full overflow-hidden">
                                 <ReplayHero />

--- a/pages/compare.js
+++ b/pages/compare.js
@@ -429,7 +429,7 @@ export default function ComparePage() {
 
                 <div className="mt-12 rounded-2xl border border-hairline bg-panel p-6 md:p-8">
                     <h2 className="font-display text-xl font-semibold tracking-tight text-ink">
-                        Where agents beat us
+                        Where another tool is the better fit
                     </h2>
                     <p className="mt-3 text-sm leading-relaxed text-ink-2 md:text-base">
                         We&#39;d rather tell you this than have you find out
@@ -442,6 +442,15 @@ export default function ComparePage() {
                         opposite case: work your team does the same way, over
                         and over, where repeatability and cost matter more than
                         improvisation.
+                    </p>
+                    <p className="mt-3 text-sm leading-relaxed text-ink-2 md:text-base">
+                        And where a real, stable API already exists for the
+                        system you&#39;re driving, use it &mdash; a direct
+                        integration beats driving a GUI every time. OpenAdapt is
+                        an API compiler for the API-less long tail: the legacy
+                        EMRs, Citrix estates, and desktop systems where the
+                        integration you&#39;d want was never shipped, so a
+                        recorded demonstration is the only interface you have.
                     </p>
                 </div>
 


### PR DESCRIPTION
## Summary

Launch-prep for the two proof pages built from our published artifacts, plus the reviews' convergent positioning.

**Important context:** the native `/compare` and `/safety` pages the task calls for **already landed on `main`** (via #133 / #151 and their supporting PRs — parallel launch work). I verified both against the published proof artifacts and they are faithful and correct:

- **`/compare`** — `components/BenchmarkCharts.js` renders native inline-SVG latency + cost charts from `data/benchmark.json`, which is copied **verbatim** from `openadapt-flow`'s `benchmark/openemr/results.json` and `benchmark/results.json` (provenance + commit pinned in the JSON). Numbers match the artifact exactly: OpenEMR 20/20 vs 10/10, $0 vs $0.55/run, 39.2s vs 70.4s p50 (1.8×); MockMed 100/100 vs 20/20, $0 vs $0.27/run, 4.9s vs 37.5s. Includes the hybrid result and the full honest-caveats block.
- **`/safety`** — `components/SafetyGallery.js` + `data/safetyCases.js`: 5 look-alike traps refused + 2 controls handled, real OCR strings, the shipping `verify_target_identity` verdicts, and the "what it does NOT protect against" limits (4 of 12 armed click steps; 5 of 7 transactional fault classes over 90 replays; 43.6–49.3% false-abort; no collision in 14 UI fonts) — all matching the artifact.

So this PR does **not** rebuild those pages. It closes the **one remaining gap** vs the reviews' convergent framing that was not yet on the site: OpenAdapt as **"an API compiler for the API-less long tail."**

## Changes
- **Hero (`components/MastHead.js`)** — compiles a demonstration into a self-healing automation that **"halts rather than guessing"**; adds the API-less-long-tail framing (legacy EMRs, Citrix estates) and the honest line: *where a real API already exists, use it — that's the better tool.*
- **`/compare` (`pages/compare.js`)** — broadens the honesty box heading to **"Where another tool is the better fit"** and adds the real-API caveat next to the existing "where agents beat us" copy.

No published numbers were touched. Standing rule respected: no enterprise customers or competitors named.

## Verification
- `npm run build` passes; `/compare` and `/safety` prerender as static.
- Existing 4-space repo style preserved (repo is not prettier-formatted on `main`; running `--write` would reformat wholesale, so it was intentionally not run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKrVJJy5jWVCkXAqgUqtqZ