### PR TITLE
copy: rewrite hero second paragraph (drop self-undercut, plain problem framing)

### DIFF
--- a/components/MastHead.js
+++ b/components/MastHead.js
@@ -100,11 +100,12 @@ export default function Home({ githubStats }) {
                                 it runs entirely on your own machines.
                             </p>
                             <p className="mt-0 mb-6 mx-auto max-w-3xl font-sans font-normal text-base md:text-lg text-ink-3">
-                                Think of it as an API compiler for the API-less
-                                long tail &mdash; the legacy EMRs and Citrix
-                                estates a real integration never reached. Where a
-                                real API already exists, use it; that&apos;s the
-                                better tool.
+                                Built for the repetitive work trapped in the
+                                systems no integration ever reached &mdash;
+                                legacy EMRs, Citrix desktops, and the
+                                line-of-business apps your team still runs by
+                                hand. Where a demonstration is the only way in,
+                                that&apos;s where OpenAdapt works.
                             </p>
                             <div className="flex flex-col align-center justify-center px-4 min-w-0 max-w-full overflow-hidden">
                                 <ReplayHero />


### PR DESCRIPTION
Reviewed the site copy against 2026 B2B landing-page best practices (5-second clarity, outcome-driven, lead with the buyer's problem). Fixed the clear miss: the hero's second paragraph used insider framing ('API-less long tail') and *recommended a competitor* ('where a real API exists, use it; that's the better tool') at the top of the funnel. That honest candor is good — but it belongs on /compare (where it already is), not in the hero. Rewrote it as a plain statement of the buyer's problem.

More to come on this branch (How-it-works demo clips, pricing section) as those land.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>