### PR TITLE
feat: switch booking from Calendly to Cal.com (embedded)

### DIFF
--- a/components/BookingEmbed.js
+++ b/components/BookingEmbed.js
@@ -44,7 +44,7 @@ export default function BookingEmbed({ name = '', email = '' }) {
         )
     }
 
-    if (provider !== 'calendly') {
+    if (provider !== 'calendly' && provider !== 'calcom') {
         const providerLabel = provider === 'clockwise' ? 'Clockwise' : 'your booking provider'
         return (
             <div className="rounded-xl border border-amber-700/40 bg-amber-100 px-4 py-5 text-amber-900">

--- a/utils/booking.js
+++ b/utils/booking.js
@@ -1,3 +1,9 @@
+// Default booking is Cal.com (richard-abrich/60min). The maintainer syncs a
+// single service they already use; override with NEXT_PUBLIC_BOOKING_URL if
+// that ever changes.
+export const DEFAULT_BOOKING_URL =
+    'https://cal.com/richard-abrich/60min?overlayCalendar=true'
+
 export function detectBookingProvider(url) {
     if (!url) {
         return 'none'
@@ -6,6 +12,9 @@ export function detectBookingProvider(url) {
     try {
         const parsed = new URL(url)
         const host = parsed.hostname.toLowerCase()
+        if (host.includes('cal.com')) {
+            return 'calcom'
+        }
         if (host.includes('calendly.com')) {
             return 'calendly'
         }
@@ -21,21 +30,27 @@ export function detectBookingProvider(url) {
 export function getBookingConfig() {
     const calendlyUrl = (process.env.NEXT_PUBLIC_CALENDLY_URL || '').trim()
     const genericUrl = (process.env.NEXT_PUBLIC_BOOKING_URL || '').trim()
-    const url = calendlyUrl || genericUrl
+    const url = genericUrl || calendlyUrl || DEFAULT_BOOKING_URL
 
     return {
         url,
         provider: detectBookingProvider(url),
-        source: calendlyUrl
-            ? 'NEXT_PUBLIC_CALENDLY_URL'
-            : genericUrl
-                ? 'NEXT_PUBLIC_BOOKING_URL'
-                : '',
+        source: genericUrl
+            ? 'NEXT_PUBLIC_BOOKING_URL'
+            : calendlyUrl
+                ? 'NEXT_PUBLIC_CALENDLY_URL'
+                : 'default',
     }
 }
 
 export function getConfiguredBookingUrl() {
     return getBookingConfig().url
+}
+
+// Providers whose booking pages render safely inside an iframe on our page.
+export function isEmbeddableBookingUrl(url) {
+    const provider = detectBookingProvider(url)
+    return provider === 'calcom' || provider === 'calendly'
 }
 
 export function isCalendlyUrl(url) {
@@ -47,7 +62,8 @@ export function buildBookingUrlWithPrefill(url, prefill = {}) {
         return ''
     }
 
-    if (!isCalendlyUrl(url)) {
+    const provider = detectBookingProvider(url)
+    if (provider !== 'calcom' && provider !== 'calendly') {
         return url
     }
 
@@ -58,18 +74,21 @@ export function buildBookingUrlWithPrefill(url, prefill = {}) {
         return url
     }
 
-    if (!parsed.searchParams.get('hide_event_type_details')) {
-        parsed.searchParams.set('hide_event_type_details', '1')
+    // Calendly-only chrome tweaks; Cal.com ignores these harmlessly but we
+    // keep them scoped to Calendly to avoid unknown query params.
+    if (provider === 'calendly') {
+        if (!parsed.searchParams.get('hide_event_type_details')) {
+            parsed.searchParams.set('hide_event_type_details', '1')
+        }
+        if (!parsed.searchParams.get('hide_gdpr_banner')) {
+            parsed.searchParams.set('hide_gdpr_banner', '1')
+        }
     }
 
-    if (!parsed.searchParams.get('hide_gdpr_banner')) {
-        parsed.searchParams.set('hide_gdpr_banner', '1')
-    }
-
+    // Both Cal.com and Calendly prefill the booker from ?name= / ?email=.
     if (prefill.name && !parsed.searchParams.get('name')) {
         parsed.searchParams.set('name', prefill.name)
     }
-
     if (prefill.email && !parsed.searchParams.get('email')) {
         parsed.searchParams.set('email', prefill.email)
     }


### PR DESCRIPTION
Replaces the Calendly booking with your Cal.com link (`cal.com/richard-abrich/60min?overlayCalendar=true`) so you only sync the one service you already use. Cal.com embeds in the same inline iframe; name/email prefill still works. Overridable via `NEXT_PUBLIC_BOOKING_URL`. No env var needed — the Cal.com link is the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKrVJJy5jWVCkXAqgUqtqZ