### PR TITLE
fix(site): repair hosted funnel routing and cross-links

### DIFF
--- a/components/EmailForm.js
+++ b/components/EmailForm.js
@@ -55,7 +55,11 @@ export default function EmailForm() {
         + (isSubmitting ? ' opacity-0' : ' opacity-100')
 
     return (
-        <div className={`${styles.background} flex flex-col justify-center items-center`}>
+        <div
+            id="get-updates"
+            className={`${styles.background} flex flex-col justify-center items-center`}
+            style={{ scrollMarginTop: '80px' }}
+        >
             {formHidden ? (
                 <div className="fade-in">
                     <h4 className="font-light text-ink-2 text-sm">

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -135,6 +135,12 @@ export default function Footer() {
                             Blog
                         </a>
                         <a
+                            href="https://app.openadapt.ai"
+                            className={styles.link}
+                        >
+                            Hosted dashboard (beta)
+                        </a>
+                        <a
                             href="https://github.com/OpenAdaptAI"
                             className={styles.link}
                             onClick={() =>

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -62,13 +62,22 @@ function HostedCheckoutButton({ available }) {
 
     if (!available) {
         return (
-            <Link
-                href="/#book"
-                data-testid="hosted-contact"
-                className="btn-ink block w-full text-center"
-            >
-                Start with our team
-            </Link>
+            <div>
+                <Link
+                    href="/#book"
+                    data-testid="hosted-contact"
+                    className="btn-ink block w-full text-center"
+                >
+                    Start with our team
+                </Link>
+                <Link
+                    href="/#get-updates"
+                    data-testid="hosted-waitlist"
+                    className="mt-3 block text-center text-xs text-accent underline"
+                >
+                    Get notified when hosted access opens
+                </Link>
+            </div>
         )
     }
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,21 @@
+/**
+ * @type {import('next').NextConfig}
+ *
+ * No framework behavior is customized here beyond redirects; the site
+ * otherwise uses Next.js defaults (see netlify.toml for deploy config).
+ */
+const nextConfig = {
+    async redirects() {
+        return [
+            {
+                // People guess /signin from the hosted-dashboard mentions;
+                // send them to the real hosted login instead of a 404.
+                source: '/signin',
+                destination: 'https://app.openadapt.ai/login',
+                permanent: false,
+            },
+        ]
+    },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
Repairs three launch funnel dead ends without changing OpenAdapt's product claims, substrate maturity, safety language, or data boundaries.

## Changes

1. `/signin` now returns a temporary framework redirect to `https://app.openadapt.ai/login` instead of a 404.
2. The footer links to the hosted dashboard and labels it Beta.
3. When the hosted offer is unavailable, the pricing card links to the existing Netlify updates form as a secondary CTA. This adds no new form, backend, or data recipient.

The earlier duplicate hero paragraph was removed. The existing canonical drift copy remains authoritative: OpenAdapt can re-resolve from retained evidence, propose a governed repair, or stop for an operator.

## Verification

- Rebases cleanly onto current `main` at `91f2867`.
- `npm test`: 31/31 passed.
- `npm run build`: passed with Next.js 15.5.20.
- Remote CI and Netlify deploy-preview verification are required on the exact revised head before merge.
