### PR TITLE
copy: PHI as an Enterprise capability, not a Hosted limitation

### DIFF
--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -121,15 +121,15 @@ export default function Pricing() {
                             ]}
                         />
                         <div className="mt-4 rounded-lg border border-hairline bg-ground p-3 text-xs leading-relaxed text-ink-3">
-                            For non-PHI / evaluation workloads. Handling PHI or
-                            PII?{' '}
+                            Working with PHI or PII?{' '}
                             <a
                                 href="#pricing-enterprise"
                                 className="text-accent underline"
                             >
-                                See Enterprise
+                                Enterprise
                             </a>{' '}
-                            and your data stays in your building.
+                            runs OpenAdapt inside your own environment, so
+                            regulated data never leaves your network.
                         </div>
                         <div className="mt-6 flex-grow" />
                         <Link


### PR DESCRIPTION
Softens the PHI framing per discussion. The Hosted card note now leads with the Enterprise capability ('Enterprise runs OpenAdapt inside your own environment, so regulated data never leaves your network') rather than 'Hosted is for non-PHI workloads'. Honest (no 'fully compliant' overclaim), and reads as a feature. Underlying boundary unchanged: PHI runs in the customer's environment (Enterprise), not our multi-tenant cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKrVJJy5jWVCkXAqgUqtqZ