### PR TITLE
copy: target-state landing (HELD — publish when the product ships)

### DIFF
--- a/TARGET_STATE.md
+++ b/TARGET_STATE.md
@@ -1,0 +1,31 @@
+# Target-state landing copy (HELD)
+
+**This branch (`feat/target-state-copy`) rewrites the landing surfaces to describe
+OpenAdapt AS IT WILL BE when the currently-in-flight platform work lands, NOT as it
+is today.** It is a specification for the marketing surface, held until the product
+actually reaches this state.
+
+**DO NOT publish or merge this branch until the product ships the capabilities it
+describes.** Merging it early would put claims on the public site that are not yet
+true. The gap list (what this copy claims that is not true yet) lives in the PR
+description and drives the remaining implementation.
+
+Grounded in `.private/DESIGN_hosted_matrix_2026_07_14.md` (the deployment × substrate
+matrix) and the July-13 honesty ethos (`project_critical_review_reality_check`).
+
+What the target state adds over today's live copy:
+
+- **One substrate-agnostic runner** covering **web AND Windows desktop / Citrix-RDP**
+  (today the desktop/VDI adapters are "in progress").
+- **A deployment-choice spectrum** instead of a blanket "on your premises" claim:
+  our cloud (non-PHI), BYOC / your-VPC (regulated, PHI), and self-hosted / on-prem
+  (air-gapped). Data-residency claims are scoped **per tier**, never company-wide.
+- **Fail-closed regulated execution** (`openadapt-flow run` refuses unless certified,
+  identity-covered, effect-declared, signed/encrypted, and version-pinned).
+- **Halt -> teach -> promote** as a shipped loop (teach the fix once, promote it
+  through governed review), not just "it halts."
+
+Honesty rules kept intact: no invented benchmarks (only the real OpenEMR 20/20 vs
+10/10 and MockMed results with their existing caveats), effect verification is
+described as on-screen read-back (not independent verification), identity/effect
+scoping stays honest, and there are no em-dashes.

--- a/components/Faq.js
+++ b/components/Faq.js
@@ -5,7 +5,7 @@ export const faqItems = [
     },
     {
         question: 'How is OpenAdapt different from RPA tools like UiPath?',
-        answer: 'With traditional RPA, someone hand-builds the automation, and it breaks when the screen changes. With OpenAdapt you just record the task once. When the screen changes, it fixes itself and shows you the change to approve. And it runs entirely on your own machines.',
+        answer: 'With traditional RPA, someone hand-builds the automation, and it breaks when the screen changes. With OpenAdapt you just record the task once. When the screen changes, it halts, a reviewer teaches the fix, and it is promoted into the workflow as a change you approve. You choose where it runs: our cloud, your own VPC, or fully self-hosted.',
     },
     {
         question: 'How is OpenAdapt different from AI computer-use agents?',
@@ -13,7 +13,7 @@ export const faqItems = [
     },
     {
         question: 'Does my data leave my machines?',
-        answer: 'No. It stays inside your network. Recordings, scripts, and replays all live on your own machines, and a healthy run makes no cloud calls at all. When the screen changes and the script needs a repair, that runs an AI model, but you can run that model on your own hardware inside your network, so your data never goes to a third party. Tools for scrubbing PII and PHI are included, so you can clean captured data before anyone or anything sees it.',
+        answer: 'That depends on the deployment you choose, and it is your choice. Non-regulated teams can use our hosted cloud. Regulated teams run OpenAdapt self-hosted and air-gapped, or managed by us inside their own VPC (single-tenant BYOC); in both of those, PHI never enters our infrastructure and we see only PHI-free run metadata. A healthy run makes no cloud calls at all, and the model that heals a drifted script can run on your own hardware. Tools for scrubbing PII and PHI are included, so you can clean captured data before anyone or anything sees it.',
     },
     {
         question: 'Is OpenAdapt free?',
@@ -21,7 +21,7 @@ export const faqItems = [
     },
     {
         question: 'What software does OpenAdapt work with?',
-        answer: "OpenAdapt works from what is on the screen, not from an API or browser internals. Today it handles web apps, including web EMRs. Because it works from the screen, the same approach can reach desktop apps and software delivered over Citrix or remote desktop. Those adapters are in progress. The goal is to automate the desktop EMRs and loan systems that cloud tools can't touch, with no API integration project.",
+        answer: "OpenAdapt works from what is on the screen, not from an API or browser internals, so one runner drives web apps, Windows desktop apps, and software delivered over Citrix or remote desktop alike. That means the desktop EMRs and loan systems cloud tools can't touch, with no API integration project. If a system already has a solid API, use that instead; OpenAdapt is for everything that doesn't.",
     },
 ]
 

--- a/components/MastHead.js
+++ b/components/MastHead.js
@@ -1,3 +1,11 @@
+/*
+ * TARGET-STATE COPY (HELD, do not publish until the product ships).
+ * This file describes OpenAdapt as it will be once the deployment x substrate
+ * matrix in .private/DESIGN_hosted_matrix_2026_07_14.md lands (web + Windows/Citrix
+ * on one runner; our-cloud / BYOC / self-hosted deployment choice; fail-closed
+ * regulated run; halt -> teach -> promote). See TARGET_STATE.md. Data-residency
+ * claims are scoped per tier, never a blanket company-wide promise.
+ */
 import { useEffect, useState } from 'react'
 import React from 'react'
 import Link from 'next/link'
@@ -10,10 +18,11 @@ import styles from './MastHead.module.css'
 const CarouselSection = () => {
     const [currentIndex, setCurrentIndex] = useState(0);
     const carouselItems = [
-        "Show it once. It runs forever. On your premises.",
+        "Show it once. It runs forever.",
         "Compiled replay. Zero per-run model cost.",
         "Self-healing: UI drift becomes a reviewable diff.",
-        "On the default path, nothing leaves your machine.",
+        "Web and Windows. Citrix and legacy desktops.",
+        "You choose where the data lives.",
     ];
 
     useEffect(() => {
@@ -91,21 +100,25 @@ export default function Home({ githubStats }) {
                                 )}
                             </div>
                             <h1 className="font-display text-2xl md:text-3xl mt-0 mb-4 font-semibold tracking-tight text-ink">
-                                Show it once. It runs forever. On your premises.
+                                Show it once. It runs forever.
                             </h1>
                             <p className="mt-0 mb-6 mx-auto max-w-3xl font-sans font-normal text-base md:text-lg text-ink-2">
                                 OpenAdapt compiles a recorded demonstration into
-                                a self-healing automation that halts rather than
-                                guessing. It&apos;s open source and auditable, and
-                                it runs entirely on your own machines.
+                                a self-healing automation that verifies its own
+                                effect on screen, confirms it is acting on the
+                                right record, and halts rather than guessing.
+                                It&apos;s open source and auditable, and you
+                                choose where it runs.
                             </p>
                             <p className="mt-0 mb-6 mx-auto max-w-3xl font-sans font-normal text-base md:text-lg text-ink-3">
                                 Every automation tool assumes an API. The
                                 systems that actually run your business
                                 don&apos;t: legacy EMRs, Citrix desktops, the
-                                internal apps your team still works by hand.
-                                OpenAdapt learns them from one demonstration and
-                                runs them where your data already lives.
+                                Windows line-of-business apps your team still
+                                works by hand. OpenAdapt learns them from one
+                                demonstration, on web and Windows alike, and runs
+                                them where your data already lives: your machines,
+                                your cloud, or ours.
                             </p>
                             <div className="flex flex-col align-center justify-center px-4 min-w-0 max-w-full overflow-hidden">
                                 <ReplayHero />

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -2,13 +2,19 @@ import Link from 'next/link'
 import { useState } from 'react'
 
 /*
+ * TARGET-STATE COPY (HELD, do not publish until the product ships). Describes
+ * the deployment x substrate matrix in .private/DESIGN_hosted_matrix_2026_07_14.md.
+ * See TARGET_STATE.md.
+ *
  * Pricing — three lanes, value-priced.
  *
- * Enterprise is the primary (visually recommended) card: on-prem, PHI never
- * leaves the building, inference runs on the customer's hardware at zero
- * metered cost. Hosted is a secondary, non-PHI / evaluation on-ramp priced on
- * outcome units (workflow-runs), never per-step / per-seat / per-VLM-call. OSS
- * stays MIT and honest.
+ * Enterprise / BYOC is the primary (visually recommended) card: on-prem or
+ * managed by us inside the customer's own VPC (single-tenant), covering web and
+ * Windows/Citrix; PHI never enters our infrastructure and inference runs in the
+ * customer's environment at zero metered cost. Hosted is a secondary, non-PHI /
+ * evaluation on-ramp (web + desktop-in-cloud) priced on outcome units
+ * (workflow-runs), never per-step / per-seat / per-VLM-call. OSS stays MIT and
+ * honest. Data-residency claims are scoped per tier, never company-wide.
  *
  * Hosted (Phase 0) is a real paid sign-up via Stripe Checkout. The Sign up CTA
  * POSTs to /api/create-checkout-session and redirects to Stripe Checkout. If
@@ -101,8 +107,8 @@ export default function Pricing() {
                 <p className="mx-auto mt-3 max-w-xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
                     The engine is open source and free. When you need it in
                     production, the AI is included in the price: no per-step,
-                    per-seat, or per-call metering. On-premises keeps your data
-                    in your building.
+                    per-seat, or per-call metering. You choose where it runs, so
+                    regulated data can stay entirely in your environment.
                 </p>
 
                 <div className="mt-10 grid items-start gap-6 md:grid-cols-3">
@@ -159,14 +165,15 @@ export default function Pricing() {
                         </div>
                         <p className="mt-3 text-sm leading-relaxed text-ink-2">
                             {cloudAppConfigured
-                                ? 'For teams without on-prem hardware who want a managed cloud runner. Sign up and your subscription links to your dashboard by email, so you are up and running the same day.'
-                                : 'For teams without on-prem hardware who want a managed cloud runner. We onboard you personally to start; the self-serve runner is rolling out.'}
+                                ? 'For non-regulated teams without on-prem hardware who want a managed cloud runner for web and desktop-in-cloud workflows. Sign up and your subscription links to your dashboard by email, so you are up and running the same day.'
+                                : 'For non-regulated teams without on-prem hardware who want a managed cloud runner for web and desktop-in-cloud workflows. We onboard you personally to start; the self-serve runner is rolling out.'}
                         </p>
                         <FeatureList
                             items={[
                                 cloudAppConfigured
                                     ? 'Sign up and land straight in your dashboard'
                                     : 'We set you up personally, nothing for you to run',
+                                'Web and desktop-in-cloud workflows on one runner',
                                 'Up to 10,000 workflow runs a month',
                                 'Hosted inference included at no extra cost',
                                 'No per-step or per-seat billing, no surprise charges',
@@ -180,8 +187,8 @@ export default function Pricing() {
                             >
                                 Enterprise
                             </a>{' '}
-                            runs OpenAdapt inside your own environment, so
-                            regulated data never leaves your network.
+                            runs OpenAdapt inside your own environment, so PHI
+                            never enters our infrastructure.
                         </div>
                         <div className="mt-6 flex-grow" />
                         <button
@@ -219,12 +226,14 @@ export default function Pricing() {
                         </p>
                         <FeatureList
                             items={[
-                                'On-prem, or managed by us inside your own cloud (single-tenant), so PHI never leaves your network',
-                                'Inference runs on your hardware at zero metered cost',
+                                'On-prem, or managed by us inside your own cloud (single-tenant BYOC), so PHI never enters our infrastructure',
+                                'Web, Windows desktop, and Citrix/RDP on one runner',
+                                'Inference runs in your environment at zero metered cost',
+                                'Fail-closed regulated run: refuses unless certified, identity-covered, effect-declared, signed, and version-pinned',
                                 'Pilot first, then an annual platform license',
-                                'On-prem architecture built for BAA and SOC 2 requirements; formal attestation in progress',
+                                'BAA signed for regulated engagements; SOC 2 attestation in progress',
                                 'Audit trail: every run writes an illustrated report',
-                                'Self-healing and fleet management included',
+                                'Self-healing, halt-teach-promote, and fleet management included',
                             ]}
                         />
                         <div className="mt-4 rounded-lg border border-hairline bg-ground p-3 text-xs leading-relaxed text-ink-3">
@@ -251,13 +260,13 @@ export default function Pricing() {
                 {/*
                  * Pilot: the paid on-ramp, not a fourth tier. One clear
                  * engagement: we get one workflow live in 30 days against a
-                 * single agreed success measure, refunded if it misses. $15k
-                 * anchors the value (10-30% of a $30-75k annual license); a
-                 * founding-design-partner discount takes it to $10k to reward
-                 * and earn references from the first customers. The fee credits
-                 * toward the first-year license (NOT "toward the pilot": the fee
-                 * IS the pilot). Sales-led (book a call, then invoice), so the
-                 * CTA is a call, not a checkout.
+                 * single agreed success measure, refunded if it misses. Standard
+                 * scope is $25k-$50k (anchored to a $30-75k annual license); the
+                 * $10k figure is a brutally-narrow founding-design-partner price
+                 * to reward and earn references from the first customers. The fee
+                 * credits toward the first-year license (NOT "toward the pilot":
+                 * the fee IS the pilot). Sales-led (book a call, then invoice),
+                 * so the CTA is a call, not a checkout.
                  */}
                 <div className="mt-6 flex flex-col gap-6 rounded-2xl border border-hairline bg-panel p-6 md:flex-row md:items-center md:justify-between md:p-7">
                     <div className="md:max-w-2xl">
@@ -286,7 +295,10 @@ export default function Pricing() {
                                 </span>
                             </div>
                             <div className="font-mono text-xs text-accent">
-                                Founding pricing, for our first design partners
+                                Founding price for a narrow first workflow
+                            </div>
+                            <div className="font-mono text-xs text-ink-3">
+                                standard scope $25k-$50k
                             </div>
                             <div className="font-mono text-xs text-ink-3">
                                 credited toward your first-year license

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -231,7 +231,7 @@ export default function Pricing() {
                                 'Inference runs in your environment at zero metered cost',
                                 'Fail-closed regulated run: refuses unless certified, identity-covered, effect-declared, signed, and version-pinned',
                                 'Pilot first, then an annual platform license',
-                                'BAA signed for regulated engagements; SOC 2 attestation in progress',
+                                'We sign a BAA (US) or PHIPA agreement (Canada) for regulated engagements',
                                 'Audit trail: every run writes an illustrated report',
                                 'Self-healing, halt-teach-promote, and fleet management included',
                             ]}

--- a/components/SafetyBand.js
+++ b/components/SafetyBand.js
@@ -17,15 +17,19 @@ export default function SafetyBand() {
             <div className="mx-auto max-w-3xl px-6 py-12 text-center">
                 <p className="eyebrow mb-2">Safety</p>
                 <h2 className="font-display text-2xl md:text-3xl font-semibold tracking-tight text-ink mb-4">
-                    It halts instead of guessing.
+                    It halts instead of guessing, then you teach it the fix.
                 </h2>
                 <p className="mx-auto max-w-2xl text-base md:text-lg text-ink-2">
-                    When the UI drifts and a step gets ambiguous, OpenAdapt
-                    stops and flags a person rather than writing to the wrong
-                    record. We built an adversarial test suite to measure how
-                    often it could still pick the wrong target, put our own
-                    engine through seven rounds of it, and publish every
-                    result, including what it gets wrong today.
+                    Every step reads its own result back off the screen and
+                    confirms it is acting on the right record before it moves on.
+                    When the UI drifts and a step gets ambiguous, OpenAdapt stops
+                    and flags a person rather than writing to the wrong record. A
+                    reviewer teaches the fix once, and it is promoted into the
+                    compiled workflow through governed review, so the next run is
+                    clean. We built an adversarial test suite to measure how often
+                    it could still pick the wrong target, put our own engine
+                    through seven rounds of it, and publish every result, including
+                    what it gets wrong today.
                 </p>
                 <div className="mt-6 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm">
                     <a

--- a/pages/compare.js
+++ b/pages/compare.js
@@ -49,14 +49,14 @@ const rows = [
     },
     {
         dimension: 'Where it runs',
-        openadapt: 'Your machines',
+        openadapt: 'Your machines, your cloud, or ours (you choose)',
         rpa: 'Your infrastructure or vendor cloud',
         agents: 'Vendor cloud, with screenshots of your screen',
         browser: 'The browser; often with a cloud backend',
     },
     {
         dimension: 'App coverage',
-        openadapt: 'Desktop, web, and VDI/RDP (vision-based; adapters in progress)',
+        openadapt: 'Web, Windows desktop, and Citrix/RDP (one vision-based runner)',
         rpa: 'Desktop and web via connectors',
         agents: 'Anything on screen',
         browser: 'Browser only',
@@ -160,7 +160,8 @@ export default function ComparePage() {
                         Honest exception, published against ourselves: inside a
                         browser, an identity-keyed competitor is just as safe. We
                         pull ahead where there is no browser to lean on, which is
-                        most of this work: desktop EMRs, Citrix, and Windows.
+                        most of this work: desktop EMRs, Citrix, and Windows,
+                        which the same runner drives directly.
                     </p>
                     <p className="mt-4 text-xs leading-relaxed text-ink-3">
                         &ldquo;Zero wrong actions&rdquo; is a target, not a boast;
@@ -208,8 +209,10 @@ export default function ComparePage() {
                     on novel work, but for repetitive work every run is slow,
                     differently-pathed, billed, and usually sends your screen to
                     the cloud. OpenAdapt uses a model only at compile and heal
-                    time. A healthy run is a local compiled replay: same steps, no
-                    model calls, no per-run bill, screen stays on your machines.
+                    time. A healthy run is a compiled replay: same steps, no
+                    model calls, no per-run bill, and on a self-hosted or
+                    in-your-VPC deployment the screen never leaves your
+                    environment.
                 </p>
 
                 <div className="mt-6 rounded-2xl border border-hairline bg-panel p-6 md:p-8">
@@ -308,8 +311,9 @@ export default function ComparePage() {
                     workflow lives in a browser tab, they&#39;re worth a look. The
                     structural limit: they can&#39;t reach the desktop EMR, the
                     Windows loan system, or anything over Citrix. OpenAdapt works
-                    from pixels and inputs, so the same approach extends to desktop
-                    and VDI/RDP (adapters in progress), all on your infrastructure.
+                    from pixels and inputs, so one runner reaches the browser, the
+                    Windows desktop, and Citrix/RDP alike, deployed wherever your
+                    data lives.
                 </p>
 
                 <h2 className="mt-12 font-display text-xl font-semibold tracking-tight text-ink">

--- a/pages/index.js
+++ b/pages/index.js
@@ -27,7 +27,7 @@ const organizationSchema = {
         height: 512,
     },
     description:
-        'Open-source demonstration compiler for desktop automation. Record a workflow once and OpenAdapt compiles it into a self-healing automation that runs entirely on your own machines with no per-run model calls.',
+        'Open-source demonstration compiler for desktop automation. Record a workflow once and OpenAdapt compiles it into a self-healing automation that verifies its own effect on screen and halts rather than guessing. One runner covers web, Windows desktop, and Citrix, deployed in our cloud, your VPC, or fully self-hosted, with no per-run model calls on a healthy run.',
     foundingDate: '2023',
     sameAs: [
         'https://github.com/OpenAdaptAI/OpenAdapt',
@@ -55,7 +55,7 @@ const softwareSchema = {
     applicationCategory: 'DeveloperApplication',
     operatingSystem: 'Windows, macOS, Linux',
     description:
-        'Open-source demonstration compiler for desktop automation. Record a workflow once and OpenAdapt compiles it into a self-healing script that replays locally with no per-run model calls. A model is only used to heal the script when the UI drifts, and the fix is proposed as a reviewable diff.',
+        'Open-source demonstration compiler for desktop automation. Record a workflow once and OpenAdapt compiles it into a self-healing script that replays with no per-run model calls across web, Windows desktop, and Citrix. A model is only used to heal the script when the UI drifts; when a step is ambiguous the run halts, a reviewer teaches the fix, and it is promoted through governed review. Deploy in our cloud, your VPC, or fully self-hosted.',
     url: 'https://openadapt.ai',
     downloadUrl: 'https://pypi.org/project/openadapt/',
     author: {
@@ -74,9 +74,13 @@ const softwareSchema = {
     featureList: [
         'Record a desktop workflow once as a demonstration',
         'Compile demonstrations into editable automation scripts',
-        'Local replay with zero per-run model cost',
+        'One runner for web, Windows desktop, and Citrix/RDP',
+        'Replay with zero per-run model cost on a healthy run',
         'Self-healing: UI drift is repaired via a fallback ladder and proposed as a reviewable diff',
-        'Local-first: recordings, scripts, and replays stay on your infrastructure',
+        'On-screen effect verification and identity gate before each write',
+        'Halts on ambiguity, then teach the fix and promote it through governed review',
+        'Fail-closed regulated execution: refuses unless certified, identity-covered, effect-declared, signed, and version-pinned',
+        'Deploy in our cloud, in your VPC, or fully self-hosted (PHI never enters our infrastructure)',
         'PII/PHI data scrubbing for sensitive workflows',
         'Illustrated audit report for every run',
     ],
@@ -90,7 +94,7 @@ const websiteSchema = {
     alternateName: 'OpenAdapt',
     url: 'https://openadapt.ai',
     description:
-        'Open-source demonstration compiler: record a desktop workflow once and it compiles into a self-healing automation that runs on your premises with no per-run model calls.',
+        'Open-source demonstration compiler: record a desktop workflow once and it compiles into a self-healing automation across web, Windows, and Citrix, deployed where you choose, with no per-run model calls on a healthy run.',
     publisher: {
         '@type': 'Organization',
         name: 'OpenAdapt.AI',

--- a/pages/pricing.js
+++ b/pages/pricing.js
@@ -11,7 +11,7 @@ export default function PricingPage() {
                 <title>Pricing | OpenAdapt.AI</title>
                 <meta
                     name="description"
-                    content="OpenAdapt pricing: the open-source engine is free (MIT), a hosted runner for non-PHI teams, and on-premises Enterprise where PHI never leaves your building and inference runs on your hardware at zero metered cost. No per-step, per-seat, or per-model-call charges."
+                    content="OpenAdapt pricing: the open-source engine is free (MIT), a hosted runner for non-PHI teams (web and desktop-in-cloud), and Enterprise on-prem or in-your-VPC where PHI never enters our infrastructure and inference runs in your environment at zero metered cost. No per-step, per-seat, or per-model-call charges."
                 />
                 <link rel="canonical" href="https://openadapt.ai/pricing" />
                 <meta property="og:title" content="Pricing | OpenAdapt.AI" />

--- a/pages/security.js
+++ b/pages/security.js
@@ -77,7 +77,7 @@ const posture = [
     {
         status: 'yes',
         title: 'BAA (Business Associate Agreement)',
-        body: 'We sign a BAA for regulated BYOC and on-prem engagements, backed by a documented HIPAA risk analysis, even though the PHI-touching data plane runs inside your environment. If your pilot needs one, we scope it as part of the engagement.',
+        body: 'We sign a BAA (US) or a PHIPA data-processing agreement (Canada) for regulated BYOC and on-prem engagements. Because the PHI-touching data plane runs inside your environment, PHI never enters our infrastructure. If your pilot needs one, we scope it as part of the engagement.',
     },
     {
         status: 'progress',

--- a/pages/security.js
+++ b/pages/security.js
@@ -13,7 +13,7 @@ const webPageSchema = {
     name: 'Security and trust',
     url: 'https://openadapt.ai/security',
     description:
-        'How OpenAdapt handles your data: on-premises, local-first, model-free on the default replay path. What is and is not certified today, and how to report a vulnerability.',
+        'How OpenAdapt handles your data: a deployment-choice spectrum (our cloud, your VPC, or self-hosted), model-free on the default replay path, fail-closed for regulated runs. What is and is not certified today, and how to report a vulnerability.',
     isPartOf: {
         '@type': 'WebSite',
         name: 'OpenAdapt.AI',
@@ -31,13 +31,33 @@ const webPageSchema = {
 const posture = [
     {
         status: 'yes',
-        title: 'On-premises, local-first by architecture',
-        body: 'Recordings, scripts, and replays live on your own machines. In an on-premises deployment, the AI model runs on your hardware too, so your data stays inside your network.',
+        title: 'You choose where the data lives',
+        body: 'OpenAdapt runs three ways: our cloud for non-regulated work, managed by us inside your own VPC (single-tenant BYOC), or fully self-hosted and air-gapped. The data-residency guarantee is scoped to the deployment you pick, not a single company-wide promise. For BYOC and self-hosted, PHI never enters our infrastructure.',
+    },
+    {
+        status: 'yes',
+        title: 'PHI never enters our infrastructure (BYOC and self-hosted)',
+        body: 'On a self-hosted or in-your-VPC deployment, recordings, scripts, replays, and the model that heals them all run inside your perimeter. Our control plane sees only PHI-free run metadata: status, timestamps, and aggregate counts. It never sees screenshots, field values, patient identifiers, or run report bodies.',
     },
     {
         status: 'yes',
         title: 'No AI calls on a normal run',
         body: 'A normal replay makes no cloud AI calls, so nothing about the run leaves your machine. An AI model is only used when you first compile the recording, or when the screen changes and the script needs a repair. You can run that model on your own hardware inside your network, so your data never goes to a third party.',
+    },
+    {
+        status: 'yes',
+        title: 'Fail-closed regulated execution',
+        body: 'In regulated mode, a run refuses to start unless the workflow is a certified, signed bundle, every write step declares the effect it must verify on screen, identity coverage is complete, and the configuration is pinned to a reviewed version. Missing any of these, it refuses to run rather than proceed unchecked.',
+    },
+    {
+        status: 'yes',
+        title: 'Effect verification and identity gate',
+        body: 'Each step reads its own result back off the screen and confirms it is acting on the intended record before it moves on. This is an on-screen read-back, not an independent second source of truth, and we scope its coverage honestly: it confirms name and date of birth, and halts rather than write when only a look-alike identifier separates two records.',
+    },
+    {
+        status: 'yes',
+        title: 'Halt, teach, promote',
+        body: 'When a step is ambiguous the run halts and flags a person. A reviewer teaches the fix once, and it is promoted into the compiled workflow through governed review, so the change is auditable rather than a silent edit.',
     },
     {
         status: 'yes',
@@ -55,14 +75,14 @@ const posture = [
         body: 'The engine is MIT-licensed. You can read the code, run it yourself, and verify these claims rather than take them on trust.',
     },
     {
-        status: 'progress',
-        title: 'SOC 2',
-        body: 'We do not hold a SOC 2 attestation today. The on-prem architecture is built to meet SOC 2 requirements and formal attestation is in progress. We will not claim otherwise until a report exists.',
+        status: 'yes',
+        title: 'BAA (Business Associate Agreement)',
+        body: 'We sign a BAA for regulated BYOC and on-prem engagements, backed by a documented HIPAA risk analysis, even though the PHI-touching data plane runs inside your environment. If your pilot needs one, we scope it as part of the engagement.',
     },
     {
-        status: 'planned',
-        title: 'BAA (Business Associate Agreement)',
-        body: 'We do not run a standing BAA program today. If an enterprise pilot requires a BAA, talk to us and we will scope it as part of the engagement. We would rather tell you this up front than imply a program we have not stood up.',
+        status: 'progress',
+        title: 'SOC 2',
+        body: 'We do not hold a SOC 2 attestation today. The architecture is built to meet SOC 2 requirements and formal attestation is in progress. We will not claim otherwise until a report exists.',
     },
 ]
 
@@ -85,7 +105,7 @@ export default function SecurityPage() {
                 <title>Security and trust | OpenAdapt</title>
                 <meta
                     name="description"
-                    content="How OpenAdapt handles your data: on-premises, local-first, and model-free on the default replay path. An honest account of what is and is not certified today, and how to report a vulnerability."
+                    content="How OpenAdapt handles your data: a deployment-choice spectrum (our cloud, your VPC, or self-hosted), model-free on the default replay path, and fail-closed for regulated runs. An honest account of what is and is not certified today, and how to report a vulnerability."
                 />
                 <link rel="canonical" href="https://openadapt.ai/security" />
                 <meta
@@ -94,7 +114,7 @@ export default function SecurityPage() {
                 />
                 <meta
                     property="og:description"
-                    content="On-premises, local-first, model-free on the default path. What is and is not certified yet, stated plainly, plus how to report a vulnerability."
+                    content="A deployment-choice spectrum, model-free on the default path, fail-closed for regulated runs. What is and is not certified yet, stated plainly, plus how to report a vulnerability."
                 />
                 <meta property="og:url" content="https://openadapt.ai/security" />
                 <script
@@ -112,10 +132,13 @@ export default function SecurityPage() {
                     certified yet
                 </h1>
                 <p className="mt-5 max-w-3xl text-base text-ink-2 md:text-lg">
-                    OpenAdapt is built to run where your data already lives. This
-                    page states our posture plainly: what is in place today, what
-                    is underway, and what is still just planned. If a badge is not
-                    here, we do not have it yet.
+                    OpenAdapt runs where you choose: our cloud for non-regulated
+                    work, managed inside your own VPC, or fully self-hosted. Every
+                    data-residency claim below is scoped to the deployment you
+                    pick, never a blanket company-wide promise. This page states
+                    our posture plainly: what is in place today, what is underway,
+                    and what is still just planned. If a badge is not here, we do
+                    not have it yet.
                 </p>
 
                 <div className="mt-10 space-y-4">

--- a/pages/solutions/healthcare.js
+++ b/pages/solutions/healthcare.js
@@ -11,7 +11,7 @@ export default function HealthcarePage() {
                 <title>Healthcare Clinic Automation — Referral Intake & EMR Data Entry | OpenAdapt</title>
                 <meta
                     name="description"
-                    content="OpenAdapt compiles a recorded demonstration of referral intake or EMR data entry into a self-healing automation that runs inside your clinic. PHI never leaves your machines. Web EMRs today, with desktop and VDI adapters in progress."
+                    content="OpenAdapt compiles a recorded demonstration of referral intake or EMR data entry into a self-healing automation that runs inside your environment. Web, desktop, and Citrix EMRs. Deployed on-prem or managed by us inside your own VPC, so PHI never enters our infrastructure."
                 />
                 <link rel="canonical" href="https://openadapt.ai/solutions/healthcare" />
                 <meta property="og:title" content="Healthcare Clinic Automation | OpenAdapt" />
@@ -30,10 +30,13 @@ export default function HealthcarePage() {
                 <p className="mt-5 max-w-3xl text-base text-ink-2 md:text-lg">
                     Record the intake workflow once (open the referral, read
                     the fields, enter them into the EMR) and OpenAdapt
-                    compiles it into an automation your clinic runs on its own
-                    machines. Healthy runs make no cloud model calls, and when
-                    the EMR&#39;s screens change, the fix arrives as a
-                    reviewable diff, not a support ticket.
+                    compiles it into an automation your clinic runs inside its
+                    own environment, whether the EMR is a web app, a Windows
+                    desktop, or delivered over Citrix. Healthy runs make no
+                    cloud model calls, and when the EMR&#39;s screens change,
+                    the automation halts, a reviewer teaches the fix, and it is
+                    promoted into the workflow as a reviewable diff, not a
+                    support ticket.
                 </p>
                 <div className="mt-7 flex flex-wrap gap-3">
                     <Link
@@ -56,18 +59,20 @@ export default function HealthcarePage() {
             <div className="mx-auto max-w-4xl px-4 py-12">
                 <div className="rounded-2xl border border-hairline bg-panel p-6 md:p-8">
                     <h2 className="font-display text-xl font-semibold tracking-tight text-ink">
-                        Why local matters here
+                        Your data stays in your environment
                     </h2>
                     <p className="mt-3 text-sm leading-relaxed text-ink-2 md:text-base">
-                        PHI never leaves the clinic. OpenAdapt is local-first
-                        by architecture: recordings, compiled scripts, and
-                        replays all stay on your own infrastructure, and
-                        PII/PHI scrubbing tooling is included. Because it
-                        works from the screen rather than browser internals,
-                        the same vision-based approach is designed to reach the
-                        desktop and VDI EMRs that cloud automation tools
-                        can&#39;t. Web EMRs are supported today, and those
-                        desktop and VDI adapters are in progress.
+                        For regulated workloads you deploy OpenAdapt one of two
+                        ways: fully on-prem and air-gapped, or managed by us
+                        inside your own cloud (single-tenant BYOC). Either way,
+                        recordings, compiled scripts, replays, and the model
+                        that heals them all run inside your perimeter, and PHI
+                        never enters our infrastructure. We see only PHI-free
+                        run metadata (status, timings, counts), and we sign a
+                        BAA for the engagement. Because OpenAdapt works from the
+                        screen rather than browser internals, it reaches web,
+                        Windows-desktop, and Citrix EMRs alike, including the
+                        legacy systems cloud automation tools can&#39;t touch.
                     </p>
                 </div>
 
@@ -117,6 +122,21 @@ export default function HealthcarePage() {
                         every run: what ran, what it saw, what changed.
                     </li>
                 </ul>
+
+                <div className="mt-8 rounded-2xl border border-hairline bg-panel p-6 md:p-8">
+                    <p className="eyebrow">Fail-closed by default</p>
+                    <h2 className="mt-2 font-display text-xl font-semibold tracking-tight text-ink">
+                        A regulated run refuses to start unless it is safe.
+                    </h2>
+                    <p className="mt-3 text-sm leading-relaxed text-ink-2 md:text-base">
+                        In regulated mode, OpenAdapt will not touch a chart
+                        unless the workflow is a certified, signed bundle, every
+                        write step declares the effect it must verify on screen,
+                        identity coverage is complete, and the configuration is
+                        pinned to a reviewed version. If any of those is missing,
+                        it refuses to run rather than proceed unchecked.
+                    </p>
+                </div>
 
                 <div className="mt-12 rounded-2xl border-2 border-ink bg-panel p-6 text-center md:p-8">
                     <h2 className="font-display text-xl font-semibold tracking-tight text-ink">

--- a/pages/solutions/healthcare.js
+++ b/pages/solutions/healthcare.js
@@ -69,7 +69,8 @@ export default function HealthcarePage() {
                         that heals them all run inside your perimeter, and PHI
                         never enters our infrastructure. We see only PHI-free
                         run metadata (status, timings, counts), and we sign a
-                        BAA for the engagement. Because OpenAdapt works from the
+                        BAA (US) or PHIPA agreement (Canada) for the engagement.
+                        Because OpenAdapt works from the
                         screen rather than browser internals, it reaches web,
                         Windows-desktop, and Citrix EMRs alike, including the
                         legacy systems cloud automation tools can&#39;t touch.


### PR DESCRIPTION
## HELD spec branch — do NOT merge

This rewrites the landing surfaces to describe OpenAdapt **as it will be** once the currently-in-flight deployment × substrate work lands, NOT as it is today. It is a specification for the marketing surface, held until the product actually reaches this state. Grounded in `.private/DESIGN_hosted_matrix_2026_07_14.md` and the July-13 honesty ethos. See `TARGET_STATE.md`.

**Do not publish or merge until the product ships the capabilities described here.** Merging early would put untrue claims on the public site. The gap list below drives the remaining implementation.

## Surfaces rewritten (coherently)
Hero/MastHead, safety band, healthcare solution, compare, pricing, security, FAQ, and the home JSON-LD schema.

## What the target state adds over today's live copy
- **One substrate-agnostic runner** for web **AND** Windows desktop / Citrix-RDP (drops the "adapters in progress" framing).
- **A deployment-choice spectrum** (our cloud non-PHI · BYOC / your-VPC regulated · self-hosted / on-prem air-gapped) replacing the blanket "on your premises" claim.
- **Fail-closed regulated execution**: a run refuses unless certified, full identity coverage, declared+verified effects, encrypted/signed bundle, version-pinned config.
- **Halt → teach → promote** as a shipped loop; on-screen effect verification before each write.
- **Pricing tiers**: OSS free · Hosted \$500/mo (web + desktop-in-cloud) · Enterprise/BYOC (PHI never enters our infrastructure) · pilot \$10k founding / \$25k–\$50k standard, credited to first-year license, refund if KPI missed.

## Honesty guardrails held
- **No invented benchmarks** — only the real OpenEMR 20/20 vs 10/10 and MockMed results, with existing caveats, unchanged.
- Effect verification described as **on-screen read-back**, not independent verification; identity/effect scoping kept honest.
- **Data-residency claims scoped per tier** ("PHI never enters our infrastructure" for BYOC/self-host); the company-wide "never leaves your network" tagline is gone.
- **No em-dashes.** `npm run build` passes.

## What this copy claims that isn't true YET (gap list → drives implementation)
- **Windows desktop / Citrix-RDP as a shipped substrate.** Design doc: substrate is TO-BUILD (Windows-in-QEMU + Guacamole/win_agent not wired to the control plane). Copy presents it as GA.
- **BYOC / your-VPC as a purchasable deployment.** The outbound-only Connector + pull queue + customer-owned storage are TO-BUILD (Phase 1, demand-gated).
- **Our-cloud Hosted desktop-in-cloud runner.** Web Modal runner is PARTIAL (waitlist/billing); the desktop-in-cloud runner is TO-BUILD.
- **Fail-closed regulated `openadapt-flow run` with all five gates enforced.** The full certified+identity+effect+signed+version-pinned refusal is not proven end-to-end on a real recording.
- **Halt → teach → promote as a governed shipped loop.** Halt exists; teach-the-fix + governed promotion is not a shipped end-to-end loop on real recordings.
- **"PHI never enters our infrastructure" as a live guarantee.** Blocked by the compliance gate (§6): cleartext-PHI at rest/in transit must close first; no lane may carry real PHI until then.
- **BAA signed for regulated engagements + documented HIPAA risk analysis.** Legal artifacts not yet stood up.
- **Enterprise inference "runs in your environment at zero metered cost" for desktop/Citrix.** Depends on the Windows substrate above existing.
- **\$25k–\$50k standard pilot scope / \$500/mo Hosted with desktop-in-cloud.** Pricing presented as available; Hosted self-serve is still rolling out and the desktop runner does not exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKrVJJy5jWVCkXAqgUqtqZ