### PR TITLE
fix: use canonical Cal.com booking event

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,11 @@ NEXT_PUBLIC_POSTHOG_KEY=
 # PostHog API host (default: https://us.i.posthog.com; use https://eu.i.posthog.com for EU)
 NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 
+# --- Sales booking ---------------------------------------------------------
+# Canonical production event. Override only for an intentional preview or
+# provider migration; local builds use this same URL when the value is unset.
+NEXT_PUBLIC_BOOKING_URL=https://cal.com/richard-abrich/30min?overlayCalendar=true
+
 # --- OpenAdapt Hosted - Stripe Checkout -------------------------------------
 # The website creates Checkout Sessions. OpenAdapt Cloud retrieves and claims
 # those Sessions and owns the signed Stripe webhook and subscription state.

--- a/README.md
+++ b/README.md
@@ -38,19 +38,16 @@ Open [http://localhost:3000](http://localhost:3000) to view the site.
 
 ### Booking configuration
 
-Set Calendly for inline booking in `.env.local`:
+Production and local fallback use the 30-minute Cal.com event:
 
 ```bash
-NEXT_PUBLIC_CALENDLY_URL=https://calendly.com/your-org/intro-call
+NEXT_PUBLIC_BOOKING_URL=https://cal.com/richard-abrich/30min?overlayCalendar=true
 ```
 
-Optional backward-compatible fallback:
-
-```bash
-NEXT_PUBLIC_BOOKING_URL=https://calendly.com/your-org/intro-call
-```
-
-Clockwise links are supported as link-only fallback and are not iframed.
+`NEXT_PUBLIC_BOOKING_URL` supports Cal.com and Calendly inline embeds. Other
+HTTPS booking providers are presented as a direct link rather than an iframe.
+`NEXT_PUBLIC_CALENDLY_URL` remains a legacy compatibility fallback, but is not
+used by the production deployment.
 
 ## Deployment
 

--- a/components/ContactBookingSection.js
+++ b/components/ContactBookingSection.js
@@ -89,7 +89,7 @@ export default function ContactBookingSection({
             <div className="rounded-2xl border border-hairline bg-panel p-6 md:p-8">
                 <p className="eyebrow mb-2">Workflow qualification</p>
                 <h2 className="font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl">
-                    Book a 15-minute automation fit call
+                    Book a 30-minute automation fit call
                 </h2>
                 <p className="mt-3 text-sm text-ink-2 md:text-base">
                     Tell us the substrate, repetition, consequence of error,

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -17,6 +17,26 @@ describe('public product truth', () => {
         cy.get('a[href="/security"]').should('exist')
     })
 
+    it('uses the canonical 30-minute Cal.com booking event', () => {
+        cy.visit('/book')
+        cy.get('h1').should(
+            'contain.text',
+            'Book a 30-minute automation fit call'
+        )
+        cy.get('iframe[title="Book a call with OpenAdapt"]')
+            .should('have.attr', 'src')
+            .and(
+                'equal',
+                'https://cal.com/richard-abrich/30min?overlayCalendar=true'
+            )
+        cy.contains('this direct booking link')
+            .should('have.attr', 'href')
+            .and(
+                'equal',
+                'https://cal.com/richard-abrich/30min?overlayCalendar=true'
+            )
+    })
+
     it('states repair, maturity, and commercial boundaries', () => {
         cy.contains('What “repair” means, and where it stops').should('be.visible')
         cy.contains('Unsupported drift').should('be.visible')

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 [build.environment]
   # Cache buster - change this to force fresh build
   CACHE_BUSTER = "2026-01-18-fix-cdn-cache"
-  NEXT_PUBLIC_CALENDLY_URL = "https://calendly.com/openadapt/30min"
+  NEXT_PUBLIC_BOOKING_URL = "https://cal.com/richard-abrich/30min?overlayCalendar=true"
 
 ## Next.js plugin for Netlify
 ## This handles API routes, middleware, and SSR automatically

--- a/pages/book.js
+++ b/pages/book.js
@@ -16,16 +16,16 @@ export default function BookPage() {
                 <title>Book a Call | OpenAdapt.AI</title>
                 <meta
                     name="description"
-                    content="Book a 15-minute automation fit call with the OpenAdapt team. Share your highest-friction workflow and we'll map what can be automated."
+                    content="Book a 30-minute automation fit call with the OpenAdapt team. Share your highest-friction workflow and we'll map what can be automated."
                 />
                 <link rel="canonical" href="https://openadapt.ai/book" />
                 <meta property="og:title" content="Book a Call | OpenAdapt.AI" />
-                <meta property="og:description" content="Book a 15-minute automation fit call with OpenAdapt. We'll map what can be automated." />
+                <meta property="og:description" content="Book a 30-minute automation fit call with OpenAdapt. We'll map what can be automated." />
                 <meta property="og:url" content="https://openadapt.ai/book" />
             </Head>
             <div className="mx-auto max-w-4xl px-4 py-10">
                 <h1 className="font-display text-3xl font-semibold tracking-tight text-ink md:text-4xl">
-                    Book a 15-minute automation fit call
+                    Book a 30-minute automation fit call
                 </h1>
                 <p className="mt-3 text-sm text-ink-2 md:text-base">
                     Share your highest-friction workflow and we will map what can
@@ -53,4 +53,3 @@ export default function BookPage() {
         </div>
     )
 }
-

--- a/tests/bookingContract.test.js
+++ b/tests/bookingContract.test.js
@@ -1,0 +1,49 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+const root = path.join(__dirname, '..')
+const canonicalUrl =
+    'https://cal.com/richard-abrich/30min?overlayCalendar=true'
+const read = (relativePath) =>
+    fs.readFileSync(path.join(root, relativePath), 'utf8')
+
+test('production, local fallback, and environment example share one booking URL', () => {
+    for (const relativePath of [
+        'utils/booking.js',
+        'netlify.toml',
+        '.env.example',
+        'README.md',
+    ]) {
+        assert.match(
+            read(relativePath),
+            new RegExp(canonicalUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+            `${relativePath} must use the canonical booking URL`
+        )
+    }
+})
+
+test('production config has no Calendly destination or stale event duration', () => {
+    const deployment = read('netlify.toml')
+    assert.doesNotMatch(deployment, /calendly\.com/i)
+    assert.doesNotMatch(deployment, /NEXT_PUBLIC_CALENDLY_URL/)
+
+    const buyerSurfaces = [
+        'pages/book.js',
+        'components/ContactBookingSection.js',
+    ]
+        .map(read)
+        .join('\n')
+    assert.doesNotMatch(buyerSurfaces, /15-minute automation fit call/)
+    assert.doesNotMatch(buyerSurfaces, /richard-abrich\/60min/)
+})
+
+test('provider detection matches provider domains rather than lookalike hosts', () => {
+    const bookingSource = read('utils/booking.js')
+    for (const host of ['cal.com', 'calendly.com', 'clockwise.com']) {
+        assert.ok(bookingSource.includes(`host === '${host}'`))
+        assert.ok(bookingSource.includes(`host.endsWith('.${host}')`))
+    }
+    assert.doesNotMatch(bookingSource, /host\.includes\(/)
+})

--- a/utils/booking.js
+++ b/utils/booking.js
@@ -1,8 +1,7 @@
-// Default booking is Cal.com (richard-abrich/60min). The maintainer syncs a
-// single service they already use; override with NEXT_PUBLIC_BOOKING_URL if
-// that ever changes.
+// Keep production and local builds on the same canonical booking destination.
+// NEXT_PUBLIC_BOOKING_URL remains available for explicit preview/provider tests.
 export const DEFAULT_BOOKING_URL =
-    'https://cal.com/richard-abrich/60min?overlayCalendar=true'
+    'https://cal.com/richard-abrich/30min?overlayCalendar=true'
 
 export function detectBookingProvider(url) {
     if (!url) {
@@ -12,13 +11,13 @@ export function detectBookingProvider(url) {
     try {
         const parsed = new URL(url)
         const host = parsed.hostname.toLowerCase()
-        if (host.includes('cal.com')) {
+        if (host === 'cal.com' || host.endsWith('.cal.com')) {
             return 'calcom'
         }
-        if (host.includes('calendly.com')) {
+        if (host === 'calendly.com' || host.endsWith('.calendly.com')) {
             return 'calendly'
         }
-        if (host.includes('clockwise.com')) {
+        if (host === 'clockwise.com' || host.endsWith('.clockwise.com')) {
             return 'clockwise'
         }
         return 'other'


### PR DESCRIPTION
## Summary
- replace the production Calendly override and stale 60-minute fallback with the canonical 30-minute Cal.com event
- align visible booking duration and social metadata with the event
- retain optional provider overrides while requiring exact provider domains for inline embedding
- add deployment-contract and browser regression coverage

## Verification
- npm test (16/16)
- npm run build
- npx cypress run --config baseUrl=http://127.0.0.1:3217 --spec cypress/e2e/basic.cy.js (13/13)
- git diff --check