### PR TITLE
feat: pricing section (OSS / Hosted / Enterprise; value-priced, no per-step COGS exposed)

### DIFF
--- a/components/NavHeader.js
+++ b/components/NavHeader.js
@@ -16,6 +16,7 @@ const NAV_LINKS = [
     { label: 'Lending', href: '/solutions/lending' },
     { label: 'Safety', href: '/safety' },
     { label: 'Compare', href: '/compare' },
+    { label: 'Pricing', href: '/#pricing' },
     { label: 'About', href: '/about' },
     {
         label: 'Open source',

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -1,0 +1,181 @@
+import Link from 'next/link'
+
+/*
+ * Pricing — three lanes, value-priced.
+ *
+ * Enterprise is the primary (visually recommended) card: on-prem, PHI never
+ * leaves the building, inference runs on the customer's hardware at zero
+ * metered cost. Hosted is a secondary, non-PHI / evaluation on-ramp priced on
+ * outcome units (workflow-runs), never per-step / per-seat / per-VLM-call. OSS
+ * stays MIT and honest.
+ *
+ * Deliberately NOT shown anywhere: $/step, $/VLM-call, per-seat, or a raw
+ * $/run meter. We price the outcome and the compliance; inference is bundled.
+ */
+
+const GITHUB_URL = 'https://github.com/OpenAdaptAI/OpenAdapt'
+
+function Check() {
+    return (
+        <span
+            aria-hidden="true"
+            className="mt-[2px] flex-shrink-0 font-mono text-accent"
+        >
+            ✓
+        </span>
+    )
+}
+
+function FeatureList({ items }) {
+    return (
+        <ul className="mt-5 flex flex-col gap-2.5 text-sm leading-relaxed text-ink-2">
+            {items.map((item) => (
+                <li key={item} className="flex gap-2.5">
+                    <Check />
+                    <span>{item}</span>
+                </li>
+            ))}
+        </ul>
+    )
+}
+
+export default function Pricing() {
+    return (
+        <section
+            id="pricing"
+            className="border-t-2 border-ink bg-ground px-5 py-16 md:py-20"
+        >
+            <div className="mx-auto max-w-5xl">
+                <p className="eyebrow text-center">Pricing</p>
+                <h2 className="mx-auto mt-2 max-w-2xl text-center font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl">
+                    Priced on the outcome, not the click
+                </h2>
+                <p className="mx-auto mt-3 max-w-xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
+                    The engine is open source and free. When you need it in
+                    production, inference is bundled in — no per-step, per-seat,
+                    or per-model-call metering. On-prem keeps your data in your
+                    building.
+                </p>
+
+                <div className="mt-10 grid items-start gap-6 md:grid-cols-3">
+                    {/* Card 1 — Open Source */}
+                    <div className="flex h-full flex-col rounded-2xl border border-hairline bg-panel p-6 md:p-7">
+                        <p className="eyebrow">Open Source</p>
+                        <div className="mt-2 flex items-baseline gap-2">
+                            <span className="font-display text-2xl font-semibold tracking-tight text-ink">
+                                Free
+                            </span>
+                            <span className="text-sm text-ink-3">MIT</span>
+                        </div>
+                        <p className="mt-3 text-sm leading-relaxed text-ink-2">
+                            For builders and self-hosters who want it running on
+                            their own machines.
+                        </p>
+                        <FeatureList
+                            items={[
+                                'Record → compile → replay, fully local',
+                                'Self-healing scripts, reviewable as diffs',
+                                'Self-host for full auditability',
+                                'The engine is MIT and always will be',
+                            ]}
+                        />
+                        <div className="mt-6 flex-grow" />
+                        <a
+                            href={GITHUB_URL}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="btn-ghost-ink w-full text-center"
+                        >
+                            View on GitHub
+                        </a>
+                        <p className="mt-3 text-center font-mono text-xs text-ink-3">
+                            pip install openadapt-flow
+                        </p>
+                    </div>
+
+                    {/* Card 2 — Hosted */}
+                    <div className="flex h-full flex-col rounded-2xl border border-hairline bg-panel p-6 md:p-7">
+                        <p className="eyebrow">Hosted</p>
+                        <div className="mt-2 flex items-baseline gap-2">
+                            <span className="font-display text-2xl font-semibold tracking-tight text-ink">
+                                Flat base
+                            </span>
+                            <span className="text-sm text-ink-3">
+                                + run volume
+                            </span>
+                        </div>
+                        <p className="mt-3 text-sm leading-relaxed text-ink-2">
+                            For teams without on-prem hardware who want a managed
+                            cloud runner.
+                        </p>
+                        <FeatureList
+                            items={[
+                                'Managed cloud runner — nothing to operate',
+                                'Flat platform fee + a workflow-run volume band',
+                                'Hosted inference included',
+                                'No per-step, per-seat, or surprise metering',
+                            ]}
+                        />
+                        <div className="mt-4 rounded-lg border border-hairline bg-ground p-3 text-xs leading-relaxed text-ink-3">
+                            For non-PHI / evaluation workloads. Handling PHI or
+                            PII?{' '}
+                            <a
+                                href="#pricing-enterprise"
+                                className="text-accent underline"
+                            >
+                                See Enterprise
+                            </a>{' '}
+                            — your data stays in your building.
+                        </div>
+                        <div className="mt-6 flex-grow" />
+                        <Link
+                            href="/#book"
+                            className="btn-ghost-ink w-full text-center"
+                        >
+                            Get early access
+                        </Link>
+                    </div>
+
+                    {/* Card 3 — Enterprise (primary / recommended) */}
+                    <div
+                        id="pricing-enterprise"
+                        className="relative flex h-full flex-col rounded-2xl border-2 border-ink bg-panel p-6 shadow-[0_8px_32px_rgba(35,40,31,0.10)] md:p-7"
+                    >
+                        <span className="absolute -top-3 left-6 rounded-full bg-ink px-3 py-1 font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-ground">
+                            Recommended
+                        </span>
+                        <p className="eyebrow">Enterprise</p>
+                        <div className="mt-2 flex items-baseline gap-2">
+                            <span className="font-display text-2xl font-semibold tracking-tight text-ink">
+                                Talk to us
+                            </span>
+                        </div>
+                        <p className="mt-3 text-sm leading-relaxed text-ink-2">
+                            For regulated teams — healthcare, lending, and other
+                            compliance-bound back-offices.
+                        </p>
+                        <FeatureList
+                            items={[
+                                'On-premises deployment — PHI never leaves the building',
+                                'Inference runs on your hardware at zero metered cost',
+                                'Paid pilot → annual platform license',
+                                'BAA, SOC 2, credential vault, and audit trail',
+                                'Self-healing and fleet management included',
+                            ]}
+                        />
+                        <div className="mt-6 flex-grow" />
+                        <Link href="/#book" className="btn-ink w-full text-center">
+                            Book a demo
+                        </Link>
+                    </div>
+                </div>
+
+                <p className="mx-auto mt-8 max-w-2xl text-center text-xs leading-relaxed text-ink-3">
+                    We price the workflow outcome and the compliance, and bundle
+                    the inference. No per-step, per-seat, or per-model-call
+                    charges anywhere.
+                </p>
+            </div>
+        </section>
+    )
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -9,6 +9,7 @@ import Footer from '@components/Footer'
 import HowItWorks from '@components/HowItWorks'
 import IndustriesGrid from '@components/IndustriesGrid'
 import MastHead from '@components/MastHead'
+import Pricing from '@components/Pricing'
 import ProofBand from '@components/ProofBand'
 import SafetyBand from '@components/SafetyBand'
 // import SocialSection from '@components/SocialSection' // Temporarily disabled - feeds not working
@@ -222,6 +223,7 @@ export default function Home({ githubStats }) {
                     Book a pilot →
                 </a>
             </div>
+            <Pricing />
             <Developers />
             {/* <SocialSection /> */} {/* Temporarily disabled - feeds not working */}
             <Faq />

--- a/pages/pricing.js
+++ b/pages/pricing.js
@@ -1,0 +1,29 @@
+import Head from 'next/head'
+
+import ContactBookingSection from '@components/ContactBookingSection'
+import Footer from '@components/Footer'
+import Pricing from '@components/Pricing'
+
+export default function PricingPage() {
+    return (
+        <div className="min-h-screen bg-ground text-ink">
+            <Head>
+                <title>Pricing | OpenAdapt.AI</title>
+                <meta
+                    name="description"
+                    content="OpenAdapt pricing: the open-source engine is free (MIT), a hosted runner for non-PHI teams, and on-premises Enterprise where PHI never leaves your building and inference runs on your hardware at zero metered cost. No per-step, per-seat, or per-model-call charges."
+                />
+                <link rel="canonical" href="https://openadapt.ai/pricing" />
+                <meta property="og:title" content="Pricing | OpenAdapt.AI" />
+                <meta
+                    property="og:description"
+                    content="Open source and free. Hosted for teams without on-prem hardware. Enterprise on-prem where your data stays in your building — inference bundled, never metered per step or per seat."
+                />
+                <meta property="og:url" content="https://openadapt.ai/pricing" />
+            </Head>
+            <Pricing />
+            <ContactBookingSection />
+            <Footer />
+        </div>
+    )
+}


### PR DESCRIPTION
## What

Adds a **Pricing** section to the marketing site — three value-priced lanes, following the pricing strategy (never expose per-step / per-VLM / per-seat / raw \$/run COGS).

Rendered on the home page (after the industries block, before the developer/CTA sections) with `id="pricing"`, plus a dedicated **`/pricing`** page (SEO Head + booking) and a **Pricing** nav link.

## The three cards

| Card | Who it's for | CTA |
|---|---|---|
| **Open Source · Free (MIT)** | Builders / self-hosters | View on GitHub (`pip install openadapt-flow`) |
| **Hosted · Flat base + run volume** | Teams without on-prem hardware — carries a visible **"non-PHI / evaluation"** boundary | Get early access (→ `#book`) |
| **Enterprise · Talk to us** *(primary / "Recommended")* | Regulated teams (healthcare, lending) — on-prem, **PHI never leaves the building**, **\$0 metered inference** | Book a demo (→ `#book`) |

Enterprise is the visually primary lane (`border-2 border-ink` + shadow + "Recommended" badge), matching the existing highlighted-panel pattern in `compare.js`.

## Guardrails honored
- No `$/step`, `$/VLM-call`, per-seat, or raw `$/run` meter anywhere.
- Reassurance surfaced: inference **bundled/included**, on-prem keeps **data in your building** — without exposing the COGS math.
- Outcome-unit (workflow-run) volume bands only.

## Design / build
- Matches the paper-terminal design language: custom tokens (`ground`/`panel`/`ink`/`ink-2`/`ink-3`/`hairline`/`accent`), `eyebrow` / `btn-ink` / `btn-ghost-ink`, `font-display`.
- Theme-aware, responsive, mobile-first (`md:grid-cols-3` → single column on mobile).
- `npm run build` passes; `/` and `/pricing` prerender clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKrVJJy5jWVCkXAqgUqtqZ