### PR TITLE
copy: sharpen hero second paragraph (name the API blind spot)

### DIFF
--- a/components/MastHead.js
+++ b/components/MastHead.js
@@ -100,12 +100,12 @@ export default function Home({ githubStats }) {
                                 it runs entirely on your own machines.
                             </p>
                             <p className="mt-0 mb-6 mx-auto max-w-3xl font-sans font-normal text-base md:text-lg text-ink-3">
-                                Built for the repetitive work trapped in the
-                                systems no integration ever reached &mdash;
-                                legacy EMRs, Citrix desktops, and the
-                                line-of-business apps your team still runs by
-                                hand. Where a demonstration is the only way in,
-                                that&apos;s where OpenAdapt works.
+                                Every automation tool assumes an API. The
+                                systems that actually run your business
+                                don&apos;t: legacy EMRs, Citrix desktops, the
+                                internal apps your team still works by hand.
+                                OpenAdapt learns them from one demonstration and
+                                runs them where your data already lives.
                             </p>
                             <div className="flex flex-col align-center justify-center px-4 min-w-0 max-w-full overflow-hidden">
                                 <ReplayHero />


### PR DESCRIPTION
Rewrites the hero's second paragraph.

**Before:** "Built for the repetitive work trapped in the systems no integration ever reached — legacy EMRs, Citrix desktops, and the line-of-business apps your team still runs by hand. Where a demonstration is the only way in, that's where OpenAdapt works."

**After:** "Every automation tool assumes an API. The systems that actually run your business don't: legacy EMRs, Citrix desktops, the internal apps your team still works by hand. OpenAdapt learns them from one demonstration and runs them where your data already lives."

**Why:** the old closer was circular (defined the product by restating its premise) and ended the hero on a hedge. The new copy opens by naming what every competitor assumes (an API) and flips it into our ownable category, then closes on the on-prem line. Also drops the em-dash per house style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKrVJJy5jWVCkXAqgUqtqZ