### PR TITLE
copy: unify install + quickstart on `pip install openadapt` / `openadapt flow …`

### DIFF
--- a/components/InstallSection.js
+++ b/components/InstallSection.js
@@ -175,28 +175,27 @@ export default function InstallSection() {
                 <div className={styles.commandGrid}>
                     <div className={styles.commandItem}>
                         <code>
-                            pip install openadapt-flow && playwright install
-                            chromium
+                            pip install openadapt
                         </code>
                         <span>Install the demonstration compiler</span>
                     </div>
                     <div className={styles.commandItem}>
-                        <code>openadapt-flow demo-record --out rec</code>
+                        <code>openadapt flow demo-record --out rec</code>
                         <span>Record a demonstration</span>
                     </div>
                     <div className={styles.commandItem}>
                         <code>
-                            openadapt-flow compile rec --out bundle --name
+                            openadapt flow compile rec --out bundle --name
                             my-task
                         </code>
                         <span>Compile it into an editable workflow</span>
                     </div>
                     <div className={styles.commandItem}>
-                        <code>openadapt-flow replay bundle</code>
+                        <code>openadapt flow replay bundle</code>
                         <span>Replay: local, with zero model calls</span>
                     </div>
                     <div className={styles.commandItem}>
-                        <code>openadapt-flow replay bundle --drift theme</code>
+                        <code>openadapt flow replay bundle --drift theme</code>
                         <span>Drift the UI and watch it heal itself</span>
                     </div>
                 </div>

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -89,7 +89,7 @@ export default function Pricing() {
                             View on GitHub
                         </a>
                         <p className="mt-3 text-center font-mono text-xs text-ink-3">
-                            pip install openadapt-flow
+                            pip install openadapt
                         </p>
                     </div>
 


### PR DESCRIPTION
Updates the site install + quickstart copy to the unified CLI now that it's shipped.

- \`pip install openadapt-flow && playwright install\` → **\`pip install openadapt\`** (single command; chromium is auto-provisioned on first run by openadapt-flow's \`ensure_chromium_installed()\`, wired into the record / demo-record / replay entrypoints — no separate \`playwright install\` step).
- \`openadapt-flow demo-record|compile|replay\` → **\`openadapt flow demo-record|compile|replay\`** (matches the mounted \`flow\` command group).
- Pricing OSS card install line → \`pip install openadapt\`.

Live as of openadapt v1.5.0 (mounts \`openadapt flow demo-record\`, OpenAdapt#1010).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKrVJJy5jWVCkXAqgUqtqZ