### PR TITLE
fix: make comparison buyer-led and concise

### DIFF
--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -93,22 +93,49 @@ describe('public product truth', () => {
         })
 
         cy.visit('/compare')
+        cy.get('h1').should(
+            'contain.text',
+            'Choose repeatable automation for work that repeats.'
+        )
+        cy.get('#side-by-side').within(() => {
+            cy.contains('Choose by the operating model you need.').should(
+                'be.visible'
+            )
+            cy.contains('Repeated, consequential browser workflows').should(
+                'be.visible'
+            )
+            cy.contains('Novel or changing tasks').should('be.visible')
+        })
         cy.get('#benchmark-evidence').within(() => {
-            cy.contains('In a bounded browser benchmark').should('be.visible')
+            cy.contains('On MockMed').should('be.visible')
+            cy.contains('Faster repeat runs without per-run model spend.').should(
+                'be.visible'
+            )
             cy.contains('100 compiled replays').should('not.exist')
             cy.contains('$3/$15').should('not.exist')
             cy.contains('introductory').should('not.exist')
-        })
-        cy.contains('A bounded field cross-check').parent().within(() => {
-            cy.contains('does not establish production EMR reliability').should(
-                'be.visible'
-            )
             cy.contains('resets daily').should('not.exist')
             cy.contains('N=10').should('not.exist')
             cy.contains(
-                'Review scope, samples, demo limitations, pricing basis, and raw results'
+                'Method, raw results, and rerun instructions'
+            ).should('have.attr', 'href').and('include', 'benchmark/BENCHMARK.md')
+            cy.contains(
+                'OpenEMR cross-check'
             ).should('have.attr', 'href').and('include', 'openemr/BENCHMARK.md')
         })
+        cy.contains("We'd rather tell you").should('not.exist')
+        cy.contains('Versus traditional RPA platforms').should('not.exist')
+
+        cy.viewport(375, 812)
+        cy.visit('/compare')
+        cy.contains('Scroll horizontally to compare all approaches.').should(
+            'be.visible'
+        )
+        cy.get('#side-by-side [role="region"]')
+            .should('be.visible')
+            .and('have.attr', 'tabindex', '0')
+        cy.contains('Start hosted').scrollIntoView().should('be.visible')
+        cy.contains('Book a workflow review').should('be.visible')
     })
 
     it('keeps buyer claims inside the shipped browser and tested safety scope', () => {

--- a/pages/compare.js
+++ b/pages/compare.js
@@ -5,13 +5,15 @@ import Footer from '@components/Footer'
 import BenchmarkCharts from '@components/BenchmarkCharts'
 import benchmark from '../data/benchmark.json'
 
+const description =
+    'See when OpenAdapt, traditional RPA, computer-use agents, or browser recorders fit repeated browser work. Compare authoring, run economics, change handling, verification, and deployment.'
+
 const webPageSchema = {
     '@context': 'https://schema.org',
     '@type': 'WebPage',
-    name: 'How OpenAdapt compares',
+    name: 'OpenAdapt compared with RPA and computer-use agents',
     url: 'https://openadapt.ai/compare',
-    description:
-        'Compare OpenAdapt with RPA, AI computer-use agents, and browser recorders on repeated-work economics, verification boundaries, deployment, and maturity.',
+    description,
     isPartOf: {
         '@type': 'WebSite',
         name: 'OpenAdapt.AI',
@@ -25,48 +27,74 @@ const webPageSchema = {
     inLanguage: 'en',
 }
 
-const rows = [
+const outcomes = [
     {
-        dimension: 'How automations are built',
-        openadapt: 'Recorded demonstration, compiled into a script',
-        rpa: 'Hand-authored selectors and flowcharts',
-        agents: 'A model re-reasons through the task on every run',
-        browser: 'Browser recording or a prompt',
+        title: 'Predictable repeat economics',
+        body: 'Healthy replay is deterministic and uses no model calls. Model spend is reserved for compilation or repair.',
     },
     {
-        dimension: 'Model API cost per healthy run',
-        openadapt: '$0 measured; execution infrastructure is separate',
-        rpa: 'Licensed per robot or per seat',
-        agents: 'Metered model calls on every run',
-        browser: 'Varies; cloud inference is metered',
+        title: 'Review change once',
+        body: 'A repair updates the reusable workflow instead of asking a model to rediscover the task on every run.',
+    },
+    {
+        title: 'Know when it stopped',
+        body: 'Configured identity and effect checks halt ambiguous work and preserve a run report for review.',
+    },
+    {
+        title: 'Control the runtime boundary',
+        body: 'Choose local, managed browser, customer-cloud, or on-prem execution for the supported workflow.',
+    },
+]
+
+const rows = [
+    {
+        dimension: 'Best fit',
+        openadapt: 'Repeated, consequential browser workflows without a practical API',
+        rpa: 'Broad enterprise automation with mature connectors and orchestration',
+        agents: 'Novel or changing tasks that benefit from reasoning each time',
+        browser: 'Simple browser workflows and test automation',
+    },
+    {
+        dimension: 'Authoring',
+        openadapt: 'Record a task; compile the demonstration',
+        rpa: 'Build selectors, rules, and flowcharts',
+        agents: 'Describe the goal and configure tools and guardrails',
+        browser: 'Record steps or write a script or prompt',
+    },
+    {
+        dimension: 'Healthy repeat run',
+        openadapt: 'Deterministic replay; no model calls',
+        rpa: 'Deterministic replay; platform licensing applies',
+        agents: 'A model plans and acts on every run',
+        browser: 'Fixed or model-driven replay, depending on the tool',
     },
     {
         dimension: 'When the UI changes',
-        openadapt: 'Re-resolves, proposes a governed repair, or halts',
-        rpa: 'Selectors break; someone repairs the flow by hand',
-        agents: 'The model may adapt, or may take a different path',
-        browser: 'DOM selectors break, or the model re-infers',
+        openadapt: 'Re-resolve from evidence, propose a repair, or halt',
+        rpa: 'Repair selectors and workflow logic',
+        agents: 'Reason through the changed interface',
+        browser: 'Repair selectors or let a model re-infer',
     },
     {
-        dimension: 'Where it runs',
-        openadapt: 'Local, managed browser, BYOC, or on-prem by declared boundary',
-        rpa: 'Your infrastructure or vendor cloud',
-        agents: 'Vendor cloud, with screenshots of your screen',
-        browser: 'The browser; often with a cloud backend',
+        dimension: 'Failure control',
+        openadapt: 'Configured identity and effect checks can halt and preserve a report',
+        rpa: 'Depends on configured platform controls',
+        agents: 'Depends on the agent platform and its guardrails',
+        browser: 'Depends on the tool and script',
     },
     {
-        dimension: 'App coverage',
-        openadapt: 'Browser supported; Windows experimental; RDP/Citrix research',
-        rpa: 'Desktop and web via connectors',
-        agents: 'Anything on screen',
+        dimension: 'Execution boundary',
+        openadapt: 'Local, managed browser, customer cloud, or on-prem',
+        rpa: 'Customer infrastructure or vendor cloud',
+        agents: 'Local or cloud, depending on the provider',
+        browser: 'Browser with local or cloud services',
+    },
+    {
+        dimension: 'Current coverage',
+        openadapt: 'Browser Beta; Windows Experimental; RDP and Citrix Research',
+        rpa: 'Mature desktop and browser coverage',
+        agents: 'Broad screen coverage; provider-specific',
         browser: 'Browser only',
-    },
-    {
-        dimension: 'License',
-        openadapt: 'MIT open source',
-        rpa: 'Proprietary',
-        agents: 'Proprietary services',
-        browser: 'Varies; some open source',
     },
 ]
 
@@ -74,17 +102,14 @@ export default function ComparePage() {
     return (
         <div className="min-h-screen bg-ground text-ink">
             <Head>
-                <title>How OpenAdapt compares to RPA, AI agents, and browser recorders | OpenAdapt</title>
-                <meta
-                    name="description"
-                    content="Compare OpenAdapt with RPA, AI computer-use agents, and browser recorders on repeated-work economics, verification boundaries, deployment, and maturity."
-                />
+                <title>OpenAdapt vs RPA and computer-use agents | OpenAdapt</title>
+                <meta name="description" content={description} />
                 <link rel="canonical" href="https://openadapt.ai/compare" />
-                <meta property="og:title" content="How OpenAdapt compares | OpenAdapt" />
                 <meta
-                    property="og:description"
-                    content="Where governed compiled replay fits: repeated-work economics, verification boundaries, deployment, and current substrate maturity."
+                    property="og:title"
+                    content="OpenAdapt vs RPA and computer-use agents"
                 />
+                <meta property="og:description" content={description} />
                 <meta property="og:url" content="https://openadapt.ai/compare" />
                 <script
                     type="application/ld+json"
@@ -94,289 +119,286 @@ export default function ComparePage() {
                 />
             </Head>
 
-            <div className="mx-auto max-w-4xl px-4 py-14">
-                <p className="eyebrow">
-                    Compare
-                </p>
-                <h1 className="font-display mt-3 text-3xl font-semibold tracking-tight text-ink md:text-4xl">
-                    How OpenAdapt compares
+            <main className="mx-auto max-w-4xl px-4 py-14">
+                <p className="eyebrow">Automation decision guide</p>
+                <h1 className="font-display mt-3 max-w-3xl text-3xl font-semibold tracking-tight text-ink md:text-5xl">
+                    Choose repeatable automation for work that repeats.
                 </h1>
-                <p className="mt-5 max-w-3xl text-base text-ink-2 md:text-lg">
-                    Repeated work needs more than a successful click. Operators
-                    need predictable execution cost, a clear record of what ran,
-                    and a visible halt when the workflow cannot verify its target
-                    or effect.
+                <p className="mt-5 max-w-3xl text-base leading-relaxed text-ink-2 md:text-lg">
+                    OpenAdapt compiles a demonstrated browser workflow into
+                    governed replay. Healthy runs are deterministic and make no
+                    model calls. When the interface changes, the workflow
+                    re-resolves from evidence, proposes a reviewable repair, or
+                    halts.
                 </p>
-                <p className="mt-4 max-w-3xl text-base text-ink-2 md:text-lg">
-                    There are three common ways to automate desktop work:
-                    traditional RPA, AI agents that drive a computer with a large
-                    model, and browser recorders. OpenAdapt is a fourth. You
-                    record the task once, and it compiles that recording into a
-                    script that replays without model calls on a healthy run,
-                    then re-resolves, proposes a governed repair, or halts when
-                    the screen changes. In a certified workflow, it{' '}
-                    <strong>halts rather than guess</strong> when it can&#39;t
-                    confirm it&#39;s acting on the right record. Each approach
-                    wins somewhere. Here is the honest picture, safety first.
-                </p>
-
-                <div className="mt-10 rounded-2xl border-2 border-ink bg-panel p-6 md:p-8">
-                    <p className="eyebrow">Operational risk</p>
-                    <h2 className="mt-2 font-display text-xl font-semibold tracking-tight text-ink md:text-2xl">
-                        Verify the record before the write.
-                    </h2>
-                    <p className="mt-3 text-sm leading-relaxed text-ink-2 md:text-base">
-                        For a consequential workflow, confirming that a button
-                        responded is not enough. OpenAdapt can require identity and
-                        effect evidence before continuing, then halt for an operator
-                        when that evidence is ambiguous.
-                    </p>
-                    <div className="mt-5 grid gap-6 sm:grid-cols-2">
-                        <div>
-                            <p className="font-display text-2xl font-semibold text-ink">
-                                Verify intent
-                            </p>
-                            <p className="mt-1 text-sm text-ink-2">
-                                require configured evidence that the workflow is
-                                acting on the intended record
-                            </p>
-                        </div>
-                        <div>
-                            <p className="font-display text-2xl font-semibold text-ink">
-                                Refuse ambiguity
-                            </p>
-                            <p className="mt-1 text-sm text-ink-2">
-                                stop and preserve evidence instead of treating an
-                                uncertain target as a successful action
-                            </p>
-                        </div>
-                    </div>
-                    <p className="mt-5 text-sm leading-relaxed text-ink-2 md:text-base">
-                        Stable browser identity controls can provide the same kind
-                        of protection. OpenAdapt&apos;s current public evidence is
-                        strongest on the browser path; Windows is Experimental and
-                        RDP/Citrix remain Research.
-                    </p>
-                    <p className="mt-4 text-xs leading-relaxed text-ink-3">
-                        Verification is only as strong as its configured identity,
-                        effect, and policy coverage. This reduces named failure
-                        modes; it does not prove zero wrong actions.
-                    </p>
-                    <div className="mt-4 flex flex-wrap gap-x-6 gap-y-1">
-                        <a
-                            href="https://github.com/OpenAdaptAI/openadapt-flow/blob/main/docs/LIMITS.md"
-                            className="inline-block text-sm font-medium text-accent hover:underline"
-                        >
-                            Read the honest limitations (LIMITS.md)
-                        </a>
-                        <a
-                            href="https://github.com/OpenAdaptAI/openadapt-flow/blob/main/docs/validation/IDENTITY_ROC.md"
-                            className="inline-block text-sm text-accent hover:underline"
-                        >
-                            The adversary log &amp; ROC
-                        </a>
-                    </div>
-                </div>
-
-                <h2 className="mt-12 font-display text-xl font-semibold tracking-tight text-ink">
-                    Versus traditional RPA platforms
-                </h2>
-                <p className="mt-3 text-sm leading-relaxed text-ink-2 md:text-base">
-                    UiPath, Automation Anywhere, and Blue Prism make you
-                    hand-author selectors and flowcharts and maintain them: a
-                    vendor UI update breaks the selectors, and someone reopens the
-                    studio. Licensing is per robot or seat, and it&#39;s
-                    proprietary. OpenAdapt skips the authoring: record the task
-                    once, it compiles to a script, and when the UI drifts it
-                    re-resolves from evidence, proposes a governed repair, or
-                    halts under configured verification. The engine is MIT
-                    open source and supports local deployment.
-                </p>
-
-                <h2 className="mt-12 font-display text-xl font-semibold tracking-tight text-ink">
-                    Versus AI computer-use agents
-                </h2>
-                <p className="mt-3 text-sm leading-relaxed text-ink-2 md:text-base">
-                    Cloud agents (OpenAI Operator, Claude computer-use) re-reason
-                    through your task with a large model on every run: impressive
-                    on novel work, but for repetitive work every run is slow,
-                    differently-pathed, billed, and usually sends your screen to
-                    the cloud. OpenAdapt can use a model during compilation or
-                    governed repair, not on a healthy replay. Local execution
-                    keeps live observations local; hosted execution keeps them
-                    inside its declared managed runtime boundary. Only an
-                    approved sanitized derivative may cross the artifact
-                    boundary.
-                </p>
-
-                <div
-                    id="benchmark-evidence"
-                    className="mt-6 rounded-2xl border border-hairline bg-panel p-6 md:p-8"
-                >
-                    <p className="eyebrow">Measured evidence</p>
-                    <h3 className="mt-2 font-display text-lg font-semibold tracking-tight text-ink">
-                        Repeated work should not pay an agent to rethink the same task.
-                    </h3>
-                    <p className="mt-3 text-sm leading-relaxed text-ink-2 md:text-base">
-                        In a bounded browser benchmark, both approaches completed
-                        the measured workflow. Compiled replay was faster and used
-                        no model calls. This supports a cost-and-latency claim for
-                        repeated work on this task, not a broader reliability claim.
-                    </p>
-                    <BenchmarkCharts
-                        dataset={benchmark.mockmed}
-                    />
-                    <div className="mt-3 flex flex-wrap gap-x-6 gap-y-1">
-                        <a
-                            href="https://github.com/OpenAdaptAI/openadapt-flow/blob/main/benchmark/BENCHMARK.md"
-                            className="inline-block text-sm text-accent hover:underline"
-                        >
-                            Review scope, samples, pricing basis, caveats, and raw results
-                        </a>
-                        <a
-                            href="https://github.com/OpenAdaptAI/openadapt-flow/blob/main/benchmark/hybrid/BENCHMARK.md"
-                            className="inline-block text-sm text-accent hover:underline"
-                        >
-                            Review drift and fallback evidence
-                        </a>
-                    </div>
-                </div>
-
-                <div className="mt-4 rounded-2xl border border-hairline bg-panel p-6 md:p-8">
-                    <h3 className="font-display text-lg font-semibold tracking-tight text-ink">
-                        A bounded field cross-check
-                    </h3>
-                    <p className="mt-3 text-sm leading-relaxed text-ink-2 md:text-base">
-                        We repeated the comparison against the public OpenEMR demo.
-                        Both approaches completed the measured workflow, while
-                        compiled replay showed lower median latency and no model
-                        calls. This is a cost-and-latency cross-check only. It does
-                        not establish production EMR reliability, safety, or readiness.
-                    </p>
-                    <BenchmarkCharts
-                        dataset={benchmark.openemr}
-                    />
-                    <a
-                        href="https://github.com/OpenAdaptAI/openadapt-flow/blob/main/benchmark/openemr/BENCHMARK.md"
-                        className="mt-3 inline-block text-sm text-accent hover:underline"
-                    >
-                        Review scope, samples, demo limitations, pricing basis, and raw results
+                <div className="mt-6 flex flex-wrap gap-3">
+                    <a href="#side-by-side" className="btn-ink">
+                        Compare approaches
+                    </a>
+                    <a href="#benchmark-evidence" className="btn-ghost-ink">
+                        See measured results
                     </a>
                 </div>
 
-                <h2 className="mt-12 font-display text-xl font-semibold tracking-tight text-ink">
-                    Versus browser recording tools
-                </h2>
-                <p className="mt-3 text-sm leading-relaxed text-ink-2 md:text-base">
-                    Browser-first tools use DOM selectors or model inference and
-                    can be a strong fit when the whole workflow stays in a tab.
-                    OpenAdapt adds compiled replay, evidence-backed verification,
-                    and an execution model intended to span structured and visual
-                    targets. The current launch is the browser path; desktop is
-                    Experimental and VDI/RDP remains Research.
-                </p>
+                <section className="mt-14" aria-labelledby="fit-heading">
+                    <p className="eyebrow">Where OpenAdapt fits</p>
+                    <h2
+                        id="fit-heading"
+                        className="mt-2 font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl"
+                    >
+                        Built for consequential work trapped behind a GUI.
+                    </h2>
+                    <p className="mt-3 max-w-3xl text-sm leading-relaxed text-ink-2 md:text-base">
+                        The strongest fit is a browser workflow your team repeats,
+                        where the business intent stays stable, a wrong action
+                        matters, and a direct integration is not practical.
+                    </p>
+                    <div className="mt-6 grid gap-4 sm:grid-cols-2">
+                        {outcomes.map((outcome) => (
+                            <article
+                                key={outcome.title}
+                                className="rounded-2xl border border-hairline bg-panel p-5"
+                            >
+                                <h3 className="font-display text-lg font-semibold text-ink">
+                                    {outcome.title}
+                                </h3>
+                                <p className="mt-2 text-sm leading-relaxed text-ink-2">
+                                    {outcome.body}
+                                </p>
+                            </article>
+                        ))}
+                    </div>
+                </section>
 
-                <h2 className="mt-12 font-display text-xl font-semibold tracking-tight text-ink">
-                    Side by side
-                </h2>
-                <div className="mt-4 overflow-x-auto rounded-2xl border border-hairline bg-panel">
-                    <table className="w-full min-w-[720px] text-left text-sm">
-                        <thead>
-                            <tr className="border-b border-hairline bg-ground">
-                                <th className="p-4 font-medium text-ink-3"></th>
-                                <th className="p-4 font-semibold text-ink">
-                                    OpenAdapt
-                                </th>
-                                <th className="p-4 font-medium text-ink-2">
-                                    Traditional RPA
-                                </th>
-                                <th className="p-4 font-medium text-ink-2">
-                                    Computer-use agents
-                                </th>
-                                <th className="p-4 font-medium text-ink-2">
-                                    Browser recorders
-                                </th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {rows.map((row) => (
-                                <tr
-                                    key={row.dimension}
-                                    className="border-b border-dotted border-[#C9CCC2] last:border-b-0"
-                                >
-                                    <td className="p-4 align-top font-medium text-ink">
-                                        {row.dimension}
-                                    </td>
-                                    <td className="bg-accent/10 p-4 align-top text-ink">
-                                        {row.openadapt}
-                                    </td>
-                                    <td className="p-4 align-top text-ink-2">
-                                        {row.rpa}
-                                    </td>
-                                    <td className="p-4 align-top text-ink-2">
-                                        {row.agents}
-                                    </td>
-                                    <td className="p-4 align-top text-ink-2">
-                                        {row.browser}
-                                    </td>
+                <section
+                    id="side-by-side"
+                    className="mt-14 scroll-mt-8"
+                    aria-labelledby="side-by-side-heading"
+                >
+                    <p className="eyebrow">Side by side</p>
+                    <h2
+                        id="side-by-side-heading"
+                        className="mt-2 font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl"
+                    >
+                        Choose by the operating model you need.
+                    </h2>
+                    <p className="mt-3 text-sm text-ink-3 md:hidden">
+                        Scroll horizontally to compare all approaches.
+                    </p>
+                    <div
+                        className="mt-5 overflow-x-auto rounded-2xl border border-hairline bg-panel"
+                        role="region"
+                        aria-labelledby="side-by-side-heading"
+                        tabIndex={0}
+                    >
+                        <table className="w-full min-w-[760px] text-left text-sm">
+                            <caption className="sr-only">
+                                OpenAdapt compared with traditional RPA,
+                                computer-use agents, and browser recorders
+                            </caption>
+                            <thead>
+                                <tr className="border-b border-hairline bg-ground">
+                                    <th scope="col" className="p-4 font-medium text-ink-3">
+                                        Decision point
+                                    </th>
+                                    <th scope="col" className="p-4 font-semibold text-ink">
+                                        OpenAdapt
+                                    </th>
+                                    <th scope="col" className="p-4 font-medium text-ink-2">
+                                        Traditional RPA
+                                    </th>
+                                    <th scope="col" className="p-4 font-medium text-ink-2">
+                                        Computer-use agents
+                                    </th>
+                                    <th scope="col" className="p-4 font-medium text-ink-2">
+                                        Browser recorders
+                                    </th>
                                 </tr>
-                            ))}
-                        </tbody>
-                    </table>
-                </div>
+                            </thead>
+                            <tbody>
+                                {rows.map((row) => (
+                                    <tr
+                                        key={row.dimension}
+                                        className="border-b border-dotted border-[#C9CCC2] last:border-b-0"
+                                    >
+                                        <th
+                                            scope="row"
+                                            className="p-4 align-top font-medium text-ink"
+                                        >
+                                            {row.dimension}
+                                        </th>
+                                        <td className="bg-accent/10 p-4 align-top text-ink">
+                                            {row.openadapt}
+                                        </td>
+                                        <td className="p-4 align-top text-ink-2">
+                                            {row.rpa}
+                                        </td>
+                                        <td className="p-4 align-top text-ink-2">
+                                            {row.agents}
+                                        </td>
+                                        <td className="p-4 align-top text-ink-2">
+                                            {row.browser}
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
 
-                <div className="mt-12 rounded-2xl border border-hairline bg-panel p-6 md:p-8">
-                    <h2 className="font-display text-xl font-semibold tracking-tight text-ink">
-                        Where another tool is the better fit
+                <section
+                    className="mt-14 rounded-2xl border-2 border-ink bg-panel p-6 md:p-8"
+                    aria-labelledby="failure-path-heading"
+                >
+                    <p className="eyebrow">Governed failure</p>
+                    <h2
+                        id="failure-path-heading"
+                        className="mt-2 font-display text-2xl font-semibold tracking-tight text-ink"
+                    >
+                        Control the failure path.
                     </h2>
-                    <p className="mt-3 text-sm leading-relaxed text-ink-2 md:text-base">
-                        We&#39;d rather tell you than have you find out mid-pilot:
-                        computer-use agents are better for novel one-off tasks
-                        (compiling a demo is overhead with no second run) and for
-                        exploratory work across unfamiliar sites. OpenAdapt is for
-                        the opposite: work your team repeats, where repeatability
-                        and cost beat improvisation.
+                    <p className="mt-3 max-w-3xl text-sm leading-relaxed text-ink-2 md:text-base">
+                        OpenAdapt separates deterministic re-resolution,
+                        AI-assisted repair, human teaching, and unsupported
+                        drift. Configured identity and effect checks decide
+                        whether a consequential step continues.
                     </p>
-                    <p className="mt-3 text-sm leading-relaxed text-ink-2 md:text-base">
-                        And if the system you need to automate already has a
-                        solid API, use it; a direct integration will always beat
-                        driving a screen. The current OpenAdapt launch covers
-                        integration-hostile browser workflows. Native desktop,
-                        RDP, and Citrix are separate Experimental/Research paths,
-                        not capabilities implied by this comparison.
-                    </p>
-                </div>
-
-                <div className="mt-12 rounded-2xl border-2 border-ink bg-panel p-6 text-center md:p-8">
-                    <h2 className="font-display text-xl font-semibold tracking-tight text-ink">
-                        See it on your workflow
-                    </h2>
-                    <p className="mx-auto mt-3 max-w-2xl text-sm text-ink-2 md:text-base">
-                        The fastest way to compare is to bring a real task.
-                        Book 15 minutes, or read the code first.
-                    </p>
-                    <div className="mt-5 flex flex-wrap justify-center gap-3">
-                        <Link
-                            href="/#book"
-                            className="btn-ink"
-                        >
-                            Book a demo
+                    <div className="mt-6 grid gap-6 sm:grid-cols-3">
+                        <div>
+                            <h3 className="font-display text-xl font-semibold text-ink">
+                                Resolve
+                            </h3>
+                            <p className="mt-1 text-sm text-ink-2">
+                                Find the target from retained evidence.
+                            </p>
+                        </div>
+                        <div>
+                            <h3 className="font-display text-xl font-semibold text-ink">
+                                Review
+                            </h3>
+                            <p className="mt-1 text-sm text-ink-2">
+                                Inspect a proposed repair before reusing it.
+                            </p>
+                        </div>
+                        <div>
+                            <h3 className="font-display text-xl font-semibold text-ink">
+                                Halt
+                            </h3>
+                            <p className="mt-1 text-sm text-ink-2">
+                                Preserve a report when verification fails.
+                            </p>
+                        </div>
+                    </div>
+                    <p className="mt-6 flex flex-wrap gap-x-6 gap-y-2 text-sm">
+                        <Link href="/safety" className="font-medium text-accent">
+                            See the safety model
                         </Link>
                         <a
-                            href="https://github.com/OpenAdaptAI/openadapt-flow"
-                            className="btn-ghost-ink"
+                            href="https://github.com/OpenAdaptAI/openadapt-flow/blob/main/docs/LIMITS.md"
+                            className="text-accent"
                         >
-                            View on GitHub
+                            Read current limits
+                        </a>
+                    </p>
+                </section>
+
+                <section
+                    id="benchmark-evidence"
+                    className="mt-14 scroll-mt-8 rounded-2xl border border-hairline bg-panel p-6 md:p-8"
+                    aria-labelledby="benchmark-heading"
+                >
+                    <p className="eyebrow">Measured proof</p>
+                    <h2
+                        id="benchmark-heading"
+                        className="mt-2 font-display text-2xl font-semibold tracking-tight text-ink"
+                    >
+                        Faster repeat runs without per-run model spend.
+                    </h2>
+                    <p className="mt-3 max-w-3xl text-sm leading-relaxed text-ink-2 md:text-base">
+                        On MockMed, the reproducible browser workflow bundled
+                        with openadapt-flow, compiled replay completed the same
+                        checked task with lower median latency and $0 in model
+                        cost per run.
+                    </p>
+                    <BenchmarkCharts dataset={benchmark.mockmed} />
+                    <p className="mt-4 text-sm leading-relaxed text-ink-3">
+                        This benchmark measures repeat cost and latency on one
+                        task. We saw the same pattern in a public OpenEMR demo
+                        cross-check.
+                    </p>
+                    <p className="mt-3 flex flex-wrap gap-x-6 gap-y-2 text-sm">
+                        <a
+                            href="https://github.com/OpenAdaptAI/openadapt-flow/blob/main/benchmark/BENCHMARK.md"
+                            className="font-medium text-accent"
+                        >
+                            Method, raw results, and rerun instructions
                         </a>
                         <a
-                            href="https://github.com/OpenAdaptAI/openadapt-flow/tree/main/paper"
-                            className="btn-ghost-ink"
+                            href="https://github.com/OpenAdaptAI/openadapt-flow/blob/main/benchmark/openemr/BENCHMARK.md"
+                            className="text-accent"
                         >
-                            Read the paper source
+                            OpenEMR cross-check
                         </a>
+                        <a
+                            href="https://github.com/OpenAdaptAI/openadapt-flow/blob/main/benchmark/hybrid/BENCHMARK.md"
+                            className="text-accent"
+                        >
+                            Drift and repair evidence
+                        </a>
+                    </p>
+                </section>
+
+                <section
+                    className="mt-14 rounded-2xl border border-hairline bg-panel p-6 md:p-8"
+                    aria-labelledby="choice-heading"
+                >
+                    <h2
+                        id="choice-heading"
+                        className="font-display text-2xl font-semibold tracking-tight text-ink"
+                    >
+                        Start with the right category.
+                    </h2>
+                    <p className="mt-3 text-sm leading-relaxed text-ink-2 md:text-base">
+                        Use a direct API when a stable one exists. Choose
+                        traditional RPA when connector breadth and enterprise
+                        orchestration matter most. Choose a computer-use agent
+                        for novel or exploratory work. Choose OpenAdapt when the
+                        browser workflow repeats and predictable replay,
+                        reviewable change, and governed failure matter.
+                    </p>
+                    <p className="mt-4 text-sm">
+                        <Link href="/#product-status" className="text-accent">
+                            Check current product maturity
+                        </Link>
+                    </p>
+                </section>
+
+                <section className="mt-14 rounded-2xl border-2 border-ink bg-panel p-6 text-center md:p-8">
+                    <h2 className="font-display text-2xl font-semibold tracking-tight text-ink">
+                        Test one real workflow.
+                    </h2>
+                    <p className="mx-auto mt-3 max-w-2xl text-sm leading-relaxed text-ink-2 md:text-base">
+                        Measure authoring time, run time, intervention rate, and
+                        incorrect-success rate on work your team already repeats.
+                    </p>
+                    <div className="mt-5 flex flex-wrap justify-center gap-3">
+                        <Link href="/pricing" className="btn-ink">
+                            Start hosted
+                        </Link>
+                        <Link href="/#book" className="btn-ghost-ink">
+                            Book a workflow review
+                        </Link>
                     </div>
-                </div>
-            </div>
+                    <p className="mt-5 text-sm">
+                        <a
+                            href="https://github.com/OpenAdaptAI/openadapt-flow"
+                            className="text-accent"
+                        >
+                            Inspect the open-source engine
+                        </a>
+                    </p>
+                </section>
+            </main>
 
             <Footer />
         </div>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -8,6 +8,7 @@
 
 ## Core Concepts
 - [How It Works](https://openadapt.ai/#how-it-works): Record, compile, replay, resolve or halt, then verify and report
+- [Compare Approaches](https://openadapt.ai/compare): When to choose OpenAdapt, traditional RPA, computer-use agents, browser recorders, or a direct API
 - [Product Maturity](https://openadapt.ai/#product-status): Browser path, safety controls, desktop backends, hosted execution, and enterprise deployment status
 - [FAQ](https://openadapt.ai/#faq): How OpenAdapt differs from RPA tools and AI computer-use agents, data locality, licensing
 - [Security and Data Boundaries](https://openadapt.ai/security): Screenshot, model, secret, report, certification, and commercial deployment boundaries

--- a/tests/compareCopy.test.js
+++ b/tests/compareCopy.test.js
@@ -1,0 +1,47 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+const root = path.join(__dirname, '..')
+const compare = fs.readFileSync(path.join(root, 'pages/compare.js'), 'utf8')
+const llms = fs.readFileSync(path.join(root, 'public/llms.txt'), 'utf8')
+
+test('comparison page leads with buyer fit and operating outcomes', () => {
+    ;[
+        'Choose repeatable automation for work that repeats.',
+        'Predictable repeat economics',
+        'Review change once',
+        'Know when it stopped',
+        'Control the runtime boundary',
+        'Choose by the operating model you need.',
+        'Control the failure path.',
+        'Test one real workflow.',
+    ].forEach((claim) => assert.match(compare, new RegExp(claim.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))))
+})
+
+test('comparison page keeps the evidence bounded and details optional', () => {
+    assert.match(compare, /This benchmark measures repeat cost and latency on one/)
+    assert.match(compare, /Method, raw results, and rerun instructions/)
+    assert.match(compare, /OpenEMR cross-check/)
+    assert.match(compare, /Drift and repair evidence/)
+    assert.match(compare, /benchmark\/BENCHMARK\.md/)
+    assert.match(compare, /benchmark\/openemr\/BENCHMARK\.md/)
+    assert.match(compare, /benchmark\/hybrid\/BENCHMARK\.md/)
+
+    ;[
+        "We'd rather tell you",
+        'Here is the honest picture',
+        'A bounded field cross-check',
+        'does not establish production EMR reliability',
+        'Review scope, samples, demo limitations, pricing basis, and raw results',
+    ].forEach((copy) => assert.doesNotMatch(compare, new RegExp(copy)))
+})
+
+test('comparison table is accessible and machine-readable discovery links to it', () => {
+    assert.match(compare, /<caption className="sr-only">/)
+    assert.match(compare, /scope="col"/)
+    assert.match(compare, /scope="row"/)
+    assert.match(compare, /aria-labelledby="side-by-side-heading"/)
+    assert.match(llms, /\[Compare Approaches\]\(https:\/\/openadapt\.ai\/compare\)/)
+})


### PR DESCRIPTION
## What changed

- Reframed `/compare` as a buyer decision guide around workflow fit, operating economics, failure behavior, and execution boundaries.
- Replaced three long competitor essays with a concise, fair side-by-side comparison and clear category guidance.
- Kept one primary reproducible benchmark inline; moved methodology, OpenEMR, drift, raw data, and limitations behind optional evidence links.
- Added a direct hosted CTA, an assisted workflow-review CTA, accessible table semantics, mobile scroll guidance, and machine-readable discovery copy.

## Why

The previous page led with caveats and implementation detail before answering the buyer's question: which automation model fits this workflow? The new hierarchy leads with outcomes and decision criteria while keeping claims inside the shipped browser and measured evidence scope.

## Verification

- `npm test` (13/13)
- `npm run build`
- `npx cypress run --config baseUrl=http://127.0.0.1:3031 --spec cypress/e2e/basic.cy.js` (12/12, desktop and 375px mobile)
- `git diff --check`

## Stack

This PR is based on and targets the canonical launch branch from #179 so it preserves the recent launch and cross-site accessibility work.
