### PR TITLE
fix: honest claims — security page, benchmark framing, install prerequisites, hosted-tier status

### DIFF
--- a/components/Faq.js
+++ b/components/Faq.js
@@ -13,7 +13,7 @@ export const faqItems = [
     },
     {
         question: 'Does my data leave my machines?',
-        answer: 'No. OpenAdapt is local-first by architecture: recordings, compiled scripts, and replays all stay on your own infrastructure. Nothing is uploaded to run an automation. PII/PHI scrubbing tooling is included for teams that need to sanitize captured data before anyone (human or model) sees it.',
+        answer: 'It stays inside your network. OpenAdapt is local-first by architecture: recordings, compiled scripts, and replays live on your own infrastructure, and on the default path a healthy run makes no cloud calls at all, so nothing leaves your machine. When the UI drifts, healing calls a model; you can run that model on your own hardware or an appliance inside your network, so the data stays within your perimeter rather than going to a third party. PII/PHI scrubbing tooling is included for teams that need to sanitize captured data before anyone (human or model) sees it.',
     },
     {
         question: 'Is OpenAdapt free?',

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -107,6 +107,9 @@ export default function Footer() {
                         </a>
                     </div>
                     <div className={styles.footerLinks}>
+                        <a href="/security" className={styles.link}>
+                            Security
+                        </a>{' '}
                         <a href="/privacy-policy" className={styles.link}>
                             Privacy Policy
                         </a>{' '}

--- a/components/InstallSection.js
+++ b/components/InstallSection.js
@@ -169,13 +169,17 @@ export default function InstallSection() {
                 </h4>
                 <p className={styles.note} style={{ marginBottom: '0.75rem' }}>
                     Try record → compile → replay → heal right now against the
-                    bundled demo app. No account, no cloud, nothing leaves
-                    your machine.
+                    bundled demo app. No account and no cloud service: once it is
+                    installed, your workflow data stays on your machine. One
+                    heads-up on first run: the first <code>demo-record</code> or{' '}
+                    <code>replay</code> downloads a bundled Chromium (~150&nbsp;MB)
+                    once, so that step takes a few minutes, and on Linux you may
+                    need <code>playwright install-deps</code> first.
                 </p>
                 <div className={styles.commandGrid}>
                     <div className={styles.commandItem}>
                         <code>
-                            pip install openadapt
+                            curl -fsSL https://openadapt.ai/install.sh | sh
                         </code>
                         <span>Install the demonstration compiler</span>
                     </div>

--- a/components/MastHead.js
+++ b/components/MastHead.js
@@ -13,7 +13,7 @@ const CarouselSection = () => {
         "Show it once. It runs forever. On your premises.",
         "Compiled replay. Zero per-run model cost.",
         "Self-healing: UI drift becomes a reviewable diff.",
-        "Your data never leaves the building.",
+        "On the default path, nothing leaves your machine.",
     ];
 
     useEffect(() => {

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -93,8 +93,11 @@ export default function Pricing() {
                         </p>
                     </div>
 
-                    {/* Card 2 — Hosted */}
-                    <div className="flex h-full flex-col rounded-2xl border border-hairline bg-panel p-6 md:p-7">
+                    {/* Card 2 — Hosted (preview / waitlist, not yet live) */}
+                    <div className="relative flex h-full flex-col rounded-2xl border border-hairline bg-panel p-6 md:p-7">
+                        <span className="absolute -top-3 left-6 rounded-full border border-hairline bg-ground px-3 py-1 font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-ink-2">
+                            Preview · join the waitlist
+                        </span>
                         <p className="eyebrow">Hosted</p>
                         <div className="mt-2 flex items-baseline gap-2">
                             <span className="font-display text-2xl font-semibold tracking-tight text-ink">
@@ -106,7 +109,8 @@ export default function Pricing() {
                         </div>
                         <p className="mt-3 text-sm leading-relaxed text-ink-2">
                             For teams without on-prem hardware who want a managed
-                            cloud runner.
+                            cloud runner. Not live yet: this is a preview, and
+                            the price shown is what it will cost at launch.
                         </p>
                         <FeatureList
                             items={[
@@ -132,7 +136,7 @@ export default function Pricing() {
                             href="/#book"
                             className="btn-ghost-ink w-full text-center"
                         >
-                            Get early access
+                            Join the waitlist
                         </Link>
                     </div>
 
@@ -159,10 +163,22 @@ export default function Pricing() {
                                 'On-premises deployment — PHI never leaves the building',
                                 'Inference runs on your hardware at zero metered cost',
                                 'Paid pilot → annual platform license',
-                                'BAA, SOC 2, credential vault, and audit trail',
+                                'On-prem architecture built for BAA and SOC 2 requirements; formal attestation in progress',
+                                'Audit trail: every run writes an illustrated report',
                                 'Self-healing and fleet management included',
                             ]}
                         />
+                        <div className="mt-4 rounded-lg border border-hairline bg-ground p-3 text-xs leading-relaxed text-ink-3">
+                            Read our{' '}
+                            <Link
+                                href="/security"
+                                className="text-accent underline"
+                            >
+                                security posture
+                            </Link>
+                            : on-prem data handling, what is and isn&apos;t
+                            certified yet, and how to report a vulnerability.
+                        </div>
                         <div className="mt-6 flex-grow" />
                         <Link href="/#book" className="btn-ink w-full text-center">
                             Book a demo

--- a/components/ProofBand.js
+++ b/components/ProofBand.js
@@ -1,21 +1,30 @@
 import Link from 'next/link'
 
+import benchmark from '../data/benchmark.json'
 import styles from './ProofBand.module.css'
 
-const BENCHMARK_URL =
-    'https://github.com/OpenAdaptAI/openadapt-flow/blob/main/benchmark/openemr/BENCHMARK.md'
+// Numbers are read from data/benchmark.json (copied verbatim from the
+// openadapt-flow benchmark results) so the band cannot drift from the measured
+// results. The reproducible MockMed anchor leads; OpenEMR is a labelled field
+// cross-check. Both benchmarks show a cost-and-latency gap, not a reliability
+// gap: both arms pass every run.
+const mm = benchmark.mockmed
+const em = benchmark.openemr
+
+const secs = (s) => `${Math.round(s)}s`
+const cost = (c) => (c === 0 ? '$0' : `$${c.toFixed(2)}`)
 
 const stats = [
     {
-        figure: '39s vs 70s',
+        figure: `${secs(mm.compiled.wall_s_p50)} vs ${secs(mm.agent.wall_s_p50)}`,
         caption: 'median run, compiled replay vs computer-use agent',
     },
     {
-        figure: '$0 vs $0.55',
-        caption: 'model cost per run',
+        figure: `${cost(mm.compiled.cost_usd_per_run)} vs ${cost(mm.agent.cost_usd_per_run)}`,
+        caption: 'model cost per run (agent priced at list rate)',
     },
     {
-        figure: '0 vs ~24',
+        figure: `${mm.compiled.model_calls_per_run} vs ${mm.agent.model_calls_per_run}`,
         caption: 'model calls per run: the hot path is model-free',
     },
 ]
@@ -24,7 +33,9 @@ export default function ProofBand() {
     return (
         <section className={styles.section}>
             <div className={styles.inner}>
-                <p className="eyebrow">Real EMR · measured 2026-07-08</p>
+                <p className="eyebrow">
+                    MockMed benchmark · reproducible · cost and latency
+                </p>
                 <div className={styles.grid}>
                     {stats.map((stat) => (
                         <div key={stat.figure} className={styles.card}>
@@ -34,14 +45,25 @@ export default function ProofBand() {
                     ))}
                 </div>
                 <p className={styles.note}>
-                    Same 18-step task on the live OpenEMR demo, one success
-                    check for both. Both finished every run; the difference is
-                    what each run costs you.
+                    Same clinical task run both ways on MockMed, the demo app that
+                    ships with openadapt-flow so anyone can rerun it
+                    deterministically ({mm.compiled.n} compiled replays vs{' '}
+                    {mm.agent.n} agent runs). Both arms passed the same
+                    arm-independent check every time, so this is a cost-and-latency
+                    gap, not a reliability gap. Agent cost is shown at list price;
+                    an introductory model rate lowers it through 2026-08-31.
+                </p>
+                <p className={styles.note}>
+                    We also ran it on the live OpenEMR public demo (N=
+                    {em.agent.n} agent runs, both arms 100%). That is a field
+                    result on a shared instance that resets daily, so it is not
+                    independently reproducible, it is cost-and-latency only, and it
+                    implies nothing about reliability on a real EMR.
                 </p>
                 <div className={styles.links}>
                     <Link href="/compare">How we measured it →</Link>
                     <a
-                        href={BENCHMARK_URL}
+                        href={mm.methodology_url}
                         target="_blank"
                         rel="noopener noreferrer"
                     >

--- a/pages/compare.js
+++ b/pages/compare.js
@@ -264,17 +264,66 @@ export default function ComparePage() {
                 <div className="mt-6 rounded-2xl border border-hairline bg-panel p-6 md:p-8">
                     <p className="eyebrow">The support act: what repetition costs</p>
                     <h3 className="mt-2 font-display text-lg font-semibold tracking-tight text-ink">
-                        We also measured it on a real EMR
+                        Start with the number anyone can reproduce
                     </h3>
                     <p className="mt-3 text-sm leading-relaxed text-ink-2 md:text-base">
                         With the safety story established above, here is the
-                        efficiency case. An 18-step add-patient-note workflow on
-                        the official OpenEMR public demo, run both ways and
-                        judged by one arm-independent OCR check, with a distinct
-                        parameterized note per run. Both arms succeeded every
-                        time: 20/20 compiled, 10/10 for a Claude computer-use
-                        agent. The agent doesn&#39;t fail here. The difference
-                        is what each run costs.
+                        efficiency case, on the substrate you can rerun yourself.
+                        MockMed is the demo clinic app that ships with
+                        openadapt-flow, so this head-to-head is deterministic: 100
+                        compiled replays against 20 agent runs, judged by one
+                        arm-independent OCR check, both arms 100%. The agent does
+                        not fail here. This is a cost-and-latency gap, not a
+                        reliability gap.
+                    </p>
+                    <BenchmarkCharts
+                        dataset={benchmark.mockmed}
+                        runs={500}
+                    />
+                    <p className="mt-4 text-xs leading-relaxed text-ink-3">
+                        {benchmark.mockmed.caveats} Agent cost is computed at the
+                        model&#39;s list price ($3/$15 per Mtok in/out); an
+                        introductory $2/$10 rate applies through 2026-08-31, which
+                        lowers the agent figure further.
+                    </p>
+                    <p className="mt-3 text-sm leading-relaxed text-ink-2 md:text-base">
+                        On the same setup under injected UI drift, a hybrid
+                        mode (compiled replay first, agent fallback only on a
+                        detected halt) matched agent reliability (20/20) at
+                        roughly one-eighth the agent&#39;s cost per successful
+                        run. Details and caveats (synthetic detected-halt
+                        drift, assumed drift mix) in the repo.
+                    </p>
+                    <div className="mt-3 flex flex-wrap gap-x-6 gap-y-1">
+                        <a
+                            href="https://github.com/OpenAdaptAI/openadapt-flow/blob/main/benchmark/BENCHMARK.md"
+                            className="inline-block text-sm text-accent hover:underline"
+                        >
+                            MockMed methodology and raw data
+                        </a>
+                        <a
+                            href="https://github.com/OpenAdaptAI/openadapt-flow/blob/main/benchmark/hybrid/BENCHMARK.md"
+                            className="inline-block text-sm text-accent hover:underline"
+                        >
+                            Hybrid methodology and caveats
+                        </a>
+                    </div>
+                </div>
+
+                <div className="mt-4 rounded-2xl border border-hairline bg-panel p-6 md:p-8">
+                    <h3 className="font-display text-lg font-semibold tracking-tight text-ink">
+                        The same result on a real EMR
+                    </h3>
+                    <p className="mt-3 text-sm leading-relaxed text-ink-2 md:text-base">
+                        We ran the same kind of head-to-head on a real
+                        application: an 18-step add-patient-note workflow on the
+                        official OpenEMR public demo, judged by one
+                        arm-independent OCR check with a distinct parameterized
+                        note per run. Both arms succeeded every time: 20/20
+                        compiled, 10/10 for a Claude computer-use agent. Because
+                        the demo is a shared instance that resets daily, treat
+                        this as a field cross-check on cost and latency, not a
+                        reproducible number and not a reliability claim.
                     </p>
                     <BenchmarkCharts
                         dataset={benchmark.openemr}
@@ -299,7 +348,9 @@ export default function ComparePage() {
                         self-flagged postcondition drift on the final step and
                         was verified saved by OCR; success is judged by the
                         arm-independent check for both arms, never
-                        self-report. Results are pinned
+                        self-report. Agent cost is at the model&#39;s list price;
+                        the introductory rate noted above lowers it further.
+                        Results are pinned
                         to claude-sonnet-5 with the computer_20251124 tool on
                         2026-07-08; newer models will differ. The OCR success
                         check errs conservative on dense EMR text and is
@@ -311,51 +362,6 @@ export default function ComparePage() {
                     >
                         OpenEMR methodology and raw data
                     </a>
-                </div>
-
-                <div className="mt-4 rounded-2xl border border-hairline bg-panel p-6 md:p-8">
-                    <h3 className="font-display text-lg font-semibold tracking-tight text-ink">
-                        The reproducible anchor
-                    </h3>
-                    <p className="mt-3 text-sm leading-relaxed text-ink-2 md:text-base">
-                        Because the OpenEMR numbers depend on a live shared
-                        instance, we keep the same head-to-head on MockMed,
-                        the demo clinic app that ships with openadapt-flow,
-                        as the benchmark anyone can rerun deterministically:
-                        100 compiled replays against 20 agent runs, both arms
-                        100%. Same orchestrator, same agent setup, same style
-                        of OCR check. The same shape of result, on a substrate
-                        you can reproduce:
-                    </p>
-                    <BenchmarkCharts
-                        dataset={benchmark.mockmed}
-                        runs={500}
-                    />
-                    <p className="mt-4 text-xs leading-relaxed text-ink-3">
-                        {benchmark.mockmed.caveats}
-                    </p>
-                    <p className="mt-3 text-sm leading-relaxed text-ink-2 md:text-base">
-                        On the same setup under injected UI drift, a hybrid
-                        mode (compiled replay first, agent fallback only on a
-                        detected halt) matched agent reliability (20/20) at
-                        roughly one-eighth the agent&#39;s cost per successful
-                        run. Details and caveats (synthetic detected-halt
-                        drift, assumed drift mix) in the repo.
-                    </p>
-                    <div className="mt-3 flex flex-wrap gap-x-6 gap-y-1">
-                        <a
-                            href="https://github.com/OpenAdaptAI/openadapt-flow/blob/main/benchmark/BENCHMARK.md"
-                            className="inline-block text-sm text-accent hover:underline"
-                        >
-                            MockMed methodology and raw data
-                        </a>
-                        <a
-                            href="https://github.com/OpenAdaptAI/openadapt-flow/blob/main/benchmark/hybrid/BENCHMARK.md"
-                            className="inline-block text-sm text-accent hover:underline"
-                        >
-                            Hybrid methodology and caveats
-                        </a>
-                    </div>
                 </div>
 
                 <h2 className="mt-12 font-display text-xl font-semibold tracking-tight text-ink">

--- a/pages/security.js
+++ b/pages/security.js
@@ -1,0 +1,207 @@
+import Head from 'next/head'
+import Link from 'next/link'
+
+import Footer from '@components/Footer'
+
+const REPO_URL = 'https://github.com/OpenAdaptAI/OpenAdapt'
+const ADVISORY_URL =
+    'https://github.com/OpenAdaptAI/OpenAdapt/security/advisories/new'
+
+const webPageSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    name: 'Security and trust',
+    url: 'https://openadapt.ai/security',
+    description:
+        'How OpenAdapt handles your data: on-premises, local-first, model-free on the default replay path. What is and is not certified today, and how to report a vulnerability.',
+    isPartOf: {
+        '@type': 'WebSite',
+        name: 'OpenAdapt.AI',
+        url: 'https://openadapt.ai',
+    },
+    about: {
+        '@type': 'SoftwareApplication',
+        name: 'OpenAdapt',
+        url: 'https://openadapt.ai',
+    },
+    inLanguage: 'en',
+}
+
+// status: 'yes' = in place today, 'progress' = underway, 'planned' = not yet.
+const posture = [
+    {
+        status: 'yes',
+        title: 'On-premises, local-first by architecture',
+        body: 'Recordings, compiled scripts, and replays live on your own infrastructure. In an Enterprise on-prem deployment, inference runs on your hardware too, so the data stays inside your perimeter.',
+    },
+    {
+        status: 'yes',
+        title: 'Model-free on the default replay path',
+        body: 'A healthy compiled replay makes no cloud model calls. On that default path, nothing about the run leaves your machine. A model is used at compile time and to heal the script when the UI drifts; you can run that model on your own hardware or an appliance inside your network rather than sending data to a third party.',
+    },
+    {
+        status: 'yes',
+        title: 'Audit trail on every run',
+        body: 'Every replay writes an illustrated run report: what ran, what it saw, and what healed. Each action is auditable against the demonstrated script.',
+    },
+    {
+        status: 'yes',
+        title: 'PII/PHI scrubbing tooling',
+        body: 'Scrubbing tooling is included for teams that need to sanitize captured data before anyone, human or model, sees it.',
+    },
+    {
+        status: 'yes',
+        title: 'Open source and auditable',
+        body: 'The engine is MIT-licensed. You can read the code, run it yourself, and verify these claims rather than take them on trust.',
+    },
+    {
+        status: 'progress',
+        title: 'SOC 2',
+        body: 'We do not hold a SOC 2 attestation today. The on-prem architecture is built to meet SOC 2 requirements and formal attestation is in progress. We will not claim otherwise until a report exists.',
+    },
+    {
+        status: 'planned',
+        title: 'BAA (Business Associate Agreement)',
+        body: 'We do not run a standing BAA program today. If an enterprise pilot requires a BAA, talk to us and we will scope it as part of the engagement. We would rather tell you this up front than imply a program we have not stood up.',
+    },
+]
+
+const statusLabel = {
+    yes: 'In place',
+    progress: 'In progress',
+    planned: 'Planned',
+}
+
+const statusColor = {
+    yes: 'var(--accent)',
+    progress: 'var(--inset-warn)',
+    planned: 'var(--inset-warn)',
+}
+
+export default function SecurityPage() {
+    return (
+        <div className="min-h-screen bg-ground text-ink">
+            <Head>
+                <title>Security and trust | OpenAdapt</title>
+                <meta
+                    name="description"
+                    content="How OpenAdapt handles your data: on-premises, local-first, and model-free on the default replay path. An honest account of what is and is not certified today, and how to report a vulnerability."
+                />
+                <link rel="canonical" href="https://openadapt.ai/security" />
+                <meta
+                    property="og:title"
+                    content="Security and trust | OpenAdapt"
+                />
+                <meta
+                    property="og:description"
+                    content="On-premises, local-first, model-free on the default path. What is and is not certified yet, stated plainly, plus how to report a vulnerability."
+                />
+                <meta property="og:url" content="https://openadapt.ai/security" />
+                <script
+                    type="application/ld+json"
+                    dangerouslySetInnerHTML={{
+                        __html: JSON.stringify(webPageSchema),
+                    }}
+                />
+            </Head>
+
+            <div className="mx-auto max-w-4xl px-4 py-14">
+                <p className="eyebrow">Security and trust</p>
+                <h1 className="font-display mt-3 text-3xl font-semibold tracking-tight text-ink md:text-4xl">
+                    Where your data goes, and what we have and haven&#39;t
+                    certified yet
+                </h1>
+                <p className="mt-5 max-w-3xl text-base text-ink-2 md:text-lg">
+                    OpenAdapt is built to run where your data already lives. This
+                    page states our posture plainly: what is in place today, what
+                    is underway, and what is still just planned. If a badge is not
+                    here, we do not have it yet.
+                </p>
+
+                <div className="mt-10 space-y-4">
+                    {posture.map((item) => (
+                        <div
+                            key={item.title}
+                            className="rounded-xl border border-hairline bg-panel p-5"
+                            style={{
+                                borderLeft: `4px solid ${statusColor[item.status]}`,
+                            }}
+                        >
+                            <div className="flex flex-wrap items-baseline justify-between gap-2">
+                                <strong className="font-display text-base font-semibold text-ink">
+                                    {item.title}
+                                </strong>
+                                <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-ink-3">
+                                    {statusLabel[item.status]}
+                                </span>
+                            </div>
+                            <p className="mt-2 text-sm leading-relaxed text-ink-2">
+                                {item.body}
+                            </p>
+                        </div>
+                    ))}
+                </div>
+
+                <div className="mt-12 border-t-2 border-ink pt-10">
+                    <h2 className="font-display text-2xl font-semibold tracking-tight text-ink">
+                        Report a vulnerability
+                    </h2>
+                    <p className="mt-3 max-w-3xl text-sm leading-relaxed text-ink-2 md:text-base">
+                        If you have found a security issue, please report it
+                        privately so we can fix it before it is disclosed. The
+                        fastest path is GitHub&#39;s private vulnerability
+                        reporting on the repository. You can also email us with
+                        &ldquo;Security&rdquo; in the subject line. Please do not
+                        open a public issue for a suspected vulnerability.
+                    </p>
+                    <div className="mt-5 flex flex-wrap gap-x-6 gap-y-2 text-sm">
+                        <a
+                            href={ADVISORY_URL}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="font-medium text-accent hover:underline"
+                        >
+                            Report privately on GitHub →
+                        </a>
+                        <a
+                            href="mailto:hello@openadapt.ai?subject=Security"
+                            className="text-accent hover:underline"
+                        >
+                            hello@openadapt.ai
+                        </a>
+                        <a
+                            href={REPO_URL}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-accent hover:underline"
+                        >
+                            Read the source
+                        </a>
+                    </div>
+                </div>
+
+                <div className="mt-12 rounded-2xl border-2 border-ink bg-panel p-6 text-center md:p-8">
+                    <h2 className="font-display text-xl font-semibold tracking-tight text-ink">
+                        Reviewing OpenAdapt for a regulated deployment?
+                    </h2>
+                    <p className="mx-auto mt-3 max-w-2xl text-sm text-ink-2 md:text-base">
+                        We are glad to walk your security team through the
+                        architecture and answer the hard questions. Bring your
+                        requirements and we will tell you what we can and
+                        can&#39;t meet today.
+                    </p>
+                    <div className="mt-5 flex flex-wrap justify-center gap-3">
+                        <Link href="/#book" className="btn-ink">
+                            Book a demo
+                        </Link>
+                        <Link href="/compare" className="btn-ghost-ink">
+                            How OpenAdapt compares
+                        </Link>
+                    </div>
+                </div>
+            </div>
+
+            <Footer />
+        </div>
+    )
+}


### PR DESCRIPTION
Fixes six launch-risk claims found in the claim audit. Each edit is the smallest honest change; no unrelated copy touched. Build passes (`npm run build`, all 14 pages, `/security` renders). No em dashes in new copy, per style preference.

## Risk-to-fix checklist

- [x] **Risk 1 — Enterprise bullet implied SOC 2 / BAA certification + a credential vault we don't have.** `components/Pricing.js`: dropped "credential vault" (verified: no such feature in the product), reworded to "On-prem architecture built for BAA and SOC 2 requirements; formal attestation in progress" and split out the real audit-trail claim ("every run writes an illustrated report").
- [x] **Risk 2 — no honest security posture page.** New `pages/security.js`: on-prem/local-first data handling, model-free default replay path, SOC 2 in progress, BAA planned (no standing program), and how to report a vulnerability. Linked from the Enterprise card and the footer. Uses existing design tokens, no fake badges.
- [x] **Risk 3 — Hosted $500/mo tier read as a live, buyable SKU (it doesn't exist yet).** `components/Pricing.js`: added a "Preview · join the waitlist" badge, "Not live yet" copy, and changed the CTA to "Join the waitlist". Price kept as set.
- [x] **Risk 4 — benchmark headline could read as "cheaper AND more reliable on a real EMR".** `components/ProofBand.js` + `pages/compare.js`: reproducible MockMed now leads; OpenEMR labeled as N=10 field cross-check (cost-and-latency only, not independently reproducible, no reliability claim); pricing basis (list price vs the intro rate in effect through 2026-08-31) disclosed. ProofBand numbers now read from `data/benchmark.json` instead of being hardcoded.
- [x] **Risk 5 — absolute "never leaves the building" egress language.** `components/MastHead.js` (hero carousel) and `components/Faq.js`: softened to accurate scoping ("On the default path, nothing leaves your machine" / "stays inside your network"; healing calls a model that can run on your own hardware inside your perimeter).
- [x] **Risk 6 — install copy contradictions.** `components/InstallSection.js`: (a) added an honest first-run note that `demo-record`/`replay` downloads a bundled Chromium (~150 MB) once and that Linux may need `playwright install-deps`; (b) made the install path consistent (the full-loop step now uses the same `curl … | sh` one-liner as the hero, instead of `pip install openadapt`); (c) the `compile` command already carries the required `--name`, so no correction was needed there.

## Verification notes
- **credential-vault did NOT survive verification** — no vault/secrets-manager feature exists in `openadapt-flow` (only RDP host/user/pass params and benchmark references), so the claim was removed rather than softened.
- Build: `npm run build` succeeds, 14/14 pages generated, `/security` = 3.79 kB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKrVJJy5jWVCkXAqgUqtqZ