### PR TITLE
fix: exact, honest claims (certified-halt scoping, desktop/Citrix status, per-tier data claim)

### DIFF
--- a/DATA_VERIFICATION_REPORT.md
+++ b/DATA_VERIFICATION_REPORT.md
@@ -349,7 +349,7 @@ Users can independently verify all data by following the links provided in the U
 ## Contact
 
 For questions about data sources or to report discrepancies:
-- File an issue: https://github.com/OpenAdaptAI/OpenAdapt.web/issues
+- File an issue: https://github.com/OpenAdaptAI/openadapt-web/issues
 - Contact: development team via GitHub
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OpenAdapt.web
+# openadapt-web
 
 The official website for [OpenAdapt.AI](https://openadapt.ai) - AI-first desktop automation.
 

--- a/components/Faq.js
+++ b/components/Faq.js
@@ -9,11 +9,11 @@ export const faqItems = [
     },
     {
         question: 'How is OpenAdapt different from AI computer-use agents?',
-        answer: 'An AI agent works out your task from scratch on every run, so it is slow, unpredictable, and charges you each time. OpenAdapt learns the task once and replays it locally for free. It only calls an AI model when the screen changes and the script needs a repair.',
+        answer: 'An AI agent works out your task from scratch on every run, so it is slow, unpredictable, and charges you each time. OpenAdapt learns the task once and replays it locally for free. Healthy replay makes zero model calls. When the screen changes, deterministic fallbacks (template, OCR, geometry) handle many UI changes, and an optional local model assists the rest.',
     },
     {
         question: 'Does my data leave my machines?',
-        answer: 'No. It stays inside your network. Recordings, scripts, and replays all live on your own machines, and a healthy run makes no cloud calls at all. When the screen changes and the script needs a repair, that runs an AI model, but you can run that model on your own hardware inside your network, so your data never goes to a third party. Tools for scrubbing PII and PHI are included, so you can clean captured data before anyone or anything sees it.',
+        answer: 'In a self-hosted or bring-your-own-cloud deployment, no. Recordings, scripts, and replays all live on your own machines, and healthy replay makes zero model calls. When the screen changes, deterministic fallbacks (template, OCR, geometry) handle many UI changes; an optional model can assist the rest, and you can run that model on your own hardware inside your network, so PHI never enters our infrastructure. Tools for scrubbing PII and PHI are included, so you can clean captured data before anyone or anything sees it.',
     },
     {
         question: 'Is OpenAdapt free?',

--- a/components/MastHead.js
+++ b/components/MastHead.js
@@ -95,9 +95,10 @@ export default function Home({ githubStats }) {
                             </h1>
                             <p className="mt-0 mb-6 mx-auto max-w-3xl font-sans font-normal text-base md:text-lg text-ink-2">
                                 OpenAdapt compiles a recorded demonstration into
-                                a self-healing automation that halts rather than
-                                guessing. It&apos;s open source and auditable, and
-                                it runs entirely on your own machines.
+                                a self-healing automation. Certified workflows
+                                halt when identity or effects cannot be verified.
+                                It&apos;s open source and auditable, and it runs
+                                entirely on your own machines.
                             </p>
                             <p className="mt-0 mb-6 mx-auto max-w-3xl font-sans font-normal text-base md:text-lg text-ink-3">
                                 Every automation tool assumes an API. The
@@ -105,7 +106,10 @@ export default function Home({ githubStats }) {
                                 don&apos;t: legacy EMRs, Citrix desktops, the
                                 internal apps your team still works by hand.
                                 OpenAdapt learns them from one demonstration and
-                                runs them where your data already lives.
+                                runs them where your data already lives. Web
+                                workflows are supported today. Windows and Citrix
+                                workflows are being validated with design
+                                partners.
                             </p>
                             <div className="flex flex-col align-center justify-center px-4 min-w-0 max-w-full overflow-hidden">
                                 <ReplayHero />

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -181,7 +181,7 @@ export default function Pricing() {
                                 Enterprise
                             </a>{' '}
                             runs OpenAdapt inside your own environment, so
-                            regulated data never leaves your network.
+                            regulated data never enters our infrastructure.
                         </div>
                         <div className="mt-6 flex-grow" />
                         <button
@@ -219,7 +219,7 @@ export default function Pricing() {
                         </p>
                         <FeatureList
                             items={[
-                                'On-prem, or managed by us inside your own cloud (single-tenant), so PHI never leaves your network',
+                                'On-prem, or managed by us inside your own cloud (single-tenant), so PHI never enters our infrastructure',
                                 'Inference runs on your hardware at zero metered cost',
                                 'Pilot first, then an annual platform license',
                                 'On-prem architecture built for BAA and SOC 2 requirements; formal attestation in progress',

--- a/components/SafetyBand.js
+++ b/components/SafetyBand.js
@@ -17,12 +17,12 @@ export default function SafetyBand() {
             <div className="mx-auto max-w-3xl px-6 py-12 text-center">
                 <p className="eyebrow mb-2">Safety</p>
                 <h2 className="font-display text-2xl md:text-3xl font-semibold tracking-tight text-ink mb-4">
-                    It halts instead of guessing.
+                    Certified workflows halt instead of guessing.
                 </h2>
                 <p className="mx-auto max-w-2xl text-base md:text-lg text-ink-2">
-                    When the UI drifts and a step gets ambiguous, OpenAdapt
-                    stops and flags a person rather than writing to the wrong
-                    record. We built an adversarial test suite to measure how
+                    Certified workflows halt when identity or effects can&apos;t
+                    be verified, flagging a person rather than writing to the
+                    wrong record. We built an adversarial test suite to measure how
                     often it could still pick the wrong target, put our own
                     engine through seven rounds of it, and publish every
                     result, including what it gets wrong today.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "homepage": "https://openadapt.ai",
     "repository": {
         "type": "git",
-        "url": "https://github.com/OpenAdaptAI/OpenAdapt.web"
+        "url": "https://github.com/OpenAdaptAI/openadapt-web"
     },
     "scripts": {
         "dev": "next dev",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -30,7 +30,7 @@ export default function MyApp({ Component, pageProps }) {
                 <title>OpenAdapt — Record once. Compiled, self-healing desktop automation that runs on your premises.</title>
                 <meta
                     name="description"
-                    content="OpenAdapt compiles a recorded demonstration into a self-healing automation that replays on your own machines. Healthy runs make no cloud model calls; your data never leaves your machines. Open source, MIT licensed."
+                    content="OpenAdapt compiles a recorded demonstration into a self-healing automation that replays on your own machines. Healthy replay makes zero model calls. Self-hosted and bring-your-own-cloud deployments keep PHI out of our infrastructure. Open source, MIT licensed."
                 />
                 <link
                     rel="apple-touch-icon"

--- a/pages/compare.js
+++ b/pages/compare.js
@@ -116,8 +116,8 @@ export default function ComparePage() {
                     model, and browser recorders. OpenAdapt is a fourth. You
                     record the task once, and it compiles that recording into a
                     script that replays for free, repairs itself when the screen
-                    changes, and{' '}
-                    <strong>stops rather than guess</strong> when it can&#39;t
+                    changes, and, in a certified workflow,{' '}
+                    <strong>halts rather than guess</strong> when it can&#39;t
                     confirm it&#39;s acting on the right record. Each approach
                     wins somewhere. Here is the honest picture, safety first.
                 </p>

--- a/pages/hosted/welcome.js
+++ b/pages/hosted/welcome.js
@@ -103,7 +103,7 @@ export default function HostedWelcome() {
                             Enterprise
                         </Link>{' '}
                         runs OpenAdapt inside your own environment, so regulated
-                        data never leaves your network.
+                        data never enters our infrastructure.
                     </p>
                 </div>
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -55,7 +55,7 @@ const softwareSchema = {
     applicationCategory: 'DeveloperApplication',
     operatingSystem: 'Windows, macOS, Linux',
     description:
-        'Open-source demonstration compiler for desktop automation. Record a workflow once and OpenAdapt compiles it into a self-healing script that replays locally with no per-run model calls. A model is only used to heal the script when the UI drifts, and the fix is proposed as a reviewable diff.',
+        'Open-source demonstration compiler for desktop automation. Record a workflow once and OpenAdapt compiles it into a self-healing script that replays locally with no per-run model calls. Deterministic fallbacks (template, OCR, geometry) handle many UI changes, an optional local model assists unresolved ones, and the fix is proposed as a reviewable diff.',
     url: 'https://openadapt.ai',
     downloadUrl: 'https://pypi.org/project/openadapt/',
     author: {

--- a/pages/security.js
+++ b/pages/security.js
@@ -37,7 +37,7 @@ const posture = [
     {
         status: 'yes',
         title: 'No AI calls on a normal run',
-        body: 'A normal replay makes no cloud AI calls, so nothing about the run leaves your machine. An AI model is only used when you first compile the recording, or when the screen changes and the script needs a repair. You can run that model on your own hardware inside your network, so your data never goes to a third party.',
+        body: 'Healthy replay makes zero model calls, so nothing about the run leaves your machine. Compilation is deterministic and model-free by default. When the screen changes, deterministic fallbacks (template, OCR, geometry) handle many UI changes; an optional model can assist unresolved changes. Any such model, like everything else, can run on your own hardware inside your network, so your data never goes to a third party.',
     },
     {
         status: 'yes',

--- a/pages/solutions/healthcare.js
+++ b/pages/solutions/healthcare.js
@@ -77,16 +77,18 @@ export default function HealthcarePage() {
                 >
                     <p className="eyebrow">The wrong-patient defense</p>
                     <h2 className="mt-2 font-display text-xl font-semibold tracking-tight text-ink">
-                        It halts before it writes to the wrong patient.
+                        Certified workflows halt before writing to the wrong
+                        patient.
                     </h2>
                     <p className="mt-3 text-sm leading-relaxed text-ink-2 md:text-base">
                         The one catastrophe in EMR automation is writing to the
                         wrong chart. On legacy and Citrix EMRs the software
                         reads the screen as text, so two patients&#39;
                         record numbers can differ by a single look-alike
-                        character it can&#39;t tell apart. When OpenAdapt
-                        can&#39;t prove the row on screen is the recorded
-                        patient, it stops and hands the step to a person. We
+                        character it can&#39;t tell apart. When a certified
+                        workflow can&#39;t prove the row on screen is the
+                        recorded patient, it halts and hands the step to a
+                        person. We
                         show it working case by case, from real renders and the
                         real check, and we disclose what it doesn&#39;t cover.
                     </p>


### PR DESCRIPTION
Two external reviews found the site made safety/capability claims stronger than the product's DEFAULT guarantees. This makes the claims exact and honest without gutting the pitch. Local-first, \$0 healthy replay, auditability, and halt-on-ambiguity for certified workflows are all kept where they are true.

## Changes (before → after)

**1. Halt claim overstated the default**
- Hero (`MastHead.js`): "a self-healing automation that halts rather than guessing" → "a self-healing automation. Certified workflows halt when identity or effects cannot be verified."
- Safety band (`SafetyBand.js`): "It halts instead of guessing." / "When the UI drifts and a step gets ambiguous, OpenAdapt stops and flags a person rather than writing to the wrong record." → "Certified workflows halt instead of guessing." / "Certified workflows halt when identity or effects can't be verified, flagging a person rather than writing to the wrong record."
- Healthcare (`solutions/healthcare.js`): "It halts before it writes to the wrong patient." → "Certified workflows halt before writing to the wrong patient." (body: "When a certified workflow can't prove the row on screen is the recorded patient, it halts…")
- Compare (`compare.js`): "stops rather than guess when it can't confirm…" → "in a certified workflow, halts rather than guess when it can't confirm…"

Rationale: identity checks cover only *armed* steps; effect verification needs a declared effect contract + configured verifier; certification is optional. It does not always halt by default.

**2. Desktop/Citrix named as if it ships**
- Hero (`MastHead.js`): added "Web workflows are supported today. Windows and Citrix workflows are being validated with design partners." (kept the differentiated direction).

**3. Healthy-replay wording made precise**
- `security.js`, `index.js` schema, `Faq.js`: now state "Healthy replay makes zero model calls. Deterministic fallbacks (template, OCR, geometry) handle many UI changes; an optional local model can assist unresolved changes." (was: "a model is only used to heal the script when the UI drifts").

**4. Security page: model-free compilation**
- `security.js`: "An AI model is only used when you first compile the recording…" → "Compilation is deterministic and model-free by default. When the screen changes, deterministic fallbacks handle many UI changes; an optional model can assist unresolved changes."

**5. Killed company-wide data tagline; scoped per tier**
- Default site meta (`_app.js`): "your data never leaves your machines" → "Healthy replay makes zero model calls. Self-hosted and bring-your-own-cloud deployments keep PHI out of our infrastructure."
- Enterprise/BYOC lines (`Pricing.js`, `hosted/welcome.js`): "PHI/regulated data never leaves your network" → "…never enters our infrastructure."

**6. Stale repo reference**
- `OpenAdapt.web` → `openadapt-web` in `package.json`, `README.md`, `DATA_VERIFICATION_REPORT.md`.

## Verification
- `npm run build` passes (all pages compiled).
- No em-dashes introduced (house style).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKrVJJy5jWVCkXAqgUqtqZ