### PR TITLE
fix: use canonical Cal.com booking

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,16 @@ Open [http://localhost:3000](http://localhost:3000) to view the site.
 
 ### Booking configuration
 
-Set Calendly for inline booking in `.env.local`:
+Set the canonical Cal.com event for inline booking in `.env.local`:
+
+```bash
+NEXT_PUBLIC_BOOKING_URL=https://cal.com/richard-abrich/30min?overlayCalendar=true
+```
+
+An older Calendly deployment can still use the compatibility variable:
 
 ```bash
 NEXT_PUBLIC_CALENDLY_URL=https://calendly.com/your-org/intro-call
-```
-
-Optional backward-compatible fallback:
-
-```bash
-NEXT_PUBLIC_BOOKING_URL=https://calendly.com/your-org/intro-call
 ```
 
 Clockwise links are supported as link-only fallback and are not iframed.

--- a/components/ContactBookingSection.js
+++ b/components/ContactBookingSection.js
@@ -89,7 +89,7 @@ export default function ContactBookingSection({
             <div className="rounded-2xl border border-hairline bg-panel p-6 md:p-8">
                 <p className="eyebrow mb-2">Book</p>
                 <h2 className="font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl">
-                    Book a 15-minute automation fit call
+                    Book a 30-minute automation fit call
                 </h2>
                 <p className="mt-3 text-sm text-ink-2 md:text-base">
                     Tell us your highest-friction workflow and we&apos;ll map
@@ -245,4 +245,3 @@ export default function ContactBookingSection({
         </section>
     )
 }
-

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 [build.environment]
   # Cache buster - change this to force fresh build
   CACHE_BUSTER = "2026-01-18-fix-cdn-cache"
-  NEXT_PUBLIC_CALENDLY_URL = "https://calendly.com/openadapt/30min"
+  NEXT_PUBLIC_BOOKING_URL = "https://cal.com/richard-abrich/30min?overlayCalendar=true"
 
 ## Next.js plugin for Netlify
 ## This handles API routes, middleware, and SSR automatically

--- a/pages/about.js
+++ b/pages/about.js
@@ -171,7 +171,7 @@ export default function AboutPage() {
                     </h2>
                     <p className="mx-auto mt-3 max-w-2xl text-sm text-ink-2 md:text-base">
                         If you&#39;ve got a repetitive desktop workflow, bring
-                        it to a 15-minute call and we&#39;ll tell you whether
+                        it to a 30-minute call and we&#39;ll tell you whether
                         compiling it makes sense.
                     </p>
                     <Link

--- a/pages/book.js
+++ b/pages/book.js
@@ -16,16 +16,16 @@ export default function BookPage() {
                 <title>Book a Call | OpenAdapt.AI</title>
                 <meta
                     name="description"
-                    content="Book a 15-minute automation fit call with the OpenAdapt team. Share your highest-friction workflow and we'll map what can be automated."
+                    content="Book a 30-minute automation fit call with the OpenAdapt team. Share your highest-friction workflow and we'll map what can be automated."
                 />
                 <link rel="canonical" href="https://openadapt.ai/book" />
                 <meta property="og:title" content="Book a Call | OpenAdapt.AI" />
-                <meta property="og:description" content="Book a 15-minute automation fit call with OpenAdapt. We'll map what can be automated." />
+                <meta property="og:description" content="Book a 30-minute automation fit call with OpenAdapt. We'll map what can be automated." />
                 <meta property="og:url" content="https://openadapt.ai/book" />
             </Head>
             <div className="mx-auto max-w-4xl px-4 py-10">
                 <h1 className="font-display text-3xl font-semibold tracking-tight text-ink md:text-4xl">
-                    Book a 15-minute automation fit call
+                    Book a 30-minute automation fit call
                 </h1>
                 <p className="mt-3 text-sm text-ink-2 md:text-base">
                     Share your highest-friction workflow and we will map what can
@@ -53,4 +53,3 @@ export default function BookPage() {
         </div>
     )
 }
-

--- a/pages/solutions/healthcare.js
+++ b/pages/solutions/healthcare.js
@@ -126,7 +126,7 @@ export default function HealthcarePage() {
                     </h2>
                     <p className="mx-auto mt-3 max-w-2xl text-sm text-ink-2 md:text-base">
                         Bring your highest-volume retyping task to a
-                        15-minute call and we&#39;ll map what compiling it
+                        30-minute call and we&#39;ll map what compiling it
                         would look like in your clinic.
                     </p>
                     <Link

--- a/pages/solutions/lending.js
+++ b/pages/solutions/lending.js
@@ -98,7 +98,7 @@ export default function LendingPage() {
                     </h2>
                     <p className="mx-auto mt-3 max-w-2xl text-sm text-ink-2 md:text-base">
                         Bring your highest-volume data-entry task to a
-                        15-minute call and we&#39;ll map what compiling it
+                        30-minute call and we&#39;ll map what compiling it
                         would look like in your environment.
                     </p>
                     <Link

--- a/utils/booking.js
+++ b/utils/booking.js
@@ -1,8 +1,7 @@
-// Default booking is Cal.com (richard-abrich/60min). The maintainer syncs a
-// single service they already use; override with NEXT_PUBLIC_BOOKING_URL if
-// that ever changes.
+// Keep production and local builds on the same canonical booking destination.
+// NEXT_PUBLIC_BOOKING_URL remains available for explicit preview/provider tests.
 export const DEFAULT_BOOKING_URL =
-    'https://cal.com/richard-abrich/60min?overlayCalendar=true'
+    'https://cal.com/richard-abrich/30min?overlayCalendar=true'
 
 export function detectBookingProvider(url) {
     if (!url) {
@@ -12,13 +11,13 @@ export function detectBookingProvider(url) {
     try {
         const parsed = new URL(url)
         const host = parsed.hostname.toLowerCase()
-        if (host.includes('cal.com')) {
+        if (host === 'cal.com' || host.endsWith('.cal.com')) {
             return 'calcom'
         }
-        if (host.includes('calendly.com')) {
+        if (host === 'calendly.com' || host.endsWith('.calendly.com')) {
             return 'calendly'
         }
-        if (host.includes('clockwise.com')) {
+        if (host === 'clockwise.com' || host.endsWith('.clockwise.com')) {
             return 'clockwise'
         }
         return 'other'


### PR DESCRIPTION
Routes production booking to the canonical 30-minute Cal.com event, removes the Netlify Calendly override, aligns buyer-facing duration copy, and tightens provider hostname detection. Verified with a production build.