### PR TITLE
Make Cal.com the only booking destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,19 +35,12 @@ Open [http://localhost:3000](http://localhost:3000) to view the site.
 
 ### Booking configuration
 
-Set the canonical Cal.com event for inline booking in `.env.local`:
+Booking is code-owned and always routes to the canonical Cal.com event:
 
-```bash
-NEXT_PUBLIC_BOOKING_URL=https://cal.com/richard-abrich/30min?overlayCalendar=true
-```
+`https://cal.com/richard-abrich/30min?overlayCalendar=true`
 
-An older Calendly deployment can still use the compatibility variable:
-
-```bash
-NEXT_PUBLIC_CALENDLY_URL=https://calendly.com/your-org/intro-call
-```
-
-Clockwise links are supported as link-only fallback and are not iframed.
+Deploy-time booking-provider overrides are intentionally ignored so stale
+environment variables cannot redirect the homepage form or `/book` embed.
 
 ## Deployment
 

--- a/components/BookingEmbed.js
+++ b/components/BookingEmbed.js
@@ -44,13 +44,12 @@ export default function BookingEmbed({ name = '', email = '' }) {
         )
     }
 
-    if (provider !== 'calendly' && provider !== 'calcom') {
-        const providerLabel = provider === 'clockwise' ? 'Clockwise' : 'your booking provider'
+    if (provider !== 'calcom') {
         return (
             <div className="rounded-xl border border-amber-700/40 bg-amber-100 px-4 py-5 text-amber-900">
                 <p className="text-sm">
-                    {providerLabel} does not support secure inline embedding on this page.
-                    Open booking in a new tab instead.
+                    The booking destination is invalid. Use the contact form
+                    while we restore the canonical Cal.com scheduler.
                 </p>
                 <div className="mt-4 flex flex-wrap gap-3">
                     <a

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -1,16 +1,22 @@
-describe('empty spec', () => {
-    beforeEach(() => {
-        cy.visit('/')
+const BOOKING_URL =
+    'https://cal.com/richard-abrich/30min?overlayCalendar=true'
+
+function assertCanonicalBooking() {
+    cy.get('iframe[title="Book a call with OpenAdapt"]')
+        .should('have.attr', 'src')
+        .and('equal', BOOKING_URL)
+    cy.get('iframe[src*="calendly.com"]').should('not.exist')
+}
+
+describe('canonical booking destination', () => {
+    it('uses Cal.com on the dedicated booking page', () => {
+        cy.visit('/book')
+        assertCanonicalBooking()
     })
 
-    /*
-  it('displays the resources text', () => {
-    cy.get('h1')
-    .contains('Next.js Toolbox');
-  })
-  it('renders the form', () => {
-    cy.get('form')
-    .should('be.visible')
-  })
-  */
+    it('uses Cal.com after continuing through the homepage form', () => {
+        cy.visit('/')
+        cy.contains('Skip form and book now').click()
+        assertCanonicalBooking()
+    })
 })

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -16,7 +16,10 @@ describe('canonical booking destination', () => {
 
     it('uses Cal.com after continuing through the homepage form', () => {
         cy.visit('/')
-        cy.contains('Skip form and book now').click()
+        cy.contains('button', 'Skip form and book now')
+            .scrollIntoView()
+            .should('be.visible')
+            .click({ force: true })
         assertCanonicalBooking()
     })
 })

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,6 +13,12 @@
 
 [[plugins]]
   package = "netlify-plugin-cypress"
+  # `.next` is an internal runtime artifact, not a static site. Exercise the
+  # deployed Next.js preview instead of serving `.next` directly in postBuild.
+  [plugins.inputs]
+    skip = true
+  [plugins.inputs.onSuccess]
+    enable = true
 
 [[headers]]
   for = "/*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,6 @@
 [build.environment]
   # Cache buster - change this to force fresh build
   CACHE_BUSTER = "2026-01-18-fix-cdn-cache"
-  NEXT_PUBLIC_BOOKING_URL = "https://cal.com/richard-abrich/30min?overlayCalendar=true"
 
 ## Next.js plugin for Netlify
 ## This handles API routes, middleware, and SSR automatically

--- a/utils/booking.js
+++ b/utils/booking.js
@@ -1,44 +1,13 @@
-// Keep production and local builds on the same canonical booking destination.
-// NEXT_PUBLIC_BOOKING_URL remains available for explicit preview/provider tests.
+// Keep every build on one code-owned booking destination. Deploy-time provider
+// fallbacks made stale Calendly configuration capable of resurfacing.
 export const DEFAULT_BOOKING_URL =
     'https://cal.com/richard-abrich/30min?overlayCalendar=true'
 
-export function detectBookingProvider(url) {
-    if (!url) {
-        return 'none'
-    }
-
-    try {
-        const parsed = new URL(url)
-        const host = parsed.hostname.toLowerCase()
-        if (host === 'cal.com' || host.endsWith('.cal.com')) {
-            return 'calcom'
-        }
-        if (host === 'calendly.com' || host.endsWith('.calendly.com')) {
-            return 'calendly'
-        }
-        if (host === 'clockwise.com' || host.endsWith('.clockwise.com')) {
-            return 'clockwise'
-        }
-        return 'other'
-    } catch (error) {
-        return 'other'
-    }
-}
-
 export function getBookingConfig() {
-    const calendlyUrl = (process.env.NEXT_PUBLIC_CALENDLY_URL || '').trim()
-    const genericUrl = (process.env.NEXT_PUBLIC_BOOKING_URL || '').trim()
-    const url = genericUrl || calendlyUrl || DEFAULT_BOOKING_URL
-
     return {
-        url,
-        provider: detectBookingProvider(url),
-        source: genericUrl
-            ? 'NEXT_PUBLIC_BOOKING_URL'
-            : calendlyUrl
-                ? 'NEXT_PUBLIC_CALENDLY_URL'
-                : 'default',
+        url: DEFAULT_BOOKING_URL,
+        provider: 'calcom',
+        source: 'canonical',
     }
 }
 
@@ -46,24 +15,9 @@ export function getConfiguredBookingUrl() {
     return getBookingConfig().url
 }
 
-// Providers whose booking pages render safely inside an iframe on our page.
-export function isEmbeddableBookingUrl(url) {
-    const provider = detectBookingProvider(url)
-    return provider === 'calcom' || provider === 'calendly'
-}
-
-export function isCalendlyUrl(url) {
-    return detectBookingProvider(url) === 'calendly'
-}
-
 export function buildBookingUrlWithPrefill(url, prefill = {}) {
     if (!url) {
         return ''
-    }
-
-    const provider = detectBookingProvider(url)
-    if (provider !== 'calcom' && provider !== 'calendly') {
-        return url
     }
 
     let parsed
@@ -73,18 +27,7 @@ export function buildBookingUrlWithPrefill(url, prefill = {}) {
         return url
     }
 
-    // Calendly-only chrome tweaks; Cal.com ignores these harmlessly but we
-    // keep them scoped to Calendly to avoid unknown query params.
-    if (provider === 'calendly') {
-        if (!parsed.searchParams.get('hide_event_type_details')) {
-            parsed.searchParams.set('hide_event_type_details', '1')
-        }
-        if (!parsed.searchParams.get('hide_gdpr_banner')) {
-            parsed.searchParams.set('hide_gdpr_banner', '1')
-        }
-    }
-
-    // Both Cal.com and Calendly prefill the booker from ?name= / ?email=.
+    // Cal.com prefills the booker from ?name= / ?email=.
     if (prefill.name && !parsed.searchParams.get('name')) {
         parsed.searchParams.set('name', prefill.name)
     }


### PR DESCRIPTION
## What changed

- make the exact Cal.com 30-minute event code-owned instead of environment-selectable
- remove legacy Calendly and generic provider fallback logic
- remove the stale Netlify booking override
- cover both `/book` and the homepage form continuation in Cypress
- run Netlify's Cypress plugin against the deployed Next.js preview instead of serving `.next` as static files

## Why

Production still carried `NEXT_PUBLIC_CALENDLY_URL=https://calendly.com/openadapt/30min` alongside the Cal.com variable. The current resolver preferred Cal.com, but stale builds or missing generic configuration could fall back to Calendly. The legacy Netlify variable has now also been removed from all deploy contexts.

The first preview failed because `netlify-plugin-cypress` served `.next` directly during `onPostBuild`. `.next` is an internal Next.js runtime artifact, so `/book` returned 404. Post-deploy Cypress now targets the actual Netlify Next.js preview.

## Verification

- exact lockfile install completed with `npm ci` (Puppeteer download skipped only for unsupported Apple ARM)
- production Next.js build passed (16 pages)
- local Cypress against `next start`: **5/5 passed**
- deployed-preview Cypress: **5/5 passed**
- Netlify deploy preview, header rules, and redirect rules: **passed**
- pages-changed check: **neutral** (no page inventory change)
- `git diff --check`: **passed**
- no Calendly or legacy booking-environment reference remains in runtime source/config/docs
