### PR TITLE
copy: customer-voice pass across the site (home, FAQ, features, pricing, security, install)

### DIFF
--- a/components/BenchmarkSection.js
+++ b/components/BenchmarkSection.js
@@ -21,9 +21,9 @@ export default function BenchmarkSection() {
                     <a href={WAA_URL} target="_blank" rel="noopener noreferrer">
                         Windows Agent Arena
                     </a>{' '}
-                    in a CLI that handles VM lifecycle, agent execution, and
-                    step-by-step inspection — so you can iterate on your agent
-                    fast without modifying the original benchmarks.
+                    in a CLI that handles the VM, runs your agent, and lets you
+                    inspect every step. You iterate fast, and the original
+                    benchmarks stay untouched.
                 </p>
 
                 <div className={styles.highlights}>
@@ -52,8 +52,8 @@ export default function BenchmarkSection() {
                         <div>
                             <span className={styles.highlightTitle}>Unmodified benchmarks</span>
                             <span className={styles.highlightDesc}>
-                                Original tasks and scoring preserved — our
-                                tooling wraps, not forks
+                                Original tasks and scoring stay intact. Our
+                                tooling wraps them, it does not fork them
                             </span>
                         </div>
                     </div>
@@ -94,8 +94,8 @@ export default function BenchmarkSection() {
                         </div>
                     </div>
                     <p className={styles.caption}>
-                        The benchmark viewer lets you replay every step of an
-                        evaluation — screenshots, actions, and execution logs.{' '}
+                        The benchmark viewer replays every step of an
+                        evaluation: screenshots, actions, and logs.{' '}
                         <a
                             href={EVALS_REPO_URL}
                             target="_blank"

--- a/components/Developers.js
+++ b/components/Developers.js
@@ -76,8 +76,8 @@ export default function Developers() {
                         </div>
                     )}
                     <p className="mt-2 mb-6 mx-auto text-center max-w-2xl text-sm text-ink-2">
-                        OpenAdapt is an open-source demonstration compiler for desktop automation.
-                        Record a workflow once and it compiles into a self-healing automation that runs on your own machines with no per-run model calls.
+                        OpenAdapt is open source. Record a workflow once and it becomes a
+                        self-healing automation that runs on your own machines, with no AI cost per run.
                     </p>
 
                     {/* uv-first Installation Section */}

--- a/components/Faq.js
+++ b/components/Faq.js
@@ -1,27 +1,27 @@
 export const faqItems = [
     {
         question: 'What is OpenAdapt?',
-        answer: 'OpenAdapt is an open-source demonstration compiler for desktop automation. You record yourself doing a task once, and OpenAdapt compiles that recording into a self-healing script that runs on your own machines. Healthy runs make no cloud model calls, so each run costs nothing.',
+        answer: 'OpenAdapt is an open-source tool for automating desktop work. You do a task once while it records you, and it turns that recording into a script that runs on your own machines and repairs itself when the screen changes. A healthy run makes no cloud AI calls, so it costs nothing to run.',
     },
     {
         question: 'How is OpenAdapt different from RPA tools like UiPath?',
-        answer: 'Traditional RPA makes you hand-author brittle selectors and flowcharts, and the bot breaks when the UI changes. OpenAdapt compiles the automation from a demonstration instead, with no selector authoring, and when the UI drifts it heals itself and proposes the fix as a reviewable diff. It also runs entirely on your machines.',
+        answer: 'With traditional RPA, someone hand-builds the automation, and it breaks when the screen changes. With OpenAdapt you just record the task once. When the screen changes, it fixes itself and shows you the change to approve. And it runs entirely on your own machines.',
     },
     {
         question: 'How is OpenAdapt different from AI computer-use agents?',
-        answer: "Computer-use agents re-reason through your task with a large model on every run, so they're slow, non-deterministic, and bill you per run. OpenAdapt compiles the task once and replays it locally for free, with no per-run model calls. A model is only invoked to heal the script when the UI drifts.",
+        answer: 'An AI agent works out your task from scratch on every run, so it is slow, unpredictable, and charges you each time. OpenAdapt learns the task once and replays it locally for free. It only calls an AI model when the screen changes and the script needs a repair.',
     },
     {
         question: 'Does my data leave my machines?',
-        answer: 'It stays inside your network. OpenAdapt is local-first by architecture: recordings, compiled scripts, and replays live on your own infrastructure, and on the default path a healthy run makes no cloud calls at all, so nothing leaves your machine. When the UI drifts, healing calls a model; you can run that model on your own hardware or an appliance inside your network, so the data stays within your perimeter rather than going to a third party. PII/PHI scrubbing tooling is included for teams that need to sanitize captured data before anyone (human or model) sees it.',
+        answer: 'No. It stays inside your network. Recordings, scripts, and replays all live on your own machines, and a healthy run makes no cloud calls at all. When the screen changes and the script needs a repair, that runs an AI model, but you can run that model on your own hardware inside your network, so your data never goes to a third party. Tools for scrubbing PII and PHI are included, so you can clean captured data before anyone or anything sees it.',
     },
     {
         question: 'Is OpenAdapt free?',
-        answer: 'Yes — OpenAdapt is MIT-licensed open source, free to use and modify. For regulated deployments in healthcare and lending we run commercial pilots with hands-on support: we help compile your first workflows, set up review, and keep the automations healthy. Book a demo to talk about a pilot.',
+        answer: 'Yes. OpenAdapt is MIT-licensed open source, free to use and modify. For regulated teams in healthcare and lending, we also run paid pilots with hands-on support: we help build your first workflows, set up review, and keep the automations running. Book a demo to talk about a pilot.',
     },
     {
         question: 'What software does OpenAdapt work with?',
-        answer: "OpenAdapt works from pixels and inputs rather than APIs or browser internals. Today it runs web apps, including web EMRs. Because the runtime is vision-based, the same approach extends to desktop applications and software delivered over VDI or RDP as adapters, not rewrites — and those adapters are in progress. The aim is to reach the desktop EMRs and loan origination systems that cloud automation tools can't, without an API integration project.",
+        answer: "OpenAdapt works from what is on the screen, not from an API or browser internals. Today it handles web apps, including web EMRs. Because it works from the screen, the same approach can reach desktop apps and software delivered over Citrix or remote desktop. Those adapters are in progress. The goal is to automate the desktop EMRs and loan systems that cloud tools can't touch, with no API integration project.",
     },
 ]
 

--- a/components/HowItWorks.js
+++ b/components/HowItWorks.js
@@ -7,7 +7,7 @@ const steps = [
         number: '1.0',
         name: 'Record',
         description:
-            'Do the task once while OpenAdapt captures screens and inputs.',
+            'Do the task once. OpenAdapt watches your screen and your clicks.',
         // Default to the live OpenEMR footage — the strongest wow.
         clipKey: 'record_openemr',
     },
@@ -15,14 +15,14 @@ const steps = [
         number: '2.0',
         name: 'Compile',
         description:
-            'The demonstration becomes an editable script: visual anchors, per-step assertions, parameters.',
+            'Your recording becomes a script you can read, edit, and reuse.',
         clipKey: 'compile',
     },
     {
         number: '3.0',
         name: 'Run',
         description:
-            'Compiled replay in milliseconds, locally, with no per-run model calls.',
+            'It replays in milliseconds on your own machine, with no AI cost per run.',
         // Default to the live OpenEMR footage — the strongest wow.
         clipKey: 'run_openemr',
     },
@@ -30,14 +30,14 @@ const steps = [
         number: '4.0',
         name: 'Self-heal',
         description:
-            'When the UI drifts, a fallback ladder finds the target and proposes the fix as a diff.',
+            'When the app changes, it finds the button again and shows you the fix to approve.',
         clipKey: 'heal',
     },
     {
         number: '5.0',
         name: 'Audit',
         description:
-            'Every run produces an illustrated report: what ran, what it saw, what changed.',
+            'Every run leaves a step-by-step report: what it did, what it saw, what changed.',
         clipKey: 'audit',
     },
 ]
@@ -49,8 +49,8 @@ export default function HowItWorks() {
                 <p className={styles.eyebrow}>Process</p>
                 <h2 className={styles.heading}>How it works</h2>
                 <p className={styles.subheading}>
-                    A demonstration compiler: one recording in, a runnable
-                    automation out.
+                    Record a task once, and get an automation you can run,
+                    review, and audit.
                 </p>
                 <ol className={styles.steps}>
                     {steps.map((step) => {

--- a/components/IndustriesGrid.js
+++ b/components/IndustriesGrid.js
@@ -92,10 +92,10 @@ export default function IndustriesGrid({
                     Built for regulated back-offices
                 </h2>
                 <p className={styles.p}>
-                    Record the workflow once and OpenAdapt compiles it into an
-                    automation your team can review, run, and audit, entirely
-                    on your own machines. No brittle selectors to hand-author.
-                    No per-run model costs.
+                    Record the workflow once and OpenAdapt turns it into an
+                    automation your team can run, review, and audit, all on
+                    your own machines. Nothing brittle to hand-build. No AI
+                    cost per run.
                     <br />
                     <a href="https://github.com/OpenAdaptAI/openadapt-privacy">
                         Built-in PII/PHI scrubbing

--- a/components/InstallSection.js
+++ b/components/InstallSection.js
@@ -168,8 +168,8 @@ export default function InstallSection() {
                     The full loop, in five commands
                 </h4>
                 <p className={styles.note} style={{ marginBottom: '0.75rem' }}>
-                    Try record → compile → replay → heal right now against the
-                    bundled demo app. No account and no cloud service: once it is
+                    Try the whole loop right now against the
+                    bundled demo app: record, compile, replay, heal. No account, no cloud service. Once it is
                     installed, your workflow data stays on your machine. One
                     heads-up on first run: the first <code>demo-record</code> or{' '}
                     <code>replay</code> downloads a bundled Chromium (~150&nbsp;MB)
@@ -181,30 +181,30 @@ export default function InstallSection() {
                         <code>
                             curl -fsSL https://openadapt.ai/install.sh | sh
                         </code>
-                        <span>Install the demonstration compiler</span>
+                        <span>Install OpenAdapt</span>
                     </div>
                     <div className={styles.commandItem}>
                         <code>openadapt flow demo-record --out rec</code>
-                        <span>Record a demonstration</span>
+                        <span>Record yourself doing the task</span>
                     </div>
                     <div className={styles.commandItem}>
                         <code>
                             openadapt flow compile rec --out bundle --name
                             my-task
                         </code>
-                        <span>Compile it into an editable workflow</span>
+                        <span>Turn the recording into a workflow</span>
                     </div>
                     <div className={styles.commandItem}>
                         <code>openadapt flow replay bundle</code>
-                        <span>Replay: local, with zero model calls</span>
+                        <span>Replay it locally, with zero AI calls</span>
                     </div>
                     <div className={styles.commandItem}>
                         <code>openadapt flow replay bundle --drift theme</code>
-                        <span>Drift the UI and watch it heal itself</span>
+                        <span>Change the UI and watch it heal itself</span>
                     </div>
                 </div>
                 <p className={styles.note} style={{ marginTop: '0.75rem' }}>
-                    Every replay writes an illustrated run report: what ran,
+                    Every replay writes a step-by-step run report: what ran,
                     what it saw, what healed. Source on{' '}
                     <a
                         href="https://github.com/OpenAdaptAI/openadapt-flow"

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -52,9 +52,9 @@ export default function Pricing() {
                 </h2>
                 <p className="mx-auto mt-3 max-w-xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
                     The engine is open source and free. When you need it in
-                    production, inference is bundled in — no per-step, per-seat,
-                    or per-model-call metering. On-prem keeps your data in your
-                    building.
+                    production, the AI is included in the price: no per-step,
+                    per-seat, or per-call metering. On-premises keeps your data
+                    in your building.
                 </p>
 
                 <div className="mt-10 grid items-start gap-6 md:grid-cols-3">
@@ -129,7 +129,7 @@ export default function Pricing() {
                             >
                                 See Enterprise
                             </a>{' '}
-                            — your data stays in your building.
+                            and your data stays in your building.
                         </div>
                         <div className="mt-6 flex-grow" />
                         <Link
@@ -155,12 +155,12 @@ export default function Pricing() {
                             </span>
                         </div>
                         <p className="mt-3 text-sm leading-relaxed text-ink-2">
-                            For regulated teams — healthcare, lending, and other
+                            For regulated teams in healthcare, lending, and other
                             compliance-bound back-offices.
                         </p>
                         <FeatureList
                             items={[
-                                'On-premises deployment — PHI never leaves the building',
+                                'On-premises deployment, so PHI never leaves the building',
                                 'Inference runs on your hardware at zero metered cost',
                                 'Paid pilot → annual platform license',
                                 'On-prem architecture built for BAA and SOC 2 requirements; formal attestation in progress',
@@ -203,11 +203,11 @@ export default function Pricing() {
                         </h3>
                         <p className="mt-2 text-sm leading-relaxed text-ink-2">
                             Pick one well-scoped task. We record it and compile
-                            it with you, then get it running end to end with
-                            effect verification, in days. A flat fee that&apos;s
-                            credited toward your pilot if you move forward. A
-                            low-risk way to see it work on your real workflow
-                            before you commit.
+                            it with you, then get it running end to end, with
+                            checks that confirm it did the right thing, in days.
+                            The flat fee is credited toward your pilot if you
+                            move forward. A low-risk way to see it work on your
+                            real workflow before you commit.
                         </p>
                     </div>
                     <div className="flex flex-shrink-0 flex-col items-start gap-3 md:items-end">
@@ -233,9 +233,9 @@ export default function Pricing() {
                 </p>
 
                 <p className="mx-auto mt-8 max-w-2xl text-center text-xs leading-relaxed text-ink-3">
-                    We price the workflow outcome and the compliance, and bundle
-                    the inference. No per-step, per-seat, or per-model-call
-                    charges anywhere.
+                    We price the outcome and the compliance, and include the AI in
+                    that price. No per-step, per-seat, or per-call charges
+                    anywhere.
                 </p>
             </div>
         </section>

--- a/components/ProofBand.js
+++ b/components/ProofBand.js
@@ -17,15 +17,15 @@ const cost = (c) => (c === 0 ? '$0' : `$${c.toFixed(2)}`)
 const stats = [
     {
         figure: `${secs(mm.compiled.wall_s_p50)} vs ${secs(mm.agent.wall_s_p50)}`,
-        caption: 'median run, compiled replay vs computer-use agent',
+        caption: 'typical run: OpenAdapt vs an AI agent',
     },
     {
         figure: `${cost(mm.compiled.cost_usd_per_run)} vs ${cost(mm.agent.cost_usd_per_run)}`,
-        caption: 'model cost per run (agent priced at list rate)',
+        caption: 'AI cost per run (agent priced at list rate)',
     },
     {
         figure: `${mm.compiled.model_calls_per_run} vs ${mm.agent.model_calls_per_run}`,
-        caption: 'model calls per run: the hot path is model-free',
+        caption: 'AI calls per run: none on a healthy OpenAdapt run',
     },
 ]
 
@@ -45,20 +45,20 @@ export default function ProofBand() {
                     ))}
                 </div>
                 <p className={styles.note}>
-                    Same clinical task run both ways on MockMed, the demo app that
-                    ships with openadapt-flow so anyone can rerun it
-                    deterministically ({mm.compiled.n} compiled replays vs{' '}
-                    {mm.agent.n} agent runs). Both arms passed the same
-                    arm-independent check every time, so this is a cost-and-latency
-                    gap, not a reliability gap. Agent cost is shown at list price;
-                    an introductory model rate lowers it through 2026-08-31.
+                    The same clinical task, run both ways on MockMed, the demo app that
+                    ships with openadapt-flow so anyone can reproduce these numbers
+                    exactly ({mm.compiled.n} OpenAdapt replays vs{' '}
+                    {mm.agent.n} agent runs). Both passed the same
+                    independent check every time. So this is a gap in cost and speed,
+                    not in reliability. The agent cost is list price;
+                    an introductory rate lowers it through 2026-08-31.
                 </p>
                 <p className={styles.note}>
                     We also ran it on the live OpenEMR public demo (N=
-                    {em.agent.n} agent runs, both arms 100%). That is a field
-                    result on a shared instance that resets daily, so it is not
-                    independently reproducible, it is cost-and-latency only, and it
-                    implies nothing about reliability on a real EMR.
+                    {em.agent.n} agent runs, both passed 100%). It runs on a shared
+                    instance that resets daily, so you cannot reproduce it exactly.
+                    Treat it as cost and speed only. It says nothing about
+                    reliability on a real EMR.
                 </p>
                 <div className={styles.links}>
                     <Link href="/compare">How we measured it →</Link>

--- a/components/SafetyBand.js
+++ b/components/SafetyBand.js
@@ -25,7 +25,7 @@ export default function SafetyBand() {
                     record. We built an adversarial test suite to measure how
                     often it could still pick the wrong target, put our own
                     engine through seven rounds of it, and publish every
-                    result — including what it gets wrong today.
+                    result, including what it gets wrong today.
                 </p>
                 <div className="mt-6 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm">
                     <a

--- a/pages/security.js
+++ b/pages/security.js
@@ -32,17 +32,17 @@ const posture = [
     {
         status: 'yes',
         title: 'On-premises, local-first by architecture',
-        body: 'Recordings, compiled scripts, and replays live on your own infrastructure. In an Enterprise on-prem deployment, inference runs on your hardware too, so the data stays inside your perimeter.',
+        body: 'Recordings, scripts, and replays live on your own machines. In an on-premises deployment, the AI model runs on your hardware too, so your data stays inside your network.',
     },
     {
         status: 'yes',
-        title: 'Model-free on the default replay path',
-        body: 'A healthy compiled replay makes no cloud model calls. On that default path, nothing about the run leaves your machine. A model is used at compile time and to heal the script when the UI drifts; you can run that model on your own hardware or an appliance inside your network rather than sending data to a third party.',
+        title: 'No AI calls on a normal run',
+        body: 'A normal replay makes no cloud AI calls, so nothing about the run leaves your machine. An AI model is only used when you first compile the recording, or when the screen changes and the script needs a repair. You can run that model on your own hardware inside your network, so your data never goes to a third party.',
     },
     {
         status: 'yes',
         title: 'Audit trail on every run',
-        body: 'Every replay writes an illustrated run report: what ran, what it saw, and what healed. Each action is auditable against the demonstrated script.',
+        body: 'Every replay writes a step-by-step run report: what ran, what it saw, and what it repaired. You can check each action against the task you recorded.',
     },
     {
         status: 'yes',

--- a/pages/solutions/healthcare.js
+++ b/pages/solutions/healthcare.js
@@ -82,9 +82,9 @@ export default function HealthcarePage() {
                     <p className="mt-3 text-sm leading-relaxed text-ink-2 md:text-base">
                         The one catastrophe in EMR automation is writing to the
                         wrong chart. On legacy and Citrix EMRs the software
-                        reads the screen with OCR, where two patients&#39;
+                        reads the screen as text, so two patients&#39;
                         record numbers can differ by a single look-alike
-                        character OCR can&#39;t tell apart. When OpenAdapt
+                        character it can&#39;t tell apart. When OpenAdapt
                         can&#39;t prove the row on screen is the recorded
                         patient, it stops and hands the step to a person. We
                         show it working case by case, from real renders and the

--- a/pages/solutions/lending.js
+++ b/pages/solutions/lending.js
@@ -82,7 +82,7 @@ export default function LendingPage() {
                         LOS screens.
                     </li>
                     <li className="rounded-xl border border-hairline bg-panel p-4 text-sm leading-relaxed text-ink-2 md:text-base">
-                        Extract fields from loan documents into your LOS — and
+                        Extract fields from loan documents into your LOS, and
                         pull data back out for disclosures, portals, and
                         spreadsheets.
                     </li>


### PR DESCRIPTION
## What this does

A customer-voice editorial pass across the marketing site. Reframes copy from our engineer voice (mechanisms, jargon, internal notes) toward the customer's problem in plain language, shorter. Calibrated against the `/compare` rewrite in #165.

Principles applied: lead with the customer's problem, not our mechanism; translate jargon (deterministic replay, model-free hot path, OCR, fallback ladder, effect verification, demonstration compiler); one idea per sentence; no em dashes (house style). Every number, caveat, honesty link, and recent honesty fix is preserved.

**Untouched, as instructed:** `components/MastHead.js` (hero) and `pages/compare.js` (PR #165). No numbers, benchmark data, schema, or functional code changed.

## Files changed (12)
Home sections: `HowItWorks`, `ProofBand`, `SafetyBand`, `IndustriesGrid`, `Developers`, `InstallSection`, `Pricing`, `Faq`. Pages: `security.js`, `solutions/healthcare.js`, `solutions/lending.js`. Dev tooling: `BenchmarkSection`.

## Biggest before/after

**Faq.js — "How is OpenAdapt different from AI agents?"**
- Before: "Computer-use agents re-reason through your task with a large model on every run, so they're slow, non-deterministic, and bill you per run..."
- After: "An AI agent works out your task from scratch on every run, so it is slow, unpredictable, and charges you each time. OpenAdapt learns the task once and replays it locally for free. It only calls an AI model when the screen changes and the script needs a repair."

**Faq.js — "Is OpenAdapt free?"** (also removed an em dash)
- Before: "Yes — ... For regulated deployments in healthcare and lending we run commercial pilots..."
- After: "Yes. ... For regulated teams in healthcare and lending, we also run paid pilots with hands-on support..."

**HowItWorks.js — Compile step**
- Before: "The demonstration becomes an editable script: visual anchors, per-step assertions, parameters."
- After: "Your recording becomes a script you can read, edit, and reuse."

**HowItWorks.js — Self-heal step**
- Before: "When the UI drifts, a fallback ladder finds the target and proposes the fix as a diff."
- After: "When the app changes, it finds the button again and shows you the fix to approve."

**security.js — replay path** (title + body plain-language, honesty intact)
- Before title: "Model-free on the default replay path"; body led with "A healthy compiled replay makes no cloud model calls. On that default path..."
- After title: "No AI calls on a normal run"; body: "A normal replay makes no cloud AI calls, so nothing about the run leaves your machine. An AI model is only used when you first compile the recording, or when the screen changes and the script needs a repair..."

**Pricing.js — intro** (kept "no per-step, per-seat" honesty; removed em dash)
- Before: "...inference is bundled in — no per-step, per-seat, or per-model-call metering. On-prem keeps your data in your building."
- After: "...the AI is included in the price: no per-step, per-seat, or per-call metering. On-premises keeps your data in your building."

**ProofBand.js** (numbers unchanged; framing plainer)
- Before caption: "model calls per run: the hot path is model-free"
- After caption: "AI calls per run: none on a healthy OpenAdapt run"

**healthcare.js — wrong-patient defense** (de-jargoned OCR)
- Before: "...the software reads the screen with OCR, where two patients' record numbers can differ by a single look-alike character OCR can't tell apart."
- After: "...the software reads the screen as text, so two patients' record numbers can differ by a single look-alike character it can't tell apart."

## Honesty fixes preserved (verbatim)
- SOC 2 "in progress" and BAA "planned" cards in `security.js` — unchanged.
- Enterprise feature "On-prem architecture built for BAA and SOC 2 requirements; formal attestation in progress" — unchanged.
- Hosted tier "Preview · join the waitlist" status and "Not live yet: this is a preview..." — unchanged.
- "No per-step or per-seat billing" claims — kept everywhere.
- InstallSection: exact commands, single install path, and the first-run Chromium (~150 MB) / `playwright install-deps` note — kept intact.
- All benchmark numbers, N counts, list-price/introductory-rate caveats, and the "cost-and-latency, not reliability" framing — kept.

## Verification
- `npm run build` succeeds: compiled cleanly, 14/14 static pages generated.
- No em dashes in copy written (code comments and SEO `<title>` tags left as-is).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKrVJJy5jWVCkXAqgUqtqZ