### PR TITLE
feat: /download page (OS detection + latest GitHub Release assets + unsigned-build guidance)

### DIFF
--- a/components/NavHeader.js
+++ b/components/NavHeader.js
@@ -17,7 +17,6 @@ const NAV_LINKS = [
     { label: 'Safety', href: '/safety' },
     { label: 'Compare', href: '/compare' },
     { label: 'Pricing', href: '/#pricing' },
-    { label: 'Download', href: '/download' },
     { label: 'About', href: '/about' },
     {
         label: 'Open source',
@@ -105,8 +104,7 @@ export default function NavHeader() {
                                 rel="noopener noreferrer"
                                 onClick={() => {
                                     const ev = externalEvent(item.href)
-                                    if (ev)
-                                        track(ev, { location: 'nav_mobile' })
+                                    if (ev) track(ev, { location: 'nav_mobile' })
                                 }}
                             >
                                 {item.label}

--- a/components/NavHeader.js
+++ b/components/NavHeader.js
@@ -17,6 +17,7 @@ const NAV_LINKS = [
     { label: 'Safety', href: '/safety' },
     { label: 'Compare', href: '/compare' },
     { label: 'Pricing', href: '/#pricing' },
+    { label: 'Download', href: '/download' },
     { label: 'About', href: '/about' },
     {
         label: 'Open source',
@@ -104,7 +105,8 @@ export default function NavHeader() {
                                 rel="noopener noreferrer"
                                 onClick={() => {
                                     const ev = externalEvent(item.href)
-                                    if (ev) track(ev, { location: 'nav_mobile' })
+                                    if (ev)
+                                        track(ev, { location: 'nav_mobile' })
                                 }}
                             >
                                 {item.label}

--- a/cypress/e2e/download.cy.js
+++ b/cypress/e2e/download.cy.js
@@ -1,5 +1,10 @@
-const RELEASES_API =
-    'https://api.github.com/repos/OpenAdaptAI/openadapt-desktop/releases?per_page=20'
+import {
+    assetForPlatform,
+    DESKTOP_PLATFORMS,
+    detectDesktopPlatform,
+    releaseSigningState,
+    selectExperimentalDesktopRelease,
+} from '../../utils/desktopRelease'
 
 function asset(name, size = 1048576) {
     return {
@@ -28,56 +33,67 @@ function experimentalRelease(overrides = {}) {
     }
 }
 
-describe('desktop downloads', () => {
-    it('does not imply installers exist before a complete prerelease is public', () => {
-        cy.intercept('GET', RELEASES_API, {
-            body: [
-                {
-                    draft: false,
-                    prerelease: false,
-                    tag_name: 'v0.3.2',
-                    assets: [asset('openadapt_desktop-0.3.2-py3-none-any.whl')],
-                },
-            ],
-        })
-        cy.visit('/download')
-
-        cy.contains('Experimental desktop')
-        cy.contains('No public desktop installer yet')
-        cy.contains('Install the working CLI')
-            .should('have.attr', 'href')
-            .and('equal', 'https://docs.openadapt.ai')
-        cy.contains('All downloads').should('not.exist')
-        cy.contains('First launch').should('not.exist')
-    })
-
-    it('selects a complete desktop-v Experimental prerelease and exact assets', () => {
+describe('desktop release contract', () => {
+    it('ignores legacy, draft, and incomplete releases', () => {
+        const legacy = {
+            draft: false,
+            prerelease: false,
+            tag_name: 'v0.3.2',
+            assets: [asset('openadapt_desktop-0.3.2-py3-none-any.whl')],
+        }
+        const draft = experimentalRelease({ draft: true })
         const incomplete = experimentalRelease({
             tag_name: 'desktop-v0.2.0',
             assets: [asset('unrelated.msi')],
         })
-        cy.intercept('GET', RELEASES_API, {
-            body: [incomplete, experimentalRelease()],
-        })
-        cy.visit('/download')
 
-        cy.contains('Experimental prerelease desktop-v0.1.0')
-        cy.contains('All downloads')
-        cy.contains('Windows (x64)')
-            .parents('.rounded-xl')
-            .contains('Download')
-            .should(
-                'have.attr',
-                'href',
-                'https://downloads.example/OpenAdapt-Desktop-Experimental-v0.1.0-windows-x86_64-unsigned.msi'
-            )
-        cy.contains('macOS (Apple Silicon)')
-        cy.contains('macOS (Intel)')
-        cy.contains('Linux (x64)')
-        cy.contains('The DMGs are ad-hoc signed')
-        cy.contains('The Windows installers are not yet Authenticode signed')
-        cy.contains('Download SHA256SUMS')
-            .should('have.attr', 'href')
-            .and('equal', 'https://downloads.example/SHA256SUMS')
+        expect(
+            selectExperimentalDesktopRelease([legacy, draft, incomplete])
+        ).to.equal(null)
+    })
+
+    it('selects the newest complete desktop-v Experimental prerelease', () => {
+        const incomplete = experimentalRelease({
+            tag_name: 'desktop-v0.2.0',
+            assets: [asset('unrelated.msi')],
+        })
+        const complete = experimentalRelease()
+        const selected = selectExperimentalDesktopRelease([
+            incomplete,
+            complete,
+        ])
+
+        expect(selected).to.equal(complete)
+        const windows = DESKTOP_PLATFORMS.find(
+            (platform) => platform.id === 'windows'
+        )
+        expect(assetForPlatform(selected.assets, windows).name).to.equal(
+            'OpenAdapt-Desktop-Experimental-v0.1.0-windows-x86_64-unsigned.msi'
+        )
+        expect(releaseSigningState(selected.assets)).to.deep.equal({
+            macosNotarized: false,
+            windowsSigned: false,
+        })
+    })
+
+    it('does not guess unsupported or ambiguous architectures', () => {
+        expect(
+            detectDesktopPlatform({
+                userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X)',
+                platform: 'MacIntel',
+            })
+        ).to.equal(null)
+        expect(
+            detectDesktopPlatform({
+                userAgent: 'Mozilla/5.0 (X11; Linux aarch64)',
+                platform: 'Linux armv8l',
+            })
+        ).to.equal(null)
+        expect(
+            detectDesktopPlatform({
+                userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+                platform: 'Win32',
+            })
+        ).to.equal('windows')
     })
 })

--- a/cypress/e2e/download.cy.js
+++ b/cypress/e2e/download.cy.js
@@ -1,0 +1,83 @@
+const RELEASES_API =
+    'https://api.github.com/repos/OpenAdaptAI/openadapt-desktop/releases?per_page=20'
+
+function asset(name, size = 1048576) {
+    return {
+        name,
+        size,
+        browser_download_url: `https://downloads.example/${name}`,
+    }
+}
+
+function experimentalRelease(overrides = {}) {
+    const prefix = 'OpenAdapt-Desktop-Experimental-v0.1.0'
+    return {
+        draft: false,
+        prerelease: true,
+        tag_name: 'desktop-v0.1.0',
+        assets: [
+            asset(`${prefix}-macos-arm64-adhoc.dmg`),
+            asset(`${prefix}-macos-x86_64-adhoc.dmg`),
+            asset(`${prefix}-windows-x86_64-unsigned.msi`),
+            asset(`${prefix}-windows-x86_64-unsigned-nsis-setup.exe`),
+            asset(`${prefix}-linux-x86_64-unsigned.AppImage`),
+            asset(`${prefix}-linux-x86_64-unsigned.deb`),
+            asset('SHA256SUMS', 512),
+        ],
+        ...overrides,
+    }
+}
+
+describe('desktop downloads', () => {
+    it('does not imply installers exist before a complete prerelease is public', () => {
+        cy.intercept('GET', RELEASES_API, {
+            body: [
+                {
+                    draft: false,
+                    prerelease: false,
+                    tag_name: 'v0.3.2',
+                    assets: [asset('openadapt_desktop-0.3.2-py3-none-any.whl')],
+                },
+            ],
+        })
+        cy.visit('/download')
+
+        cy.contains('Experimental desktop')
+        cy.contains('No public desktop installer yet')
+        cy.contains('Install the working CLI')
+            .should('have.attr', 'href')
+            .and('equal', 'https://docs.openadapt.ai')
+        cy.contains('All downloads').should('not.exist')
+        cy.contains('First launch').should('not.exist')
+    })
+
+    it('selects a complete desktop-v Experimental prerelease and exact assets', () => {
+        const incomplete = experimentalRelease({
+            tag_name: 'desktop-v0.2.0',
+            assets: [asset('unrelated.msi')],
+        })
+        cy.intercept('GET', RELEASES_API, {
+            body: [incomplete, experimentalRelease()],
+        })
+        cy.visit('/download')
+
+        cy.contains('Experimental prerelease desktop-v0.1.0')
+        cy.contains('All downloads')
+        cy.contains('Windows (x64)')
+            .parents('.rounded-xl')
+            .contains('Download')
+            .should(
+                'have.attr',
+                'href',
+                'https://downloads.example/OpenAdapt-Desktop-Experimental-v0.1.0-windows-x86_64-unsigned.msi'
+            )
+        cy.contains('macOS (Apple Silicon)')
+        cy.contains('macOS (Intel)')
+        cy.contains('Linux (x64)')
+        cy.contains('The DMGs are ad-hoc signed')
+        cy.contains('The Windows installers are not yet Authenticode signed')
+        cy.contains('Download SHA256SUMS')
+            .should('have.attr', 'href')
+            .and('equal', 'https://downloads.example/SHA256SUMS')
+    })
+})

--- a/pages/download.js
+++ b/pages/download.js
@@ -1,0 +1,436 @@
+import { useEffect, useMemo, useState } from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+
+import Footer from '@components/Footer'
+import { track } from 'utils/analytics'
+
+const REPO = 'OpenAdaptAI/openadapt-desktop'
+const RELEASES_API = `https://api.github.com/repos/${REPO}/releases/latest`
+const RELEASES_PAGE = `https://github.com/${REPO}/releases`
+
+// Platform definitions. `match` classifies a release asset by filename so the
+// page stays correct no matter how the CI names its artifacts, as long as the
+// extension and arch token are present.
+const PLATFORMS = [
+    {
+        id: 'windows',
+        label: 'Windows',
+        arch: 'x64',
+        hint: '.msi installer (or .exe)',
+        match: (name) =>
+            /\.msi$/i.test(name) ||
+            (/\.exe$/i.test(name) && /setup/i.test(name)),
+        // Prefer the .msi over the NSIS .exe when both are present.
+        rank: (name) => (/\.msi$/i.test(name) ? 0 : 1),
+    },
+    {
+        id: 'macos-arm',
+        label: 'macOS',
+        arch: 'Apple Silicon',
+        hint: '.dmg for M1 and later',
+        match: (name) => /\.dmg$/i.test(name) && /(aarch64|arm64)/i.test(name),
+        rank: () => 0,
+    },
+    {
+        id: 'macos-x64',
+        label: 'macOS',
+        arch: 'Intel',
+        hint: '.dmg for Intel Macs',
+        match: (name) =>
+            /\.dmg$/i.test(name) && /(x64|x86_64|intel)/i.test(name),
+        rank: () => 0,
+    },
+    {
+        id: 'linux',
+        label: 'Linux',
+        arch: 'x64',
+        hint: '.AppImage (or .deb)',
+        match: (name) => /\.appimage$/i.test(name) || /\.deb$/i.test(name),
+        rank: (name) => (/\.appimage$/i.test(name) ? 0 : 1),
+    },
+]
+
+// Best-effort OS + arch detection so we can surface the right build first.
+// Returns a platform id, or null when we cannot tell.
+function detectPlatformId() {
+    if (typeof navigator === 'undefined') return null
+    const ua = (navigator.userAgent || '').toLowerCase()
+    const platform = (navigator.platform || '').toLowerCase()
+
+    if (/win/.test(ua) || /win/.test(platform)) return 'windows'
+    if (/linux/.test(ua) && !/android/.test(ua)) return 'linux'
+    if (/mac/.test(ua) || /mac/.test(platform)) {
+        // On Apple Silicon, WebGL/renderer and touch heuristics are unreliable;
+        // default to Apple Silicon (the common case) and let the user pick
+        // Intel from the full list if needed.
+        return 'macos-arm'
+    }
+    return null
+}
+
+// Given a release's assets and a platform, pick the best matching download.
+function assetForPlatform(assets, platform) {
+    const candidates = assets
+        .filter((a) => platform.match(a.name))
+        .sort((a, b) => platform.rank(a.name) - platform.rank(b.name))
+    return candidates[0] || null
+}
+
+function formatSize(bytes) {
+    if (!bytes && bytes !== 0) return ''
+    const mb = bytes / (1024 * 1024)
+    return `${mb.toFixed(1)} MB`
+}
+
+export default function DownloadPage() {
+    const [status, setStatus] = useState('loading') // loading | ready | none | error
+    const [release, setRelease] = useState(null)
+    const [detectedId, setDetectedId] = useState(null)
+
+    useEffect(() => {
+        setDetectedId(detectPlatformId())
+
+        let cancelled = false
+        async function load() {
+            try {
+                const res = await fetch(RELEASES_API, {
+                    headers: { Accept: 'application/vnd.github+json' },
+                })
+                if (cancelled) return
+                if (res.status === 404) {
+                    setStatus('none')
+                    return
+                }
+                if (!res.ok) {
+                    setStatus('error')
+                    return
+                }
+                const data = await res.json()
+                setRelease(data)
+                const hasAssets =
+                    Array.isArray(data.assets) && data.assets.length > 0
+                setStatus(hasAssets ? 'ready' : 'none')
+            } catch (err) {
+                if (!cancelled) setStatus('error')
+            }
+        }
+        load()
+        return () => {
+            cancelled = true
+        }
+    }, [])
+
+    const assets =
+        release && Array.isArray(release.assets) ? release.assets : []
+
+    // Resolve a download for each platform card.
+    const platformDownloads = useMemo(
+        () =>
+            PLATFORMS.map((p) => ({
+                platform: p,
+                asset: assetForPlatform(assets, p),
+            })),
+        [assets]
+    )
+
+    const recommended = useMemo(
+        () =>
+            platformDownloads.find(
+                (d) => d.platform.id === detectedId && d.asset
+            ) || null,
+        [platformDownloads, detectedId]
+    )
+
+    const version = release ? release.tag_name || release.name : null
+
+    return (
+        <div className="min-h-screen bg-ground text-ink">
+            <Head>
+                <title>Download OpenAdapt Desktop | OpenAdapt</title>
+                <meta
+                    name="description"
+                    content="Download OpenAdapt Desktop for Windows, macOS, and Linux. Record a workflow once and replay it as a self-healing automation on your own machine. Open source, MIT licensed."
+                />
+                <link rel="canonical" href="https://openadapt.ai/download" />
+                <meta
+                    property="og:title"
+                    content="Download OpenAdapt Desktop | OpenAdapt"
+                />
+                <meta
+                    property="og:description"
+                    content="Installers for Windows, macOS, and Linux. Record once, replay as a self-healing automation on your own machine."
+                />
+                <meta
+                    property="og:url"
+                    content="https://openadapt.ai/download"
+                />
+            </Head>
+
+            {/* Hero */}
+            <div className="mx-auto max-w-4xl px-4 py-14">
+                <p className="eyebrow">Download</p>
+                <h1 className="font-display mt-3 text-3xl font-semibold tracking-tight text-ink md:text-4xl">
+                    Get OpenAdapt Desktop
+                </h1>
+                <p className="mt-5 max-w-2xl text-base text-ink-2 md:text-lg">
+                    Record a workflow once. OpenAdapt compiles it into a
+                    self-healing automation that replays on your own machine.
+                    Healthy runs make no cloud model calls, and your recordings
+                    stay local. Open source, MIT licensed.
+                </p>
+
+                {/* Recommended download */}
+                <div className="mt-8">
+                    {status === 'loading' && (
+                        <p className="text-sm text-ink-3">
+                            Finding the latest release...
+                        </p>
+                    )}
+
+                    {status === 'ready' && recommended && (
+                        <div className="rounded-2xl border-2 border-ink bg-panel p-6 md:p-7">
+                            <p className="eyebrow">Recommended for you</p>
+                            <p className="font-display mt-2 text-xl font-semibold tracking-tight text-ink">
+                                {recommended.platform.label}
+                                {recommended.platform.arch
+                                    ? ` (${recommended.platform.arch})`
+                                    : ''}
+                            </p>
+                            <p className="mt-1 text-sm text-ink-2">
+                                {recommended.platform.hint}
+                                {recommended.asset.size
+                                    ? ` · ${formatSize(recommended.asset.size)}`
+                                    : ''}
+                            </p>
+                            <div className="mt-4">
+                                <a
+                                    href={
+                                        recommended.asset.browser_download_url
+                                    }
+                                    className="btn-ink"
+                                    onClick={() =>
+                                        track('download_click', {
+                                            platform: recommended.platform.id,
+                                            version,
+                                            recommended: true,
+                                        })
+                                    }
+                                >
+                                    Download for {recommended.platform.label}
+                                </a>
+                            </div>
+                            {version && (
+                                <p className="mt-3 text-xs text-ink-3">
+                                    Latest release {version}
+                                </p>
+                            )}
+                        </div>
+                    )}
+
+                    {status === 'ready' && !recommended && (
+                        <p className="text-sm text-ink-2">
+                            We could not detect your operating system
+                            automatically. Pick your platform below.
+                        </p>
+                    )}
+
+                    {status === 'none' && (
+                        <div className="rounded-2xl border border-hairline bg-panel p-6">
+                            <p className="font-display text-lg font-semibold text-ink">
+                                Installers are on the way
+                            </p>
+                            <p className="mt-2 max-w-2xl text-sm text-ink-2">
+                                The first public build has not been published
+                                yet. In the meantime you can run OpenAdapt from
+                                source, and you can watch the releases page to
+                                be notified when installers land.
+                            </p>
+                            <div className="mt-4 flex flex-wrap gap-3">
+                                <a
+                                    href={RELEASES_PAGE}
+                                    className="btn-ink"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    Watch releases on GitHub
+                                </a>
+                                <a
+                                    href={`https://github.com/${REPO}`}
+                                    className="btn-ghost-ink"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    Run from source
+                                </a>
+                            </div>
+                        </div>
+                    )}
+
+                    {status === 'error' && (
+                        <div className="rounded-2xl border border-hairline bg-panel p-6">
+                            <p className="font-display text-lg font-semibold text-ink">
+                                We could not reach GitHub just now
+                            </p>
+                            <p className="mt-2 max-w-2xl text-sm text-ink-2">
+                                The download list is served from GitHub
+                                Releases. You can open the releases page
+                                directly to grab the right installer.
+                            </p>
+                            <div className="mt-4">
+                                <a
+                                    href={RELEASES_PAGE}
+                                    className="btn-ink"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    Open releases on GitHub
+                                </a>
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </div>
+
+            {/* All platforms */}
+            {status === 'ready' && (
+                <div className="mx-auto max-w-4xl px-4 pb-4">
+                    <h2 className="font-display text-2xl font-semibold tracking-tight text-ink">
+                        All downloads
+                    </h2>
+                    <p className="mt-3 max-w-2xl text-sm leading-relaxed text-ink-2">
+                        Every installer for the latest release
+                        {version ? ` (${version})` : ''}. Choose the one that
+                        matches your machine.
+                    </p>
+                    <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+                        {platformDownloads.map(({ platform, asset }) => (
+                            <div
+                                key={platform.id}
+                                className="flex flex-col rounded-xl border border-hairline bg-panel p-5"
+                            >
+                                <p className="font-display text-base font-semibold text-ink">
+                                    {platform.label}
+                                    {platform.arch ? ` (${platform.arch})` : ''}
+                                </p>
+                                <p className="mt-1 text-sm text-ink-2">
+                                    {platform.hint}
+                                    {asset && asset.size
+                                        ? ` · ${formatSize(asset.size)}`
+                                        : ''}
+                                </p>
+                                <div className="mt-4">
+                                    {asset ? (
+                                        <a
+                                            href={asset.browser_download_url}
+                                            className="text-accent font-medium"
+                                            onClick={() =>
+                                                track('download_click', {
+                                                    platform: platform.id,
+                                                    version,
+                                                    recommended: false,
+                                                })
+                                            }
+                                        >
+                                            Download →
+                                        </a>
+                                    ) : (
+                                        <span className="text-sm text-ink-3">
+                                            Not available in this release
+                                        </span>
+                                    )}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                    <p className="mt-6 text-sm text-ink-3">
+                        Looking for a different build or an older version?{' '}
+                        <a
+                            href={RELEASES_PAGE}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            Browse all releases on GitHub
+                        </a>
+                        .
+                    </p>
+                </div>
+            )}
+
+            {/* Get past the OS warning */}
+            <div className="mx-auto max-w-4xl px-4 py-12">
+                <div className="border-t-2 border-ink pt-10">
+                    <h2 className="font-display text-2xl font-semibold tracking-tight text-ink">
+                        First time you open it
+                    </h2>
+                    <p className="mt-3 max-w-2xl text-sm leading-relaxed text-ink-2">
+                        These builds are not code-signed yet, so your operating
+                        system will show a one-time warning before the first
+                        launch. Here is exactly how to get past it.
+                    </p>
+
+                    <div className="mt-6 grid grid-cols-1 gap-4 md:grid-cols-2">
+                        <div className="rounded-xl border border-hairline bg-panel p-5">
+                            <p className="font-display text-base font-semibold text-ink">
+                                macOS
+                            </p>
+                            <p className="mt-2 text-sm leading-relaxed text-ink-2">
+                                macOS will say the app is from an unidentified
+                                developer. To open it the first time:
+                                right-click (or Control-click) OpenAdapt in
+                                Applications, choose Open, then Open again.
+                                macOS remembers your choice, so you will not see
+                                this again. We are rolling out Apple
+                                notarization shortly.
+                            </p>
+                        </div>
+                        <div className="rounded-xl border border-hairline bg-panel p-5">
+                            <p className="font-display text-base font-semibold text-ink">
+                                Windows
+                            </p>
+                            <p className="mt-2 text-sm leading-relaxed text-ink-2">
+                                Windows SmartScreen may show a blue
+                                &quot;Windows protected your PC&quot; banner.
+                                Click More info, then Run anyway to install.
+                                This appears because the installer is not
+                                code-signed yet. Signing is on our roadmap.
+                            </p>
+                        </div>
+                    </div>
+                    <p className="mt-4 text-xs text-ink-3">
+                        Both warnings are expected for unsigned software and do
+                        not indicate a problem with the download.
+                    </p>
+                </div>
+            </div>
+
+            {/* CTA */}
+            <div className="mx-auto max-w-4xl px-4 pb-16">
+                <div className="rounded-2xl border-2 border-ink bg-panel p-6 text-center md:p-8">
+                    <h2 className="font-display text-xl font-semibold tracking-tight text-ink">
+                        Want it running on a real workflow?
+                    </h2>
+                    <p className="mx-auto mt-3 max-w-2xl text-sm text-ink-2 md:text-base">
+                        Bring the workflow you most want to automate. Fifteen
+                        minutes, one workflow, on your own machine.
+                    </p>
+                    <div className="mt-5 flex flex-wrap justify-center gap-3">
+                        <Link href="/#book" className="btn-ink">
+                            Book a demo
+                        </Link>
+                        <a
+                            href="https://docs.openadapt.ai"
+                            className="btn-ghost-ink"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            Read the docs
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <Footer />
+        </div>
+    )
+}

--- a/pages/download.js
+++ b/pages/download.js
@@ -4,78 +4,15 @@ import Link from 'next/link'
 
 import Footer from '@components/Footer'
 import { track } from 'utils/analytics'
-
-const REPO = 'OpenAdaptAI/openadapt-desktop'
-const RELEASES_API = `https://api.github.com/repos/${REPO}/releases/latest`
-const RELEASES_PAGE = `https://github.com/${REPO}/releases`
-
-// Platform definitions. `match` classifies a release asset by filename so the
-// page stays correct no matter how the CI names its artifacts, as long as the
-// extension and arch token are present.
-const PLATFORMS = [
-    {
-        id: 'windows',
-        label: 'Windows',
-        arch: 'x64',
-        hint: '.msi installer (or .exe)',
-        match: (name) =>
-            /\.msi$/i.test(name) ||
-            (/\.exe$/i.test(name) && /setup/i.test(name)),
-        // Prefer the .msi over the NSIS .exe when both are present.
-        rank: (name) => (/\.msi$/i.test(name) ? 0 : 1),
-    },
-    {
-        id: 'macos-arm',
-        label: 'macOS',
-        arch: 'Apple Silicon',
-        hint: '.dmg for M1 and later',
-        match: (name) => /\.dmg$/i.test(name) && /(aarch64|arm64)/i.test(name),
-        rank: () => 0,
-    },
-    {
-        id: 'macos-x64',
-        label: 'macOS',
-        arch: 'Intel',
-        hint: '.dmg for Intel Macs',
-        match: (name) =>
-            /\.dmg$/i.test(name) && /(x64|x86_64|intel)/i.test(name),
-        rank: () => 0,
-    },
-    {
-        id: 'linux',
-        label: 'Linux',
-        arch: 'x64',
-        hint: '.AppImage (or .deb)',
-        match: (name) => /\.appimage$/i.test(name) || /\.deb$/i.test(name),
-        rank: (name) => (/\.appimage$/i.test(name) ? 0 : 1),
-    },
-]
-
-// Best-effort OS + arch detection so we can surface the right build first.
-// Returns a platform id, or null when we cannot tell.
-function detectPlatformId() {
-    if (typeof navigator === 'undefined') return null
-    const ua = (navigator.userAgent || '').toLowerCase()
-    const platform = (navigator.platform || '').toLowerCase()
-
-    if (/win/.test(ua) || /win/.test(platform)) return 'windows'
-    if (/linux/.test(ua) && !/android/.test(ua)) return 'linux'
-    if (/mac/.test(ua) || /mac/.test(platform)) {
-        // On Apple Silicon, WebGL/renderer and touch heuristics are unreliable;
-        // default to Apple Silicon (the common case) and let the user pick
-        // Intel from the full list if needed.
-        return 'macos-arm'
-    }
-    return null
-}
-
-// Given a release's assets and a platform, pick the best matching download.
-function assetForPlatform(assets, platform) {
-    const candidates = assets
-        .filter((a) => platform.match(a.name))
-        .sort((a, b) => platform.rank(a.name) - platform.rank(b.name))
-    return candidates[0] || null
-}
+import {
+    assetForPlatform,
+    DESKTOP_PLATFORMS,
+    DESKTOP_RELEASES_API,
+    DESKTOP_RELEASES_PAGE,
+    detectDesktopPlatform,
+    releaseSigningState,
+    selectExperimentalDesktopRelease,
+} from 'utils/desktopRelease'
 
 function formatSize(bytes) {
     if (!bytes && bytes !== 0) return ''
@@ -89,28 +26,27 @@ export default function DownloadPage() {
     const [detectedId, setDetectedId] = useState(null)
 
     useEffect(() => {
-        setDetectedId(detectPlatformId())
+        setDetectedId(
+            detectDesktopPlatform(
+                typeof navigator === 'undefined' ? null : navigator
+            )
+        )
 
         let cancelled = false
         async function load() {
             try {
-                const res = await fetch(RELEASES_API, {
+                const res = await fetch(DESKTOP_RELEASES_API, {
                     headers: { Accept: 'application/vnd.github+json' },
                 })
                 if (cancelled) return
-                if (res.status === 404) {
-                    setStatus('none')
-                    return
-                }
                 if (!res.ok) {
                     setStatus('error')
                     return
                 }
                 const data = await res.json()
-                setRelease(data)
-                const hasAssets =
-                    Array.isArray(data.assets) && data.assets.length > 0
-                setStatus(hasAssets ? 'ready' : 'none')
+                const selected = selectExperimentalDesktopRelease(data)
+                setRelease(selected)
+                setStatus(selected ? 'ready' : 'none')
             } catch (err) {
                 if (!cancelled) setStatus('error')
             }
@@ -127,7 +63,7 @@ export default function DownloadPage() {
     // Resolve a download for each platform card.
     const platformDownloads = useMemo(
         () =>
-            PLATFORMS.map((p) => ({
+            DESKTOP_PLATFORMS.map((p) => ({
                 platform: p,
                 asset: assetForPlatform(assets, p),
             })),
@@ -143,6 +79,8 @@ export default function DownloadPage() {
     )
 
     const version = release ? release.tag_name || release.name : null
+    const signing = useMemo(() => releaseSigningState(assets), [assets])
+    const checksumAsset = assets.find((asset) => asset.name === 'SHA256SUMS')
 
     return (
         <div className="min-h-screen bg-ground text-ink">
@@ -150,7 +88,7 @@ export default function DownloadPage() {
                 <title>Download OpenAdapt Desktop | OpenAdapt</title>
                 <meta
                     name="description"
-                    content="Download OpenAdapt Desktop for Windows, macOS, and Linux. Record a workflow once and replay it as a self-healing automation on your own machine. Open source, MIT licensed."
+                    content="Download the Experimental OpenAdapt Desktop packaging preview for Windows, macOS, and Linux."
                 />
                 <link rel="canonical" href="https://openadapt.ai/download" />
                 <meta
@@ -159,7 +97,7 @@ export default function DownloadPage() {
                 />
                 <meta
                     property="og:description"
-                    content="Installers for Windows, macOS, and Linux. Record once, replay as a self-healing automation on your own machine."
+                    content="Experimental native packaging previews for Windows, macOS, and Linux."
                 />
                 <meta
                     property="og:url"
@@ -169,15 +107,24 @@ export default function DownloadPage() {
 
             {/* Hero */}
             <div className="mx-auto max-w-4xl px-4 py-14">
-                <p className="eyebrow">Download</p>
+                <p className="eyebrow">Experimental desktop</p>
                 <h1 className="font-display mt-3 text-3xl font-semibold tracking-tight text-ink md:text-4xl">
-                    Get OpenAdapt Desktop
+                    OpenAdapt Desktop preview
                 </h1>
                 <p className="mt-5 max-w-2xl text-base text-ink-2 md:text-lg">
-                    Record a workflow once. OpenAdapt compiles it into a
-                    self-healing automation that replays on your own machine.
-                    Healthy runs make no cloud model calls, and your recordings
-                    stay local. Open source, MIT licensed.
+                    These installers validate native packaging and removal. The
+                    desktop shell is not yet connected to workflow recording or
+                    replay. Use the open-source{' '}
+                    <a
+                        href="https://github.com/OpenAdaptAI/openadapt-flow"
+                        className="font-medium underline underline-offset-4"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        openadapt-flow CLI
+                    </a>{' '}
+                    for the working record, compile, certify, replay, and repair
+                    path.
                 </p>
 
                 {/* Recommended download */}
@@ -222,33 +169,39 @@ export default function DownloadPage() {
                             </div>
                             {version && (
                                 <p className="mt-3 text-xs text-ink-3">
-                                    Latest release {version}
+                                    Experimental prerelease {version}
                                 </p>
                             )}
                         </div>
                     )}
 
                     {status === 'ready' && !recommended && (
-                        <p className="text-sm text-ink-2">
-                            We could not detect your operating system
-                            automatically. Pick your platform below.
-                        </p>
+                        <div>
+                            <p className="eyebrow">
+                                Experimental prerelease {version}
+                            </p>
+                            <p className="mt-2 text-sm text-ink-2">
+                                We could not safely choose an installer for this
+                                device. Pick your platform and architecture
+                                below.
+                            </p>
+                        </div>
                     )}
 
                     {status === 'none' && (
                         <div className="rounded-2xl border border-hairline bg-panel p-6">
                             <p className="font-display text-lg font-semibold text-ink">
-                                Installers are on the way
+                                No public desktop installer yet
                             </p>
                             <p className="mt-2 max-w-2xl text-sm text-ink-2">
-                                The first public build has not been published
-                                yet. In the meantime you can run OpenAdapt from
-                                source, and you can watch the releases page to
-                                be notified when installers land.
+                                No complete Experimental desktop prerelease has
+                                been published. Use openadapt-flow today, or
+                                watch the desktop releases page for the first
+                                native preview.
                             </p>
                             <div className="mt-4 flex flex-wrap gap-3">
                                 <a
-                                    href={RELEASES_PAGE}
+                                    href={DESKTOP_RELEASES_PAGE}
                                     className="btn-ink"
                                     target="_blank"
                                     rel="noopener noreferrer"
@@ -256,12 +209,12 @@ export default function DownloadPage() {
                                     Watch releases on GitHub
                                 </a>
                                 <a
-                                    href={`https://github.com/${REPO}`}
+                                    href="https://docs.openadapt.ai"
                                     className="btn-ghost-ink"
                                     target="_blank"
                                     rel="noopener noreferrer"
                                 >
-                                    Run from source
+                                    Install the working CLI
                                 </a>
                             </div>
                         </div>
@@ -275,11 +228,11 @@ export default function DownloadPage() {
                             <p className="mt-2 max-w-2xl text-sm text-ink-2">
                                 The download list is served from GitHub
                                 Releases. You can open the releases page
-                                directly to grab the right installer.
+                                directly to inspect the published builds.
                             </p>
                             <div className="mt-4">
                                 <a
-                                    href={RELEASES_PAGE}
+                                    href={DESKTOP_RELEASES_PAGE}
                                     className="btn-ink"
                                     target="_blank"
                                     rel="noopener noreferrer"
@@ -299,7 +252,7 @@ export default function DownloadPage() {
                         All downloads
                     </h2>
                     <p className="mt-3 max-w-2xl text-sm leading-relaxed text-ink-2">
-                        Every installer for the latest release
+                        Every installer for the latest Experimental prerelease
                         {version ? ` (${version})` : ''}. Choose the one that
                         matches your machine.
                     </p>
@@ -323,7 +276,7 @@ export default function DownloadPage() {
                                     {asset ? (
                                         <a
                                             href={asset.browser_download_url}
-                                            className="text-accent font-medium"
+                                            className="text-accent font-medium underline underline-offset-4"
                                             onClick={() =>
                                                 track('download_click', {
                                                     platform: platform.id,
@@ -346,7 +299,7 @@ export default function DownloadPage() {
                     <p className="mt-6 text-sm text-ink-3">
                         Looking for a different build or an older version?{' '}
                         <a
-                            href={RELEASES_PAGE}
+                            href={DESKTOP_RELEASES_PAGE}
                             target="_blank"
                             rel="noopener noreferrer"
                         >
@@ -357,62 +310,81 @@ export default function DownloadPage() {
                 </div>
             )}
 
-            {/* Get past the OS warning */}
-            <div className="mx-auto max-w-4xl px-4 py-12">
-                <div className="border-t-2 border-ink pt-10">
-                    <h2 className="font-display text-2xl font-semibold tracking-tight text-ink">
-                        First time you open it
-                    </h2>
-                    <p className="mt-3 max-w-2xl text-sm leading-relaxed text-ink-2">
-                        These builds are not code-signed yet, so your operating
-                        system will show a one-time warning before the first
-                        launch. Here is exactly how to get past it.
-                    </p>
+            {/* Guidance is tied to the signing labels in the published assets. */}
+            {status === 'ready' &&
+                (!signing.macosNotarized || !signing.windowsSigned) && (
+                    <div className="mx-auto max-w-4xl px-4 py-12">
+                        <div className="border-t-2 border-ink pt-10">
+                            <h2 className="font-display text-2xl font-semibold tracking-tight text-ink">
+                                First launch
+                            </h2>
+                            <p className="mt-3 max-w-2xl text-sm leading-relaxed text-ink-2">
+                                Current Experimental builds may trigger an
+                                operating-system publisher warning. Verify the
+                                release checksum before overriding it.
+                            </p>
 
-                    <div className="mt-6 grid grid-cols-1 gap-4 md:grid-cols-2">
-                        <div className="rounded-xl border border-hairline bg-panel p-5">
-                            <p className="font-display text-base font-semibold text-ink">
-                                macOS
-                            </p>
-                            <p className="mt-2 text-sm leading-relaxed text-ink-2">
-                                macOS will say the app is from an unidentified
-                                developer. To open it the first time:
-                                right-click (or Control-click) OpenAdapt in
-                                Applications, choose Open, then Open again.
-                                macOS remembers your choice, so you will not see
-                                this again. We are rolling out Apple
-                                notarization shortly.
-                            </p>
-                        </div>
-                        <div className="rounded-xl border border-hairline bg-panel p-5">
-                            <p className="font-display text-base font-semibold text-ink">
-                                Windows
-                            </p>
-                            <p className="mt-2 text-sm leading-relaxed text-ink-2">
-                                Windows SmartScreen may show a blue
-                                &quot;Windows protected your PC&quot; banner.
-                                Click More info, then Run anyway to install.
-                                This appears because the installer is not
-                                code-signed yet. Signing is on our roadmap.
-                            </p>
+                            <div className="mt-6 grid grid-cols-1 gap-4 md:grid-cols-2">
+                                {!signing.macosNotarized && (
+                                    <div className="rounded-xl border border-hairline bg-panel p-5">
+                                        <p className="font-display text-base font-semibold text-ink">
+                                            macOS
+                                        </p>
+                                        <p className="mt-2 text-sm leading-relaxed text-ink-2">
+                                            The DMGs are ad-hoc signed, not yet
+                                            Developer ID notarized. In Finder,
+                                            Control-click OpenAdapt Desktop,
+                                            choose Open, then confirm Open. Only
+                                            override Gatekeeper after verifying
+                                            the release checksum.
+                                        </p>
+                                    </div>
+                                )}
+                                {!signing.windowsSigned && (
+                                    <div className="rounded-xl border border-hairline bg-panel p-5">
+                                        <p className="font-display text-base font-semibold text-ink">
+                                            Windows
+                                        </p>
+                                        <p className="mt-2 text-sm leading-relaxed text-ink-2">
+                                            The Windows installers are not yet
+                                            Authenticode signed. If SmartScreen
+                                            shows &quot;Windows protected your
+                                            PC,&quot; verify the release checksum,
+                                            then choose More info and Run
+                                            anyway.
+                                        </p>
+                                    </div>
+                                )}
+                            </div>
+                            {checksumAsset && (
+                                <p className="mt-4 text-xs text-ink-3">
+                                    <a
+                                        href={
+                                            checksumAsset.browser_download_url
+                                        }
+                                        className="font-medium underline underline-offset-4"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                    >
+                                        Download SHA256SUMS
+                                    </a>{' '}
+                                    and verify GitHub build provenance from the
+                                    release before installing.
+                                </p>
+                            )}
                         </div>
                     </div>
-                    <p className="mt-4 text-xs text-ink-3">
-                        Both warnings are expected for unsigned software and do
-                        not indicate a problem with the download.
-                    </p>
-                </div>
-            </div>
+                )}
 
             {/* CTA */}
             <div className="mx-auto max-w-4xl px-4 pb-16">
                 <div className="rounded-2xl border-2 border-ink bg-panel p-6 text-center md:p-8">
                     <h2 className="font-display text-xl font-semibold tracking-tight text-ink">
-                        Want it running on a real workflow?
+                        Need the working workflow engine?
                     </h2>
                     <p className="mx-auto mt-3 max-w-2xl text-sm text-ink-2 md:text-base">
-                        Bring the workflow you most want to automate. Fifteen
-                        minutes, one workflow, on your own machine.
+                        Start with the openadapt-flow CLI, or bring the workflow
+                        you most want to automate to a 30-minute call.
                     </p>
                     <div className="mt-5 flex flex-wrap justify-center gap-3">
                         <Link href="/#book" className="btn-ink">

--- a/utils/desktopRelease.js
+++ b/utils/desktopRelease.js
@@ -1,0 +1,148 @@
+export const DESKTOP_REPO = 'OpenAdaptAI/openadapt-desktop'
+export const DESKTOP_RELEASES_API = `https://api.github.com/repos/${DESKTOP_REPO}/releases?per_page=20`
+export const DESKTOP_RELEASES_PAGE = `https://github.com/${DESKTOP_REPO}/releases`
+
+const EXPERIMENTAL_TAG = /^desktop-v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
+const EXPERIMENTAL_PREFIX = /^OpenAdapt-Desktop-Experimental-/i
+
+export const DESKTOP_PLATFORMS = [
+    {
+        id: 'windows',
+        label: 'Windows',
+        arch: 'x64',
+        hint: '.msi installer (or .exe)',
+        match: (name) =>
+            EXPERIMENTAL_PREFIX.test(name) &&
+            /-windows-x86_64-(?:(?:unsigned|authenticode)\.msi|(?:unsigned|authenticode)-nsis-setup\.exe)$/i.test(
+                name
+            ),
+        rank: (name) => (/\.msi$/i.test(name) ? 0 : 1),
+    },
+    {
+        id: 'macos-arm',
+        label: 'macOS',
+        arch: 'Apple Silicon',
+        hint: '.dmg for M1 and later',
+        match: (name) =>
+            EXPERIMENTAL_PREFIX.test(name) &&
+            /-macos-arm64-(?:adhoc|developer-id-notarized)\.dmg$/i.test(name),
+        rank: () => 0,
+    },
+    {
+        id: 'macos-x64',
+        label: 'macOS',
+        arch: 'Intel',
+        hint: '.dmg for Intel Macs',
+        match: (name) =>
+            EXPERIMENTAL_PREFIX.test(name) &&
+            /-macos-x86_64-(?:adhoc|developer-id-notarized)\.dmg$/i.test(
+                name
+            ),
+        rank: () => 0,
+    },
+    {
+        id: 'linux',
+        label: 'Linux',
+        arch: 'x64',
+        hint: '.AppImage (or .deb)',
+        match: (name) =>
+            EXPERIMENTAL_PREFIX.test(name) &&
+            /-linux-x86_64-unsigned\.(?:AppImage|deb)$/i.test(name),
+        rank: (name) => (/\.AppImage$/i.test(name) ? 0 : 1),
+    },
+]
+
+const REQUIRED_ASSETS = [
+    /-macos-arm64-(?:adhoc|developer-id-notarized)\.dmg$/i,
+    /-macos-x86_64-(?:adhoc|developer-id-notarized)\.dmg$/i,
+    /-windows-x86_64-(?:unsigned|authenticode)\.msi$/i,
+    /-windows-x86_64-(?:unsigned|authenticode)-nsis-setup\.exe$/i,
+    /-linux-x86_64-unsigned\.AppImage$/i,
+    /-linux-x86_64-unsigned\.deb$/i,
+]
+
+function hasDownloadUrl(asset) {
+    return Boolean(
+        asset &&
+            typeof asset.name === 'string' &&
+            typeof asset.browser_download_url === 'string' &&
+            asset.browser_download_url.startsWith('https://')
+    )
+}
+
+export function assetForPlatform(assets, platform) {
+    return assets
+        .filter(hasDownloadUrl)
+        .filter((asset) => platform.match(asset.name))
+        .sort((a, b) => platform.rank(a.name) - platform.rank(b.name))[0]
+}
+
+export function isCompleteExperimentalDesktopRelease(release) {
+    if (
+        !release ||
+        release.draft ||
+        release.prerelease !== true ||
+        !EXPERIMENTAL_TAG.test(release.tag_name || '') ||
+        !Array.isArray(release.assets)
+    ) {
+        return false
+    }
+
+    const assets = release.assets.filter(hasDownloadUrl)
+    const hasChecksums = assets.some((asset) => asset.name === 'SHA256SUMS')
+    return (
+        hasChecksums &&
+        REQUIRED_ASSETS.every((pattern) =>
+            assets.some(
+                (asset) =>
+                    EXPERIMENTAL_PREFIX.test(asset.name) &&
+                    pattern.test(asset.name)
+            )
+        )
+    )
+}
+
+export function selectExperimentalDesktopRelease(releases) {
+    if (!Array.isArray(releases)) return null
+    return releases.find(isCompleteExperimentalDesktopRelease) || null
+}
+
+export function detectDesktopPlatform(navigatorValue) {
+    if (!navigatorValue) return null
+    const fingerprint = `${navigatorValue.userAgent || ''} ${
+        navigatorValue.platform || ''
+    }`.toLowerCase()
+
+    // Browser signals do not reliably distinguish Apple Silicon from Intel.
+    // A wrong installer is worse than asking macOS visitors to choose.
+    if (/mac|iphone|ipad/.test(fingerprint)) return null
+
+    const isArm = /(?:^|[^a-z])(?:arm64|aarch64|armv8)(?:[^a-z]|$)/.test(
+        fingerprint
+    )
+    const isX64 = /x86_64|x86-64|amd64|win64|wow64|x64/.test(fingerprint)
+    if (isArm || !isX64) return null
+    if (/win/.test(fingerprint)) return 'windows'
+    if (/linux/.test(fingerprint) && !/android/.test(fingerprint)) return 'linux'
+    return null
+}
+
+export function releaseSigningState(assets) {
+    const names = Array.isArray(assets)
+        ? assets.map((asset) => asset.name || '')
+        : []
+    return {
+        macosNotarized: ['arm64', 'x86_64'].every((architecture) =>
+            names.some((name) =>
+                new RegExp(
+                    `-macos-${architecture}-developer-id-notarized\\.dmg$`,
+                    'i'
+                ).test(name)
+            )
+        ),
+        windowsSigned: [
+            /-windows-x86_64-authenticode\.msi$/i,
+            /-windows-x86_64-authenticode-nsis-setup\.exe$/i,
+        ].every((pattern) => names.some((name) => pattern.test(name))),
+    }
+}


### PR DESCRIPTION
## What

Adds `/download` as the public entry point for OpenAdapt Desktop's Experimental native packaging previews.

## Release contract

- Reads the public GitHub releases list rather than `/releases/latest`, which excludes prereleases.
- Selects only a published `desktop-v*` Experimental prerelease containing the complete smoke-tested artifact set: two macOS DMGs, Windows MSI and NSIS installers, Linux AppImage and DEB packages, and `SHA256SUMS`.
- Ignores legacy Python-package releases, drafts, partial uploads, unrelated assets, and malformed download entries.
- Shows the current honest no-installer state until a complete Experimental prerelease is actually published.
- Avoids guessing macOS architecture because browser signals cannot reliably distinguish Apple Silicon from Intel.

## Product and security copy

- Labels the installers as an Experimental scaffold-shell packaging preview, not the working record/replay product.
- Routes users who need working automation to `openadapt-flow` and the canonical docs.
- Derives macOS notarization and Windows Authenticode guidance from the published asset labels.
- Links the exact `SHA256SUMS` asset before asking a user to override Gatekeeper or SmartScreen.

## Dependency

- OpenAdaptAI/openadapt-desktop#16 merged at `3afadc7876b79101267395151985d9893ac09344` with the exact artifact naming and release workflow this page consumes.
- No `desktop-v*` prerelease is public yet, so the page intentionally renders the no-installer state today.

## Verification

- Locked Next.js 14.1.2 production build passes; `/download` prerenders statically.
- Browser Cypress against `next start` passes the legacy/no-release page and complete unsigned/ad-hoc Experimental prerelease page (`2/2`).
- The exact Netlify deploy-preview build passes the server-independent selector, asset, signing, and architecture contract (`3/3`).
- `git diff --check` passes.
- Rebased on `main` after the Cal.com production correction in #183.
