### PR TITLE
fix: pypistats 502 for non-PyPI packages (filter to real packages + fail gracefully)

### DIFF
--- a/pages/api/pypistats/[package].js
+++ b/pages/api/pypistats/[package].js
@@ -78,6 +78,7 @@ async function fetchFromUpstream(url) {
 }
 
 export default async function handler(req, res) {
+  try {
     const { package: packageName, endpoint = 'overall', period } = req.query;
 
     if (!packageName) {
@@ -143,8 +144,28 @@ export default async function handler(req, res) {
             res.setHeader('X-Cache', 'STALE');
             return res.status(200).json(cached.data);
         }
+        // pypistats.org has no record of this package (404). Expected for a
+        // package that exists on PyPI but has no download history yet, or any
+        // name that slipped past discovery. Degrade quietly to an empty payload
+        // so the client excludes it from the chart — never a 502.
+        if (error.status === 404) {
+            console.warn(`pypistats has no data for ${packageName}/${endpoint}; excluding from chart`);
+            return res.status(404).json({
+                error: 'Package not found on pypistats.org',
+                package: packageName,
+                data: [],
+            });
+        }
         console.warn(`pypistats upstream failed for ${packageName}/${endpoint}: ${error.message}`);
         const status = error.status === 429 ? 429 : 502;
         return res.status(status).json({ error: `pypistats.org error: ${error.message}` });
     }
+  } catch (error) {
+    // Last-resort guard: no matter what threw above, return JSON rather than
+    // letting the serverless function crash (which surfaces as a 502).
+    console.error(`Unexpected error in pypistats handler for ${req.query?.package}:`, error);
+    if (!res.headersSent) {
+      return res.status(500).json({ error: 'Internal error', message: error.message });
+    }
+  }
 }

--- a/utils/packageDiscovery.js
+++ b/utils/packageDiscovery.js
@@ -76,27 +76,31 @@ async function fetchGitHubRepos() {
 }
 
 // FALLBACK - only used when both GitHub and PyPI discovery fail
-// Must include ALL public openadapt-* repos from the OpenAdaptAI org
-// Last updated: 2026-03-03
+// Must include ALL public openadapt-* repos from the OpenAdaptAI org.
+// `on_pypi` records whether the repo has actually been published to PyPI. It is
+// normally recomputed live (see discoverPackages), but is pinned here so the
+// raw-fallback path (double failure) still excludes non-PyPI names from stats
+// instead of requesting download data that will 404 upstream.
+// Last verified against pypi.org/pypi/<name>/json: 2026-07-13
 const FALLBACK_PACKAGES = [
-    { name: 'openadapt', description: 'Demonstration compiler for desktop automation: record once, replay deterministically, self-heal on drift', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'core' },
-    { name: 'openadapt-flow', description: 'Record a workflow once, compile it into a deterministic, self-healing, locally-run script', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'core' },
-    { name: 'openadapt-types', description: 'Canonical action and episode schemas shared across the ecosystem', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'core' },
-    { name: 'openadapt-agent', description: 'Production execution engine for OpenAdapt GUI automation agents', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'core' },
-    { name: 'openadapt-capture', description: 'GUI interaction capture with time-aligned media', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'core' },
-    { name: 'openadapt-consilium', description: 'Multi-LLM council for consensus-driven AI responses with cross-model review', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'devtools' },
-    { name: 'openadapt-crier', description: 'Event-driven social media approval bot with Telegram', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'devtools' },
-    { name: 'openadapt-desktop', description: 'Cross-platform system tray app for continuous screen recording and AI training data', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'core' },
-    { name: 'openadapt-evals', description: 'Evaluation infrastructure for GUI agent benchmarks', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'core' },
-    { name: 'openadapt-grounding', description: 'Temporal smoothing for UI element detection with OmniParser integration', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'core' },
-    { name: 'openadapt-herald', description: 'LLM-powered social media announcements from your git history', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'devtools' },
-    { name: 'openadapt-ml', description: 'ML toolkit for training and evaluating multimodal GUI-action models', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'core' },
-    { name: 'openadapt-ops', description: 'Ecosystem documentation aggregator and repository maintenance tools', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'devtools' },
-    { name: 'openadapt-privacy', description: 'PII/PHI detection and redaction for GUI automation data', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'core' },
-    { name: 'openadapt-retrieval', description: 'Multimodal demo retrieval for GUI automation', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'core' },
-    { name: 'openadapt-tray', description: 'System tray application for OpenAdapt', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'core' },
-    { name: 'openadapt-viewer', description: 'HTML viewer components for ML dashboards and benchmarks', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'core' },
-    { name: 'openadapt-wright', description: 'AI-powered dev automation: iterative code generation, testing, and PR creation', stars: 0, language: 'TypeScript', pushed_at: '', html_url: '', category: 'devtools' },
+    { name: 'openadapt', description: 'Demonstration compiler for desktop automation: record once, replay deterministically, self-heal on drift', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'core', on_pypi: true },
+    { name: 'openadapt-flow', description: 'Record a workflow once, compile it into a deterministic, self-healing, locally-run script', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'core', on_pypi: true },
+    { name: 'openadapt-types', description: 'Canonical action and episode schemas shared across the ecosystem', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'core', on_pypi: true },
+    { name: 'openadapt-agent', description: 'Production execution engine for OpenAdapt GUI automation agents', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'core', on_pypi: false },
+    { name: 'openadapt-capture', description: 'GUI interaction capture with time-aligned media', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'core', on_pypi: true },
+    { name: 'openadapt-consilium', description: 'Multi-LLM council for consensus-driven AI responses with cross-model review', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'devtools', on_pypi: true },
+    { name: 'openadapt-crier', description: 'Event-driven social media approval bot with Telegram', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'devtools', on_pypi: false },
+    { name: 'openadapt-desktop', description: 'Cross-platform system tray app for continuous screen recording and AI training data', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'core', on_pypi: true },
+    { name: 'openadapt-evals', description: 'Evaluation infrastructure for GUI agent benchmarks', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'core', on_pypi: true },
+    { name: 'openadapt-grounding', description: 'Temporal smoothing for UI element detection with OmniParser integration', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'core', on_pypi: true },
+    { name: 'openadapt-herald', description: 'LLM-powered social media announcements from your git history', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'devtools', on_pypi: false },
+    { name: 'openadapt-ml', description: 'ML toolkit for training and evaluating multimodal GUI-action models', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'core', on_pypi: true },
+    { name: 'openadapt-ops', description: 'Ecosystem documentation aggregator and repository maintenance tools', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'devtools', on_pypi: false },
+    { name: 'openadapt-privacy', description: 'PII/PHI detection and redaction for GUI automation data', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'core', on_pypi: true },
+    { name: 'openadapt-retrieval', description: 'Multimodal demo retrieval for GUI automation', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'core', on_pypi: true },
+    { name: 'openadapt-tray', description: 'System tray application for OpenAdapt', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'core', on_pypi: true },
+    { name: 'openadapt-viewer', description: 'HTML viewer components for ML dashboards and benchmarks', stars: 0, language: 'Python', pushed_at: '', html_url: '', category: 'core', on_pypi: true },
+    { name: 'openadapt-wright', description: 'AI-powered dev automation: iterative code generation, testing, and PR creation', stars: 0, language: 'TypeScript', pushed_at: '', html_url: '', category: 'devtools', on_pypi: false },
 ];
 
 let cachedResult = null;
@@ -173,7 +177,10 @@ export async function discoverPackages() {
  */
 export async function getDiscoveredPackages() {
     const result = await discoverPackages();
-    return result.packages.map((p) => p.name);
+    // Only return names that actually exist on PyPI. Requesting download stats
+    // for a repo that was never published (on_pypi === false) makes the upstream
+    // (pypistats.org) 404 and previously crashed the serverless function (502).
+    return result.packages.filter((p) => p.on_pypi === true).map((p) => p.name);
 }
 
 export { FALLBACK_PACKAGES, CACHE_DURATION };

--- a/utils/pypiStats.js
+++ b/utils/pypiStats.js
@@ -79,8 +79,10 @@ async function getPackageData() {
  */
 async function getPackageList() {
     const packages = await getPackageData();
+    // Core packages that actually exist on PyPI only. Excluding on_pypi === false
+    // avoids requesting stats for repos that were never published (404 upstream).
     return packages
-        .filter((p) => typeof p === 'string' || p.category === 'core')
+        .filter((p) => typeof p === 'string' || (p.category === 'core' && p.on_pypi !== false))
         .map((p) => (typeof p === 'string' ? p : p.name));
 }
 

--- a/utils/pypistatsHistory.js
+++ b/utils/pypistatsHistory.js
@@ -49,9 +49,11 @@ async function getPackageList() {
         }
 
         const data = await response.json();
-        // Filter to core packages only, extract names for stats
+        // Filter to core packages that actually exist on PyPI, extract names for
+        // stats. Excluding on_pypi === false stops us requesting download data for
+        // repos that were never published (which 404 upstream).
         const packages = (data.packages || [])
-            .filter((p) => typeof p === 'string' || p.category === 'core')
+            .filter((p) => typeof p === 'string' || (p.category === 'core' && p.on_pypi !== false))
             .map((p) => (typeof p === 'string' ? p : p.name));
         cachedPackages = packages;
         cacheTimestamp = Date.now();


### PR DESCRIPTION
## Problem

The homepage download-stats chart threw a wall of **502s**. The API route `/api/pypistats/[package]` returns 200 for real PyPI packages (openadapt-flow, openadapt-capture, …) but **502 in ~0.15s** (fast = crash, not timeout) for openadapt-* GitHub repos that were never published to PyPI: `openadapt-agent`, `openadapt-blog`, `openadapt-console`, `openadapt-presenter` (and dev-tool repos `openadapt-crier`, `openadapt-herald`, `openadapt-ops`, `openadapt-wright`).

### Root cause

Two independent bugs compounded:

1. **Discovery leaked non-PyPI repos.** `discoverPackages()` already computes an `on_pypi` boolean per candidate (via a `HEAD https://pypi.org/pypi/<name>/json`), but nothing consumed it. `getDiscoveredPackages()` returned `result.packages.map(p => p.name)` — every repo — and the client `getPackageList()` filtered only by `category === 'core'`. So the chart requested download stats for repos that don't exist on PyPI.
2. **The API mapped 404 → 502.** `pypistats.org` returns 404 for a package it has no record of. In the handler's `catch`, `const status = error.status === 429 ? 429 : 502` turned that 404 into a 502 and the function surfaced as crashed.

## Fixes (both included)

**1. Filter discovery to real PyPI packages** (`utils/packageDiscovery.js`, `utils/pypiStats.js`, `utils/pypistatsHistory.js`)
- `getDiscoveredPackages()` (server-side allow-list) now returns only `on_pypi === true` names.
- Client `getPackageList()` in both util files now excludes `on_pypi === false`, so non-PyPI repos are **never requested**.
- `FALLBACK_PACKAGES` annotated with verified `on_pypi` flags so the rare double-failure fallback path is correct too.

**2. Fail gracefully, never 502** (`pages/api/pypistats/[package].js`)
- An upstream 404 now returns a clean `404` JSON with an empty `data: []` payload (one concise `console.warn`). The client already treats any non-ok response as "exclude from chart".
- The entire handler is wrapped in a top-level `try/catch` that returns a JSON 500 rather than letting the function crash.

## How the valid-PyPI set was determined

Programmatic verification against `https://pypi.org/pypi/<name>/json` (200 = exists, 404 = not published), cross-checked against `https://pypistats.org/api/packages/<name>/recent`. On PyPI: `openadapt`, `openadapt-flow`, `openadapt-types`, `openadapt-capture`, `openadapt-consilium`, `openadapt-desktop`, `openadapt-evals`, `openadapt-grounding`, `openadapt-ml`, `openadapt-privacy`, `openadapt-retrieval`, `openadapt-tray`, `openadapt-viewer`. Not on PyPI: `openadapt-agent`, `openadapt-crier`, `openadapt-herald`, `openadapt-ops`, `openadapt-wright` (plus `-blog/-console/-presenter`, which aren't in the fallback list). Discovery verifies this **live** at runtime and caches it; the annotated fallback list is only a last-resort mirror.

## Verification

- `npm run build` succeeds.
- Dev-server smoke test:
  - `openadapt-flow` → **200** with data; `openadapt-capture` → **200** with data.
  - `openadapt-agent`, `openadapt-blog`, `openadapt-crier` → clean **400** JSON (rejected at the allow-list before reaching upstream) — **never 502**.
  - `on_pypi === false` packages are excluded from the client package list, so the chart doesn't request them at all.

## Recommended follow-up (not in this PR)

The user would prefer **not to run a backend at all**. A stronger fix is to precompute pypistats at **build time** into a static JSON (via `getStaticProps` or a scheduled GitHub Action) and drop the runtime serverless function entirely — eliminating the upstream-rate-limit / crash surface. This PR is the minimal robustness fix; the static-precompute migration is a good next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKrVJJy5jWVCkXAqgUqtqZ