### PR TITLE
fix: pilot founding price $15k anchor -> $10k (was $7k by merge race)

### DIFF
--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -189,13 +189,13 @@ export default function Pricing() {
                 {/*
                  * Pilot: the paid on-ramp, not a fourth tier. One clear
                  * engagement: we get one workflow live in 30 days against a
-                 * single agreed success measure, refunded if it misses. Priced
-                 * LOW on purpose (the software does the work, so it is a couple
-                 * hours of setup, not a multi-week integration) to reduce
-                 * friction and earn references; the value lives in the annual
-                 * license. The fee credits toward the first-year license (NOT
-                 * "toward the pilot": the fee IS the pilot). Sales-led (book a
-                 * call, then invoice), so the CTA is a call, not a checkout.
+                 * single agreed success measure, refunded if it misses. $15k
+                 * anchors the value (10-30% of a $30-75k annual license); a
+                 * founding-design-partner discount takes it to $10k to reward
+                 * and earn references from the first customers. The fee credits
+                 * toward the first-year license (NOT "toward the pilot": the fee
+                 * IS the pilot). Sales-led (book a call, then invoice), so the
+                 * CTA is a call, not a checkout.
                  */}
                 <div className="mt-6 flex flex-col gap-6 rounded-2xl border border-hairline bg-panel p-6 md:flex-row md:items-center md:justify-between md:p-7">
                     <div className="md:max-w-2xl">
@@ -205,22 +205,21 @@ export default function Pricing() {
                         </h3>
                         <p className="mt-2 text-sm leading-relaxed text-ink-2">
                             Pick one high-value, repetitive task. You demonstrate
-                            it once and OpenAdapt compiles it, so this is a couple
-                            of hours of setup, not a multi-week integration. We
-                            agree one success measure up front and get it running
-                            end to end with checks that confirm it did the right
-                            thing. If it doesn&apos;t hit that measure, you pay
-                            nothing.
+                            it once and OpenAdapt compiles it, so it is live in
+                            days, not a multi-week integration project. We agree
+                            one success measure up front and get it running end to
+                            end with checks that confirm it did the right thing.
+                            If it doesn&apos;t hit that measure, you pay nothing.
                         </p>
                     </div>
                     <div className="flex flex-shrink-0 flex-col items-start gap-3 md:items-end">
                         <div className="md:text-right">
                             <div className="flex items-baseline gap-2 md:justify-end">
                                 <span className="font-display text-xl font-semibold tracking-tight text-ink">
-                                    $7,000
+                                    $10,000
                                 </span>
                                 <span className="text-sm text-ink-3 line-through">
-                                    $10,000
+                                    $15,000
                                 </span>
                             </div>
                             <div className="font-mono text-xs text-accent">


### PR DESCRIPTION
Corrects the pilot price. #168 merged mid-edit at $7,000/$10,000; intended is the $15,000 research anchor with a 30% founding-design-partner discount to **$10,000**. Also reframes the body to lead with speed ('live in days, not a multi-week integration project') instead of 'a couple hours of setup', which undercut a $10k price.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKrVJJy5jWVCkXAqgUqtqZ