### PR TITLE
feat: route Hosted Sign up into the cloud app (configurable, graceful fallback)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,13 @@ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
 # Optional: canonical site URL used to build Checkout success/cancel URLs.
 # Falls back to the request host when unset (fine for preview deploys).
 NEXT_PUBLIC_SITE_URL=https://openadapt.ai
+
+# --- OpenAdapt Cloud app (self-serve funnel) --------------------------------
+# Base URL of the cloud app (the dashboard). Safe to expose client-side.
+# When SET, a successful Hosted checkout routes the customer into the cloud
+# app's sign-in / onboarding (carrying the Stripe session_id); the cloud app
+# owns Hosted billing and links the subscription to a cloud org by email at
+# first login. The Hosted pricing card and welcome page then read as self-serve.
+# When UNSET (default until the cloud app is deployed), checkout falls back to
+# the concierge /hosted/welcome page and nothing breaks.
+NEXT_PUBLIC_CLOUD_APP_URL=

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -10,12 +10,15 @@ import { useState } from 'react'
  * outcome units (workflow-runs), never per-step / per-seat / per-VLM-call. OSS
  * stays MIT and honest.
  *
- * Hosted (Phase 0) is a real paid sign-up via Stripe Checkout, but a concierge
- * one: we onboard the first customers by hand, so the card is honest that this
- * is managed onboarding, not a finished self-serve runner. The Sign up CTA
+ * Hosted (Phase 0) is a real paid sign-up via Stripe Checkout. The Sign up CTA
  * POSTs to /api/create-checkout-session and redirects to Stripe Checkout. If
  * checkout is not configured yet (no keys), the API returns 503 and we surface
  * a friendly fallback.
+ *
+ * The onboarding framing follows NEXT_PUBLIC_CLOUD_APP_URL: when it is set the
+ * cloud app is live, so checkout routes the customer into their dashboard and
+ * the card reads as self-serve. When it is unset we onboard the first
+ * customers by hand, so the card is honest that this is managed onboarding.
  *
  * Deliberately NOT shown anywhere: $/step, $/VLM-call, per-seat, or a raw
  * $/run meter. We price the outcome and the compliance; inference is bundled.
@@ -50,6 +53,11 @@ function FeatureList({ items }) {
 export default function Pricing() {
     const [hostedLoading, setHostedLoading] = useState(false)
     const [hostedError, setHostedError] = useState('')
+
+    // When the cloud app is deployed, Hosted checkout routes the customer into
+    // their dashboard (subscription linked by email at first login), so the
+    // card reads as self-serve. Unset keeps the honest concierge framing.
+    const cloudAppConfigured = Boolean(process.env.NEXT_PUBLIC_CLOUD_APP_URL)
 
     // Concierge sign-up: POST to the checkout API, then redirect to Stripe
     // Checkout. If checkout is not configured yet (no keys), the API returns
@@ -136,7 +144,9 @@ export default function Pricing() {
                     {/* Card 2 — Hosted (paid sign-up, concierge onboarding) */}
                     <div className="relative flex h-full flex-col rounded-2xl border border-hairline bg-panel p-6 md:p-7">
                         <span className="absolute -top-3 left-6 rounded-full border border-hairline bg-ground px-3 py-1 font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-ink-2">
-                            Managed onboarding
+                            {cloudAppConfigured
+                                ? 'Self-serve'
+                                : 'Managed onboarding'}
                         </span>
                         <p className="eyebrow">Hosted</p>
                         <div className="mt-2 flex items-baseline gap-2">
@@ -148,13 +158,15 @@ export default function Pricing() {
                             </span>
                         </div>
                         <p className="mt-3 text-sm leading-relaxed text-ink-2">
-                            For teams without on-prem hardware who want a
-                            managed cloud runner. We onboard you personally to
-                            start; the self-serve runner is rolling out.
+                            {cloudAppConfigured
+                                ? 'For teams without on-prem hardware who want a managed cloud runner. Sign up and your subscription links to your dashboard by email, so you are up and running the same day.'
+                                : 'For teams without on-prem hardware who want a managed cloud runner. We onboard you personally to start; the self-serve runner is rolling out.'}
                         </p>
                         <FeatureList
                             items={[
-                                'We set you up personally, nothing for you to run',
+                                cloudAppConfigured
+                                    ? 'Sign up and land straight in your dashboard'
+                                    : 'We set you up personally, nothing for you to run',
                                 'Up to 10,000 workflow runs a month',
                                 'Hosted inference included at no extra cost',
                                 'No per-step or per-seat billing, no surprise charges',

--- a/pages/api/create-checkout-session.js
+++ b/pages/api/create-checkout-session.js
@@ -1,8 +1,15 @@
 /*
  * Creates a Stripe Checkout Session for OpenAdapt Hosted (Phase 0).
  *
- * Concierge model: this starts a $500/mo subscription. After payment we
- * onboard the customer by hand; there is no self-serve runner yet.
+ * This starts a $500/mo subscription. Where the customer lands after payment
+ * is configurable:
+ *   - NEXT_PUBLIC_CLOUD_APP_URL set: they go to the cloud app's sign-in /
+ *     onboarding, carrying the Stripe session_id. The cloud app owns Hosted
+ *     billing and matches the subscription to a cloud org by email at first
+ *     login (cloud ARCHITECTURE Decision 5), so they land in their dashboard.
+ *   - NEXT_PUBLIC_CLOUD_APP_URL unset: they return to the concierge welcome
+ *     page and we onboard by hand. This is the graceful fallback so nothing
+ *     breaks before the cloud app is deployed.
  *
  * Money + secrets safety:
  *   - Runs in whatever mode the configured keys are (TEST until the
@@ -15,6 +22,12 @@
  * Required env vars:
  *   STRIPE_SECRET_KEY   - Stripe secret key (sk_test_... in test mode)
  *   STRIPE_PRICE_ID     - the recurring $500/mo price id (price_...)
+ *
+ * Optional env vars:
+ *   NEXT_PUBLIC_CLOUD_APP_URL - base URL of the cloud app (e.g.
+ *     https://app.openadapt.ai). When set, post-checkout success routes into
+ *     the cloud app instead of the concierge welcome page. When unset, the
+ *     concierge flow is preserved.
  */
 
 // Read env at request time (not module load) so a missing key can't break
@@ -35,6 +48,26 @@ function getBaseUrl(req) {
     const proto = req.headers['x-forwarded-proto'] || 'https'
     const host = req.headers['x-forwarded-host'] || req.headers.host
     return `${proto}://${host}`
+}
+
+function getCloudAppUrl() {
+    const configured = process.env.NEXT_PUBLIC_CLOUD_APP_URL
+    if (!configured) return ''
+    return configured.replace(/\/$/, '')
+}
+
+// Where Stripe returns the customer after a successful checkout. Both branches
+// carry the Stripe session_id so the destination can look up the subscription.
+//
+//   - Cloud app configured: route into the cloud app's sign-in / onboarding.
+//     The cloud app owns Hosted billing and links the subscription to a cloud
+//     org by email at first login, so the customer lands in their dashboard.
+//   - Not configured: fall back to the concierge welcome page (today's flow).
+function getSuccessUrl(req, cloudAppUrl) {
+    if (cloudAppUrl) {
+        return `${cloudAppUrl}/signin?session_id={CHECKOUT_SESSION_ID}`
+    }
+    return `${getBaseUrl(req)}/hosted/welcome?session_id={CHECKOUT_SESSION_ID}`
 }
 
 export default async function handler(req, res) {
@@ -61,17 +94,18 @@ export default async function handler(req, res) {
         const stripe = new Stripe(secretKey)
 
         const baseUrl = getBaseUrl(req)
+        const cloudAppUrl = getCloudAppUrl()
 
         const session = await stripe.checkout.sessions.create({
             mode: 'subscription',
             line_items: [{ price: priceId, quantity: 1 }],
             allow_promotion_codes: true,
             billing_address_collection: 'auto',
-            success_url: `${baseUrl}/hosted/welcome?session_id={CHECKOUT_SESSION_ID}`,
+            success_url: getSuccessUrl(req, cloudAppUrl),
             cancel_url: `${baseUrl}/#pricing`,
             metadata: {
                 plan: 'hosted',
-                onboarding: 'concierge',
+                onboarding: cloudAppUrl ? 'self_serve' : 'concierge',
             },
         })
 

--- a/pages/hosted/welcome.js
+++ b/pages/hosted/welcome.js
@@ -12,6 +12,12 @@ import Footer from '@components/Footer'
  */
 
 export default function HostedWelcome() {
+    // When the cloud app is deployed, offer a direct link into it. The cloud
+    // app links the subscription to a cloud org by email at first login, so
+    // this drops the customer into their dashboard. Unset (cloud app not live
+    // yet) keeps the concierge-only flow below.
+    const cloudAppUrl = process.env.NEXT_PUBLIC_CLOUD_APP_URL || ''
+
     return (
         <div className="min-h-screen bg-ground text-ink">
             <Head>
@@ -61,10 +67,28 @@ export default function HostedWelcome() {
                             </span>
                         </li>
                     </ol>
+                    {cloudAppUrl && (
+                        <div className="mt-6">
+                            <a
+                                href={cloudAppUrl}
+                                className="btn-ink w-full text-center"
+                            >
+                                Go to your dashboard
+                            </a>
+                            <p className="mt-2 text-center text-xs leading-relaxed text-ink-3">
+                                Sign in with the email you used at checkout and
+                                your subscription is already linked.
+                            </p>
+                        </div>
+                    )}
                     <div className="mt-6">
                         <Link
                             href="/#book"
-                            className="btn-ink w-full text-center"
+                            className={
+                                cloudAppUrl
+                                    ? 'btn-ghost-ink w-full text-center'
+                                    : 'btn-ink w-full text-center'
+                            }
                         >
                             Book your onboarding call
                         </Link>


### PR DESCRIPTION
Wires the self-serve funnel so Hosted "Sign up" leads into the cloud app instead of the concierge dead-end. Per cloud ARCHITECTURE Decision 5, the cloud app owns Hosted billing and matches the subscription to a cloud org by email at first login.

Everything is gated on a single new env var, `NEXT_PUBLIC_CLOUD_APP_URL` (e.g. `https://app.openadapt.ai`). **Until the cloud app is live, leaving it unset preserves today's concierge flow exactly** — nothing breaks on deploy.

## Behavior

**`NEXT_PUBLIC_CLOUD_APP_URL` set (cloud app live):**
- Stripe Checkout `success_url` -> `${NEXT_PUBLIC_CLOUD_APP_URL}/signin?session_id={CHECKOUT_SESSION_ID}`. Customer lands in the cloud app's sign-in / onboarding; the subscription links to their org by email at first login.
- Checkout metadata `onboarding: self_serve`.
- Hosted pricing card badge reads "Self-serve", copy and first feature read as self-serve.
- `/hosted/welcome` (fallback path only) shows a primary "Go to your dashboard" CTA linking to the cloud app; "Book your onboarding call" demotes to a ghost button.

**`NEXT_PUBLIC_CLOUD_APP_URL` unset (default, today):**
- Stripe Checkout `success_url` -> `/hosted/welcome?session_id={CHECKOUT_SESSION_ID}` (unchanged).
- Checkout metadata `onboarding: concierge`.
- Hosted pricing card keeps the "Managed onboarding" badge and concierge copy.
- `/hosted/welcome` keeps its concierge layout; no dashboard CTA rendered.

## Changes
- `pages/api/create-checkout-session.js` — new `getCloudAppUrl()` + `getSuccessUrl()` helpers; success_url and metadata switch on the env var. The existing 503 guard (missing Stripe keys) is unchanged.
- `pages/hosted/welcome.js` — conditional "Go to your dashboard" CTA.
- `components/Pricing.js` — Hosted card self-serve framing when configured; Enterprise/PHI framing untouched.
- `.env.example` — documents `NEXT_PUBLIC_CLOUD_APP_URL`.

## Verification
- `npm run build` succeeds.
- Checkout route still returns its clean 503 when Stripe keys are missing (guard untouched).
- No em-dashes in any user-facing copy.

## Interaction with #174
PR #174 ("fix: honest welcome-page copy") edits only the intro sentence (line 34) and the PHI note (lines 73-81) on `/hosted/welcome`. This PR does not touch those lines — it adds a `cloudAppUrl` const near the top of the component and inserts the dashboard CTA in the untouched region between #174's two hunks. They compose; whichever merges first, the other should apply cleanly (at most a trivial context rebase). This PR does not add the concierge copy that #174 rewrites, so it does not fight #174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKrVJJy5jWVCkXAqgUqtqZ