### PR TITLE
feat: Hosted Phase 0 — paid sign-up via Stripe Checkout (test mode, concierge onboarding)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,25 @@ NEXT_PUBLIC_POSTHOG_KEY=
 
 # PostHog API host (default: https://us.i.posthog.com; use https://eu.i.posthog.com for EU)
 NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+
+# --- OpenAdapt Hosted (Phase 0) — Stripe Checkout ---------------------------
+# Names only. NEVER commit real values. Build in Stripe TEST mode until the
+# maintainer swaps in live keys. When these are unset, the checkout + webhook
+# API routes return a clean 503 and the site still builds and deploys.
+# See docs/HOSTED_PHASE0.md.
+
+# Stripe secret key (server-side). Test mode: sk_test_...
+STRIPE_SECRET_KEY=
+
+# Recurring $500/mo price id created in the Stripe dashboard: price_...
+STRIPE_PRICE_ID=
+
+# Webhook signing secret from the Stripe dashboard / CLI: whsec_...
+STRIPE_WEBHOOK_SECRET=
+
+# Publishable key (safe to expose client-side). Test mode: pk_test_...
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
+
+# Optional: canonical site URL used to build Checkout success/cancel URLs.
+# Falls back to the request host when unset (fine for preview deploys).
+NEXT_PUBLIC_SITE_URL=https://openadapt.ai

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { useState } from 'react'
 
 /*
  * Pricing — three lanes, value-priced.
@@ -8,6 +9,13 @@ import Link from 'next/link'
  * metered cost. Hosted is a secondary, non-PHI / evaluation on-ramp priced on
  * outcome units (workflow-runs), never per-step / per-seat / per-VLM-call. OSS
  * stays MIT and honest.
+ *
+ * Hosted (Phase 0) is a real paid sign-up via Stripe Checkout, but a concierge
+ * one: we onboard the first customers by hand, so the card is honest that this
+ * is managed onboarding, not a finished self-serve runner. The Sign up CTA
+ * POSTs to /api/create-checkout-session and redirects to Stripe Checkout. If
+ * checkout is not configured yet (no keys), the API returns 503 and we surface
+ * a friendly fallback.
  *
  * Deliberately NOT shown anywhere: $/step, $/VLM-call, per-seat, or a raw
  * $/run meter. We price the outcome and the compliance; inference is bundled.
@@ -40,6 +48,38 @@ function FeatureList({ items }) {
 }
 
 export default function Pricing() {
+    const [hostedLoading, setHostedLoading] = useState(false)
+    const [hostedError, setHostedError] = useState('')
+
+    // Concierge sign-up: POST to the checkout API, then redirect to Stripe
+    // Checkout. If checkout is not configured yet (no keys), the API returns
+    // 503 and we point the user at booking a call instead.
+    async function handleHostedSignup() {
+        setHostedError('')
+        setHostedLoading(true)
+        try {
+            const res = await fetch('/api/create-checkout-session', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+            })
+            const data = await res.json().catch(() => ({}))
+            if (res.ok && data.url) {
+                window.location.assign(data.url)
+                return
+            }
+            setHostedError(
+                data.message ||
+                    'Checkout is not available right now. Please book a call and we will set you up.'
+            )
+        } catch (err) {
+            setHostedError(
+                'Something went wrong starting checkout. Please book a call and we will set you up.'
+            )
+        } finally {
+            setHostedLoading(false)
+        }
+    }
+
     return (
         <section
             id="pricing"
@@ -93,10 +133,10 @@ export default function Pricing() {
                         </p>
                     </div>
 
-                    {/* Card 2 — Hosted (preview / waitlist, not yet live) */}
+                    {/* Card 2 — Hosted (paid sign-up, concierge onboarding) */}
                     <div className="relative flex h-full flex-col rounded-2xl border border-hairline bg-panel p-6 md:p-7">
                         <span className="absolute -top-3 left-6 rounded-full border border-hairline bg-ground px-3 py-1 font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-ink-2">
-                            Preview · join the waitlist
+                            Managed onboarding
                         </span>
                         <p className="eyebrow">Hosted</p>
                         <div className="mt-2 flex items-baseline gap-2">
@@ -108,13 +148,13 @@ export default function Pricing() {
                             </span>
                         </div>
                         <p className="mt-3 text-sm leading-relaxed text-ink-2">
-                            For teams without on-prem hardware who want a managed
-                            cloud runner. Not live yet: this is a preview, and
-                            the price shown is what it will cost at launch.
+                            For teams without on-prem hardware who want a
+                            managed cloud runner. We onboard you personally to
+                            start; the self-serve runner is rolling out.
                         </p>
                         <FeatureList
                             items={[
-                                'Fully managed cloud runner, nothing for you to run',
+                                'We set you up personally, nothing for you to run',
                                 'Up to 10,000 workflow runs a month',
                                 'Hosted inference included at no extra cost',
                                 'No per-step or per-seat billing, no surprise charges',
@@ -132,12 +172,19 @@ export default function Pricing() {
                             and your data stays in your building.
                         </div>
                         <div className="mt-6 flex-grow" />
-                        <Link
-                            href="/#book"
-                            className="btn-ghost-ink w-full text-center"
+                        <button
+                            type="button"
+                            onClick={handleHostedSignup}
+                            disabled={hostedLoading}
+                            className="btn-ink w-full text-center disabled:opacity-60"
                         >
-                            Join the waitlist
-                        </Link>
+                            {hostedLoading ? 'Starting checkout…' : 'Sign up'}
+                        </button>
+                        {hostedError && (
+                            <p className="mt-3 text-center text-xs leading-relaxed text-ink-3">
+                                {hostedError}
+                            </p>
+                        )}
                     </div>
 
                     {/* Card 3 — Enterprise (primary / recommended) */}
@@ -155,8 +202,8 @@ export default function Pricing() {
                             </span>
                         </div>
                         <p className="mt-3 text-sm leading-relaxed text-ink-2">
-                            For regulated teams in healthcare, lending, and other
-                            compliance-bound back-offices.
+                            For regulated teams in healthcare, lending, and
+                            other compliance-bound back-offices.
                         </p>
                         <FeatureList
                             items={[
@@ -180,7 +227,10 @@ export default function Pricing() {
                             certified yet, and how to report a vulnerability.
                         </div>
                         <div className="mt-6 flex-grow" />
-                        <Link href="/#book" className="btn-ink w-full text-center">
+                        <Link
+                            href="/#book"
+                            className="btn-ink w-full text-center"
+                        >
                             Book a demo
                         </Link>
                     </div>
@@ -204,12 +254,13 @@ export default function Pricing() {
                             Start with one workflow, live in 30 days.
                         </h3>
                         <p className="mt-2 text-sm leading-relaxed text-ink-2">
-                            Pick one high-value, repetitive task. You demonstrate
-                            it once and OpenAdapt compiles it, so it is live in
-                            days, not a multi-week integration project. We agree
-                            one success measure up front and get it running end to
-                            end with checks that confirm it did the right thing.
-                            If it doesn&apos;t hit that measure, you pay nothing.
+                            Pick one high-value, repetitive task. You
+                            demonstrate it once and OpenAdapt compiles it, so it
+                            is live in days, not a multi-week integration
+                            project. We agree one success measure up front and
+                            get it running end to end with checks that confirm
+                            it did the right thing. If it doesn&apos;t hit that
+                            measure, you pay nothing.
                         </p>
                     </div>
                     <div className="flex flex-shrink-0 flex-col items-start gap-3 md:items-end">
@@ -238,13 +289,13 @@ export default function Pricing() {
                     </div>
                 </div>
                 <p className="mx-auto mt-4 max-w-2xl text-center text-xs leading-relaxed text-ink-3">
-                    Scope and price are confirmed before we begin. Full refund if
-                    the success criteria we agree up front aren&apos;t met.
+                    Scope and price are confirmed before we begin. Full refund
+                    if the success criteria we agree up front aren&apos;t met.
                 </p>
 
                 <p className="mx-auto mt-8 max-w-2xl text-center text-xs leading-relaxed text-ink-3">
-                    We price the outcome and the compliance, and include the AI in
-                    that price. No per-step, per-seat, or per-call charges
+                    We price the outcome and the compliance, and include the AI
+                    in that price. No per-step, per-seat, or per-call charges
                     anywhere.
                 </p>
             </div>

--- a/docs/HOSTED_PHASE0.md
+++ b/docs/HOSTED_PHASE0.md
@@ -1,0 +1,111 @@
+# OpenAdapt Hosted — Phase 0 (paid sign-up, concierge onboarding)
+
+Phase 0 turns the Hosted pricing card from a waitlist into a real, paid
+sign-up via **Stripe Checkout**. It is a **concierge** model: after a customer
+subscribes, we onboard them by hand. There is no self-serve runner yet, and
+the site copy says so.
+
+Everything runs in **Stripe TEST mode** until the maintainer swaps in live
+keys. No keys are hardcoded anywhere; the app reads them from the environment
+at request time.
+
+## The flow
+
+1. On the Hosted card (`components/Pricing.js`) the user clicks **Sign up**.
+2. The button POSTs to `POST /api/create-checkout-session`
+   (`pages/api/create-checkout-session.js`), which creates a Stripe Checkout
+   Session in `subscription` mode for `STRIPE_PRICE_ID`.
+3. The user is redirected to Stripe Checkout to pay ($500/mo).
+4. On success, Stripe redirects to
+   `/hosted/welcome?session_id={CHECKOUT_SESSION_ID}`
+   (`pages/hosted/welcome.js`), which confirms the subscription and sets the
+   concierge expectation ("We'll reach out within one business day").
+   On cancel, Stripe returns the user to `/#pricing`.
+5. Stripe also calls `POST /api/stripe-webhook`
+   (`pages/api/stripe-webhook.js`), which verifies the signature and handles
+   `checkout.session.completed` and `customer.subscription.created` by logging
+   and calling a stub notifier (TODO: wire to email / Slack).
+
+If the required env vars are missing (local dev, CI, preview deploys without
+secrets), the API routes return a clean **503** instead of crashing. The site
+still builds and deploys, and the Sign up button surfaces a friendly fallback
+pointing the user at booking a call.
+
+## Environment variables
+
+Copy `.env.example` to `.env.local` and fill in. Names only live in the repo.
+
+| Variable | Where | Example (test) | Purpose |
+| --- | --- | --- | --- |
+| `STRIPE_SECRET_KEY` | server | `sk_test_...` | Create Checkout Sessions, verify webhooks |
+| `STRIPE_PRICE_ID` | server | `price_...` | The recurring $500/mo price |
+| `STRIPE_WEBHOOK_SECRET` | server | `whsec_...` | Verify webhook signatures |
+| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | client | `pk_test_...` | Publishable key (reserved for client use) |
+| `NEXT_PUBLIC_SITE_URL` | both | `https://openadapt.ai` | Base URL for success/cancel URLs (optional; falls back to request host) |
+
+Set these as environment variables in your host (Vercel / Netlify), not in
+committed files.
+
+## Create the $500/mo price in Stripe
+
+1. In the Stripe dashboard, ensure the **Test mode** toggle is on.
+2. **Products → Add product**. Name it e.g. "OpenAdapt Hosted".
+3. Add a **recurring** price: **$500.00 USD**, billing period **Monthly**.
+4. Save, then copy the price id (`price_...`) into `STRIPE_PRICE_ID`.
+5. Copy your test secret key (`sk_test_...`, Developers → API keys) into
+   `STRIPE_SECRET_KEY`, and the publishable key (`pk_test_...`) into
+   `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`.
+
+## Set up the webhook
+
+The webhook endpoint is `POST /api/stripe-webhook`. It requires the **raw**
+request body, so Next.js body parsing is disabled in that route.
+
+**Local testing (Stripe CLI):**
+
+```bash
+stripe login
+stripe listen --forward-to localhost:3000/api/stripe-webhook
+# copy the printed whsec_... into STRIPE_WEBHOOK_SECRET in .env.local
+stripe trigger checkout.session.completed
+```
+
+**Production:**
+
+1. Stripe dashboard → **Developers → Webhooks → Add endpoint**.
+2. URL: `https://openadapt.ai/api/stripe-webhook`.
+3. Events: `checkout.session.completed` and `customer.subscription.created`.
+4. Copy the endpoint's **Signing secret** (`whsec_...`) into
+   `STRIPE_WEBHOOK_SECRET`.
+
+## Test a real (test-mode) purchase
+
+1. `npm run dev` with the four Stripe env vars set to test values.
+2. Open the Hosted card and click **Sign up**.
+3. On Stripe Checkout use test card `4242 4242 4242 4242`, any future expiry,
+   any CVC and postal code.
+4. Confirm you land on `/hosted/welcome` and that the webhook logs
+   `checkout.session.completed`.
+
+## Go-live checklist
+
+- [ ] Recreate the product/price in **live** mode; update `STRIPE_PRICE_ID`.
+- [ ] Swap all keys from test to **live**: `STRIPE_SECRET_KEY` (`sk_live_...`),
+      `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` (`pk_live_...`).
+- [ ] Recreate the webhook endpoint in live mode; update
+      `STRIPE_WEBHOOK_SECRET` (`whsec_...`).
+- [ ] Add a **Terms of Service** and **refund/cancellation policy** link to
+      the Checkout / Hosted flow (link `/terms-of-service`).
+- [ ] Wire the webhook stub notifier to real **email and/or Slack** so the
+      concierge team is alerted on every sign-up (currently a TODO).
+- [ ] Do a **real card** end-to-end purchase, confirm the subscription in the
+      Stripe dashboard, then refund/cancel it.
+- [ ] Confirm `success_url` / `cancel_url` resolve to the production domain
+      (set `NEXT_PUBLIC_SITE_URL`).
+
+## Scope note
+
+Phase 0 is deliberately concierge: it collects payment and sets expectations.
+It does **not** provision a runner or unlock self-serve. For non-PHI /
+evaluation workloads only; PHI or PII goes to **Enterprise** (on-prem, data
+stays in the customer's building).

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,8 @@
                 "react-dom": "^18.2.0",
                 "react-fontawesome": "^1.7.1",
                 "react-slick": "^0.30.2",
-                "simplex-noise": "^4.0.3"
+                "simplex-noise": "^4.0.3",
+                "stripe": "^16.12.0"
             },
             "devDependencies": {
                 "@netlify/plugin-nextjs": "^5.15.5",
@@ -1671,6 +1672,35 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2689,6 +2719,20 @@
                 "@types/trusted-types": "^2.0.7"
             }
         },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/duplexer3": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
@@ -2814,6 +2858,24 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/es-get-iterator": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
@@ -2837,6 +2899,18 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
             "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
         },
         "node_modules/es-set-tostringtag": {
             "version": "2.0.1",
@@ -3757,9 +3831,13 @@
             }
         },
         "node_modules/function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/function.prototype.name": {
             "version": "1.1.5",
@@ -3787,16 +3865,40 @@
             }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-            "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "license": "MIT",
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.3"
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/get-stream": {
@@ -3965,11 +4067,12 @@
             }
         },
         "node_modules/gopd": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-            "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-            "dependencies": {
-                "get-intrinsic": "^1.1.3"
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -4077,9 +4180,10 @@
             }
         },
         "node_modules/has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -4099,6 +4203,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/http-assert": {
@@ -5621,6 +5737,15 @@
                 "node": ">=10"
             }
         },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/media-typer": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -5999,9 +6124,13 @@
             }
         },
         "node_modules/object-inspect": {
-            "version": "1.12.3",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-            "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -7226,13 +7355,72 @@
             }
         },
         "node_modules/side-channel": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-            "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+            "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.0",
-                "get-intrinsic": "^1.0.2",
-                "object-inspect": "^1.9.0"
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-list": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-weakmap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3",
+                "side-channel-map": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -7502,6 +7690,35 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/stripe": {
+            "version": "16.12.0",
+            "resolved": "https://registry.npmjs.org/stripe/-/stripe-16.12.0.tgz",
+            "integrity": "sha512-H7eFVLDxeTNNSn4JTRfL2//LzCbDrMSZ+2q1c7CanVWgK2qIW5TwS+0V7N9KcKZZNpYh/uCqK0PyZh/2UsaAtQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": ">=8.1.0",
+                "qs": "^6.11.0"
+            },
+            "engines": {
+                "node": ">=12.*"
+            }
+        },
+        "node_modules/stripe/node_modules/qs": {
+            "version": "6.15.3",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/styled-jsx": {
@@ -9538,6 +9755,24 @@
                 "get-intrinsic": "^1.0.2"
             }
         },
+        "call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "requires": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            }
+        },
+        "call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "requires": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            }
+        },
         "callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -10267,6 +10502,16 @@
                 "@types/trusted-types": "^2.0.7"
             }
         },
+        "dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "requires": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            }
+        },
         "duplexer3": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
@@ -10376,6 +10621,16 @@
                 "which-typed-array": "^1.1.9"
             }
         },
+        "es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+        },
+        "es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+        },
         "es-get-iterator": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
@@ -10397,6 +10652,14 @@
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
                     "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
                 }
+            }
+        },
+        "es-object-atoms": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+            "requires": {
+                "es-errors": "^1.3.0"
             }
         },
         "es-set-tostringtag": {
@@ -11075,9 +11338,9 @@
             "optional": true
         },
         "function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
         },
         "function.prototype.name": {
             "version": "1.1.5",
@@ -11096,13 +11359,29 @@
             "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
         },
         "get-intrinsic": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-            "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
             "requires": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.3"
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            }
+        },
+        "get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "requires": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
             }
         },
         "get-stream": {
@@ -11218,12 +11497,9 @@
             }
         },
         "gopd": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-            "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-            "requires": {
-                "get-intrinsic": "^1.1.3"
-            }
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
         },
         "got": {
             "version": "10.7.0",
@@ -11299,9 +11575,9 @@
             "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg=="
         },
         "has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
         },
         "has-tostringtag": {
             "version": "1.0.0",
@@ -11309,6 +11585,14 @@
             "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
             "requires": {
                 "has-symbols": "^1.0.2"
+            }
+        },
+        "hasown": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+            "requires": {
+                "function-bind": "^1.1.2"
             }
         },
         "http-assert": {
@@ -12435,6 +12719,11 @@
                 "koa-static": "^5.0.0"
             }
         },
+        "math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+        },
         "media-typer": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -12701,9 +12990,9 @@
             "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="
         },
         "object-inspect": {
-            "version": "1.12.3",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-            "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g=="
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
         },
         "object-is": {
             "version": "1.1.5",
@@ -13574,13 +13863,47 @@
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
         },
         "side-channel": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-            "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
             "requires": {
-                "call-bind": "^1.0.0",
-                "get-intrinsic": "^1.0.2",
-                "object-inspect": "^1.9.0"
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
+            }
+        },
+        "side-channel-list": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+            "requires": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.4"
+            }
+        },
+        "side-channel-map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "requires": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3"
+            }
+        },
+        "side-channel-weakmap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "requires": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3",
+                "side-channel-map": "^1.0.1"
             }
         },
         "signal-exit": {
@@ -13782,6 +14105,26 @@
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "peer": true
+        },
+        "stripe": {
+            "version": "16.12.0",
+            "resolved": "https://registry.npmjs.org/stripe/-/stripe-16.12.0.tgz",
+            "integrity": "sha512-H7eFVLDxeTNNSn4JTRfL2//LzCbDrMSZ+2q1c7CanVWgK2qIW5TwS+0V7N9KcKZZNpYh/uCqK0PyZh/2UsaAtQ==",
+            "requires": {
+                "@types/node": ">=8.1.0",
+                "qs": "^6.11.0"
+            },
+            "dependencies": {
+                "qs": {
+                    "version": "6.15.3",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+                    "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+                    "requires": {
+                        "es-define-property": "^1.0.1",
+                        "side-channel": "^1.1.1"
+                    }
+                }
+            }
         },
         "styled-jsx": {
             "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
         "react-dom": "^18.2.0",
         "react-fontawesome": "^1.7.1",
         "react-slick": "^0.30.2",
-        "simplex-noise": "^4.0.3"
+        "simplex-noise": "^4.0.3",
+        "stripe": "^16.12.0"
     },
     "devDependencies": {
         "@netlify/plugin-nextjs": "^5.15.5",

--- a/pages/api/create-checkout-session.js
+++ b/pages/api/create-checkout-session.js
@@ -1,0 +1,86 @@
+/*
+ * Creates a Stripe Checkout Session for OpenAdapt Hosted (Phase 0).
+ *
+ * Concierge model: this starts a $500/mo subscription. After payment we
+ * onboard the customer by hand; there is no self-serve runner yet.
+ *
+ * Money + secrets safety:
+ *   - Runs in whatever mode the configured keys are (TEST until the
+ *     maintainer swaps in live keys). No keys are ever hardcoded.
+ *   - If the required env vars are missing (local dev, CI, preview deploys
+ *     without secrets), we return a clean 503 so the site still builds and
+ *     deploys. The build never imports Stripe at module load; it is required
+ *     lazily inside the handler.
+ *
+ * Required env vars:
+ *   STRIPE_SECRET_KEY   - Stripe secret key (sk_test_... in test mode)
+ *   STRIPE_PRICE_ID     - the recurring $500/mo price id (price_...)
+ */
+
+// Read env at request time (not module load) so a missing key can't break
+// the build. The site is a static-ish Next.js app; these routes only run
+// server-side at request time.
+function getConfig() {
+    return {
+        secretKey: process.env.STRIPE_SECRET_KEY,
+        priceId: process.env.STRIPE_PRICE_ID,
+    }
+}
+
+function getBaseUrl(req) {
+    // Prefer an explicitly configured public URL; fall back to the request
+    // host so preview deploys work without extra config.
+    const configured = process.env.NEXT_PUBLIC_SITE_URL
+    if (configured) return configured.replace(/\/$/, '')
+    const proto = req.headers['x-forwarded-proto'] || 'https'
+    const host = req.headers['x-forwarded-host'] || req.headers.host
+    return `${proto}://${host}`
+}
+
+export default async function handler(req, res) {
+    if (req.method !== 'POST') {
+        res.setHeader('Allow', 'POST')
+        return res.status(405).json({ error: 'method_not_allowed' })
+    }
+
+    const { secretKey, priceId } = getConfig()
+
+    // Guard: without keys the endpoint is a clean 503, not a 500 crash.
+    if (!secretKey || !priceId) {
+        return res.status(503).json({
+            error: 'checkout_not_configured',
+            message:
+                'Hosted checkout is not configured yet. Please email us and we will set you up personally.',
+        })
+    }
+
+    try {
+        // Lazy import so the build never depends on Stripe being importable
+        // or on any key being present.
+        const Stripe = require('stripe')
+        const stripe = new Stripe(secretKey)
+
+        const baseUrl = getBaseUrl(req)
+
+        const session = await stripe.checkout.sessions.create({
+            mode: 'subscription',
+            line_items: [{ price: priceId, quantity: 1 }],
+            allow_promotion_codes: true,
+            billing_address_collection: 'auto',
+            success_url: `${baseUrl}/hosted/welcome?session_id={CHECKOUT_SESSION_ID}`,
+            cancel_url: `${baseUrl}/#pricing`,
+            metadata: {
+                plan: 'hosted',
+                onboarding: 'concierge',
+            },
+        })
+
+        return res.status(200).json({ url: session.url })
+    } catch (err) {
+        console.error('[create-checkout-session] Stripe error:', err.message)
+        return res.status(502).json({
+            error: 'checkout_failed',
+            message: 'Could not start checkout. Please try again or email us.',
+        })
+    }
+}

--- a/pages/api/stripe-webhook.js
+++ b/pages/api/stripe-webhook.js
@@ -1,0 +1,132 @@
+/*
+ * Stripe webhook receiver for OpenAdapt Hosted (Phase 0).
+ *
+ * Verifies the Stripe signature with STRIPE_WEBHOOK_SECRET, then handles the
+ * events that matter for concierge onboarding:
+ *   - checkout.session.completed      (a customer just paid)
+ *   - customer.subscription.created   (the $500/mo subscription is live)
+ *
+ * For now it logs and calls a stub notifier. Wiring the stub to real email /
+ * Slack is a Phase 1 TODO; the concierge team is notified out of band until
+ * then.
+ *
+ * Money + secrets safety:
+ *   - No keys hardcoded. Reads STRIPE_SECRET_KEY + STRIPE_WEBHOOK_SECRET.
+ *   - If keys are missing, returns 503 (does not crash the build/deploy).
+ *   - Signature verification requires the raw request body, so Next.js body
+ *     parsing is disabled below.
+ */
+
+// Disable Next.js body parsing: Stripe signature verification needs the raw,
+// unparsed request body.
+export const config = {
+    api: {
+        bodyParser: false,
+    },
+}
+
+function getConfig() {
+    return {
+        secretKey: process.env.STRIPE_SECRET_KEY,
+        webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
+    }
+}
+
+// Read the raw request body as a Buffer for signature verification.
+async function readRawBody(req) {
+    const chunks = []
+    for await (const chunk of req) {
+        chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk)
+    }
+    return Buffer.concat(chunks)
+}
+
+// Stub notifier. TODO(Phase 1): send email (Resend/Postmark) and/or Slack
+// so the concierge team is alerted the moment someone pays.
+function notifyConciergeTeam(summary) {
+    console.log('[stripe-webhook] TODO notify concierge team:', summary)
+    // TODO: await sendEmail({ to: 'team@openadapt.ai', subject: ..., body: ... })
+    // TODO: await postToSlack({ channel: '#hosted-signups', text: ... })
+}
+
+export default async function handler(req, res) {
+    if (req.method !== 'POST') {
+        res.setHeader('Allow', 'POST')
+        return res.status(405).json({ error: 'method_not_allowed' })
+    }
+
+    const { secretKey, webhookSecret } = getConfig()
+    if (!secretKey || !webhookSecret) {
+        return res.status(503).json({
+            error: 'webhook_not_configured',
+            message: 'Stripe webhook is not configured yet.',
+        })
+    }
+
+    const Stripe = require('stripe')
+    const stripe = new Stripe(secretKey)
+
+    let event
+    try {
+        const rawBody = await readRawBody(req)
+        const signature = req.headers['stripe-signature']
+        event = stripe.webhooks.constructEvent(
+            rawBody,
+            signature,
+            webhookSecret
+        )
+    } catch (err) {
+        console.error(
+            '[stripe-webhook] signature verification failed:',
+            err.message
+        )
+        return res.status(400).json({ error: 'invalid_signature' })
+    }
+
+    try {
+        switch (event.type) {
+            case 'checkout.session.completed': {
+                const session = event.data.object
+                console.log('[stripe-webhook] checkout.session.completed', {
+                    id: session.id,
+                    customer: session.customer,
+                    email:
+                        session.customer_details &&
+                        session.customer_details.email,
+                    subscription: session.subscription,
+                })
+                notifyConciergeTeam({
+                    event: 'checkout.session.completed',
+                    email:
+                        session.customer_details &&
+                        session.customer_details.email,
+                    customer: session.customer,
+                })
+                break
+            }
+            case 'customer.subscription.created': {
+                const subscription = event.data.object
+                console.log('[stripe-webhook] customer.subscription.created', {
+                    id: subscription.id,
+                    customer: subscription.customer,
+                    status: subscription.status,
+                })
+                notifyConciergeTeam({
+                    event: 'customer.subscription.created',
+                    customer: subscription.customer,
+                    status: subscription.status,
+                })
+                break
+            }
+            default:
+                // Acknowledge unhandled events so Stripe stops retrying.
+                console.log('[stripe-webhook] unhandled event:', event.type)
+        }
+    } catch (err) {
+        console.error('[stripe-webhook] handler error:', err.message)
+        // Return 500 so Stripe retries transient handler failures.
+        return res.status(500).json({ error: 'handler_error' })
+    }
+
+    return res.status(200).json({ received: true })
+}

--- a/pages/hosted/welcome.js
+++ b/pages/hosted/welcome.js
@@ -1,0 +1,94 @@
+import Head from 'next/head'
+import Link from 'next/link'
+
+import Footer from '@components/Footer'
+
+/*
+ * Post-payment landing for OpenAdapt Hosted (Phase 0, concierge).
+ *
+ * Reached from Stripe Checkout success_url with ?session_id=... . We do not
+ * unlock a self-serve runner here: we confirm the subscription and set the
+ * expectation that a human reaches out to onboard the first workflow.
+ */
+
+export default function HostedWelcome() {
+    return (
+        <div className="min-h-screen bg-ground text-ink">
+            <Head>
+                <title>You&apos;re in | OpenAdapt Hosted</title>
+                <meta name="robots" content="noindex" />
+                <meta
+                    name="description"
+                    content="Thanks for subscribing to OpenAdapt Hosted. We onboard you personally and will reach out within one business day."
+                />
+            </Head>
+
+            <div className="mx-auto flex max-w-2xl flex-col px-5 py-16 md:py-24">
+                <p className="eyebrow">OpenAdapt Hosted</p>
+                <h1 className="mt-2 font-display text-3xl font-semibold tracking-tight text-ink md:text-4xl">
+                    You&apos;re in.
+                </h1>
+                <p className="mt-4 text-base leading-relaxed text-ink-2">
+                    Thanks for subscribing. We&apos;ll reach out within one
+                    business day to set up your first workflow. We onboard you
+                    personally to start; the self-serve runner is rolling out.
+                </p>
+
+                <div className="mt-8 rounded-2xl border border-hairline bg-panel p-6 md:p-7">
+                    <h2 className="font-display text-lg font-semibold tracking-tight text-ink">
+                        What happens next
+                    </h2>
+                    <ol className="mt-4 flex flex-col gap-3 text-sm leading-relaxed text-ink-2">
+                        <li className="flex gap-3">
+                            <span className="font-mono text-accent">1.</span>
+                            <span>
+                                A real person from our team emails you within
+                                one business day.
+                            </span>
+                        </li>
+                        <li className="flex gap-3">
+                            <span className="font-mono text-accent">2.</span>
+                            <span>
+                                We pick one high-value, repetitive workflow and
+                                you demonstrate it once.
+                            </span>
+                        </li>
+                        <li className="flex gap-3">
+                            <span className="font-mono text-accent">3.</span>
+                            <span>
+                                We compile it, run it with checks, and get it
+                                live for you. No infrastructure for you to run.
+                            </span>
+                        </li>
+                    </ol>
+                    <div className="mt-6">
+                        <Link
+                            href="/#book"
+                            className="btn-ink w-full text-center"
+                        >
+                            Book your onboarding call
+                        </Link>
+                    </div>
+                    <p className="mt-3 text-xs leading-relaxed text-ink-3">
+                        Prefer to wait for our email? That works too. For
+                        non-PHI / evaluation workloads. Handling PHI or PII?{' '}
+                        <Link
+                            href="/#pricing-enterprise"
+                            className="text-accent underline"
+                        >
+                            See Enterprise
+                        </Link>{' '}
+                        and your data stays in your building.
+                    </p>
+                </div>
+
+                <div className="mt-8">
+                    <Link href="/" className="btn-ghost-ink">
+                        Back to home
+                    </Link>
+                </div>
+            </div>
+            <Footer />
+        </div>
+    )
+}


### PR DESCRIPTION
## What & why

Phase 0 of OpenAdapt Hosted: flip the Hosted pricing card from a **waitlist** to a real, **paid sign-up via Stripe Checkout**. This is a **concierge** model — we onboard the first customers by hand, so there is no self-serve runner yet and the copy says so honestly.

Runs in **Stripe TEST mode** until the maintainer swaps in live keys. **No keys are hardcoded** anywhere; all are read from `process.env` at request time.

## The flow

1. Hosted card → **Sign up** button POSTs to `POST /api/create-checkout-session`.
2. That creates a Stripe Checkout Session in `subscription` mode for `STRIPE_PRICE_ID` ($500/mo).
3. User pays on Stripe Checkout.
4. Success → `/hosted/welcome?session_id={CHECKOUT_SESSION_ID}` (concierge confirmation + booking link). Cancel → `/#pricing`.
5. Stripe calls `POST /api/stripe-webhook`, which verifies the signature and handles `checkout.session.completed` / `customer.subscription.created` (logs + stub notifier; TODO email/Slack).

If the Stripe env vars are missing (local dev, CI, preview deploys without secrets), the API routes return a clean **503** and the site still builds and deploys. The Sign up button surfaces a friendly fallback.

## Files

- `components/Pricing.js` — Hosted card: badge → "Managed onboarding", CTA → **Sign up** (POST + redirect). Keeps $500/mo and the non-PHI / evaluation note (PHI → Enterprise). Honest line: "We onboard you personally to start; the self-serve runner is rolling out."
- `pages/api/create-checkout-session.js` — subscription Checkout Session; 503 guard when unconfigured.
- `pages/hosted/welcome.js` — post-payment concierge page ("You're in. We'll reach out within one business day…") + `/#book` booking link.
- `pages/api/stripe-webhook.js` — raw-body signature verification (`bodyParser: false`), event handling, stub notifier.
- `docs/HOSTED_PHASE0.md` — env vars, how to create the $500/mo price, webhook setup, go-live checklist.
- `.env.example` — Stripe var **names only**.
- `package.json` / `package-lock.json` — adds `stripe` SDK.

## Env vars needed (names only in repo)

| Variable | Where | Example (test) |
| --- | --- | --- |
| `STRIPE_SECRET_KEY` | server | `sk_test_...` |
| `STRIPE_PRICE_ID` | server | `price_...` (the $500/mo recurring price) |
| `STRIPE_WEBHOOK_SECRET` | server | `whsec_...` |
| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | client | `pk_test_...` |
| `NEXT_PUBLIC_SITE_URL` | both (optional) | `https://openadapt.ai` |

## Verification

- `npm run build` **succeeds with no Stripe env set** — API routes compile and only fail at request time with a clean 503.
- Handler smoke test: checkout POST (no keys) → 503, GET → 405, webhook POST (no keys) → 503, `config.api.bodyParser === false`.
- Prettier clean; no secrets committed (scanned for `sk_`/`pk_`/`whsec_` patterns).

## Go-live checklist (from docs)

- [ ] Recreate product/price in **live** mode; update `STRIPE_PRICE_ID`.
- [ ] Swap test → live keys (`sk_live_...`, `pk_live_...`).
- [ ] Recreate webhook in live mode; update `STRIPE_WEBHOOK_SECRET`.
- [ ] Add ToS + refund/cancellation link to the flow.
- [ ] Wire webhook stub notifier to real email/Slack.
- [ ] Do a **real card** end-to-end purchase, then refund/cancel.

**Test-mode only until the maintainer adds live keys. Do NOT merge without review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKrVJJy5jWVCkXAqgUqtqZ