### PR TITLE
feat(site): add sourced Testimonials section to the homepage

### DIFF
--- a/components/Testimonials.js
+++ b/components/Testimonials.js
@@ -14,8 +14,8 @@ const testimonials = [
             'automatically with just a few clicks. The personalized service ' +
             'and support were phenomenal. I will definitely be using ' +
             'OpenAdapt to audit my procedures every month from now on.',
-        name: 'Victor Abrich, MD, FHRS',
-        role: 'Electrophysiologist, MercyOne Waterloo Heart Care',
+        name: 'Victor Abrich',
+        role: 'Electrophysiologist',
         sourceUrl: 'https://github.com/OpenAdaptAI/openadapt-web/issues/9',
         sourceLabel: 'Documented on GitHub',
     },

--- a/components/Testimonials.js
+++ b/components/Testimonials.js
@@ -1,0 +1,60 @@
+import styles from './Testimonials.module.css'
+
+// Every testimonial on this page must be documented. `sourceUrl` points at
+// the public record of the quote; the quote text must match that source
+// verbatim. Do not add testimonials without a source.
+const testimonials = [
+    {
+        figure: '$75K',
+        figureCaption: 'in under-billed procedural RVUs recovered',
+        quote:
+            'My hospital had under-billed $75K worth of procedural RVUs ' +
+            'which took me 20 hours of manual chart review over the course ' +
+            'of 6 months to recover. OpenAdapt was able to do this job ' +
+            'automatically with just a few clicks. The personalized service ' +
+            'and support were phenomenal. I will definitely be using ' +
+            'OpenAdapt to audit my procedures every month from now on.',
+        name: 'Victor Abrich, MD, FHRS',
+        role: 'Electrophysiologist, MercyOne Waterloo Heart Care',
+        sourceUrl: 'https://github.com/OpenAdaptAI/openadapt-web/issues/9',
+        sourceLabel: 'Documented on GitHub',
+    },
+]
+
+export default function Testimonials() {
+    return (
+        <section className={styles.section} data-testid="testimonials">
+            <div className={styles.inner}>
+                <p className="eyebrow">From the people running the workflows</p>
+                <h2 className={styles.heading}>
+                    Real work, recovered in a few clicks.
+                </h2>
+                <div className={styles.grid}>
+                    {testimonials.map((t) => (
+                        <figure key={t.name} className={styles.card}>
+                            <div className={styles.figure}>{t.figure}</div>
+                            <div className={styles.figureCaption}>
+                                {t.figureCaption}
+                            </div>
+                            <blockquote className={styles.quote}>
+                                &ldquo;{t.quote}&rdquo;
+                            </blockquote>
+                            <figcaption className={styles.attribution}>
+                                <span className={styles.name}>{t.name}</span>
+                                <span className={styles.role}>{t.role}</span>
+                                <a
+                                    className={styles.source}
+                                    href={t.sourceUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    {t.sourceLabel}
+                                </a>
+                            </figcaption>
+                        </figure>
+                    ))}
+                </div>
+            </div>
+        </section>
+    )
+}

--- a/components/Testimonials.module.css
+++ b/components/Testimonials.module.css
@@ -1,0 +1,91 @@
+.section {
+    background: var(--ground);
+    border-bottom: 1px solid var(--hairline);
+    padding: 48px 16px;
+}
+
+.inner {
+    max-width: 64rem;
+    margin: 0 auto;
+    text-align: center;
+}
+
+.heading {
+    max-width: 46rem;
+    margin: 10px auto 0;
+    font-family: var(--font-display);
+    font-size: clamp(1.35rem, 2.5vw, 2rem);
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    line-height: 1.2;
+    color: var(--ink);
+}
+
+/* Flex (not a fixed-column grid) so one card centers today and two or
+   three cards flow naturally as more documented testimonials land. */
+.grid {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 14px;
+    margin-top: 20px;
+}
+
+.card {
+    background: var(--panel);
+    border: 1px solid var(--hairline);
+    border-radius: 12px;
+    padding: 26px 24px;
+    max-width: 620px;
+    flex: 1 1 340px;
+    margin: 0;
+    text-align: left;
+}
+
+.figure {
+    font-family: var(--font-display);
+    font-size: 32px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    color: var(--ink);
+    line-height: 1.2;
+}
+
+.figureCaption {
+    margin-top: 4px;
+    font-size: 13px;
+    color: var(--ink-2);
+    line-height: 1.45;
+}
+
+.quote {
+    margin: 14px 0 0;
+    font-size: 15px;
+    line-height: 1.6;
+    color: var(--ink);
+}
+
+.attribution {
+    margin-top: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    font-size: 13.5px;
+}
+
+.name {
+    font-weight: 600;
+    color: var(--ink);
+}
+
+.role {
+    color: var(--ink-2);
+}
+
+.source {
+    margin-top: 4px;
+    color: var(--ink-2);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    width: fit-content;
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -15,6 +15,7 @@ import ProductStatus from '@components/ProductStatus'
 import ProofBand from '@components/ProofBand'
 import AudiencePaths from '@components/AudiencePaths'
 import SafetyBand from '@components/SafetyBand'
+import Testimonials from '@components/Testimonials'
 // import SocialSection from '@components/SocialSection' // Temporarily disabled - feeds not working
 
 const GITHUB_REPOSITORY = 'OpenAdaptAI/OpenAdapt'
@@ -199,6 +200,7 @@ export default function Home({ githubStats, hostedOffer }) {
                 setFeedbackData={setFeedbackData}
                 sectionRef={sectionRef}
             />
+            <Testimonials />
             <div style={{
                 background: 'var(--panel)',
                 textAlign: 'center',

--- a/tests/publicTruth.test.js
+++ b/tests/publicTruth.test.js
@@ -260,8 +260,11 @@ test('testimonials are verbatim from their documented public source', () => {
     // and string-concatenation syntax collapsed.
     const flattened = component.replace(/'\s*\+\s*'/g, '').replace(/\s+/g, ' ')
     assert.ok(flattened.includes(documentedQuote))
-    assert.match(component, /Victor Abrich, MD, FHRS/)
-    assert.match(component, /Electrophysiologist, MercyOne Waterloo Heart Care/)
+    assert.match(component, /Victor Abrich/)
+    assert.match(component, /Electrophysiologist/)
+    // Attribution is limited to name + specialty. No employer/institution
+    // names in public marketing copy without that institution's sign-off.
+    assert.doesNotMatch(component, /MercyOne/)
     assert.match(
         component,
         /https:\/\/github\.com\/OpenAdaptAI\/openadapt-web\/issues\/9/

--- a/tests/publicTruth.test.js
+++ b/tests/publicTruth.test.js
@@ -238,3 +238,33 @@ test('sitemap includes launch, download, and trust surfaces', () => {
         assert.match(sitemap, new RegExp(`https://openadapt\\.ai/${route}`))
     }
 })
+
+test('testimonials are verbatim from their documented public source', () => {
+    // Source of record: https://github.com/OpenAdaptAI/openadapt-web/issues/9
+    // (posted 2023-05-30). The quote below is the documented text; the
+    // component must carry it verbatim, attribute it as documented, and
+    // link the source. Testimonials without a documented source must not
+    // be added.
+    const component = read('components/Testimonials.js')
+    const home = read('pages/index.js')
+
+    const documentedQuote =
+        'My hospital had under-billed $75K worth of procedural RVUs which ' +
+        'took me 20 hours of manual chart review over the course of 6 ' +
+        'months to recover. OpenAdapt was able to do this job automatically ' +
+        'with just a few clicks. The personalized service and support were ' +
+        'phenomenal. I will definitely be using OpenAdapt to audit my ' +
+        'procedures every month from now on.'
+
+    // The quote is wrapped across source lines; compare with whitespace
+    // and string-concatenation syntax collapsed.
+    const flattened = component.replace(/'\s*\+\s*'/g, '').replace(/\s+/g, ' ')
+    assert.ok(flattened.includes(documentedQuote))
+    assert.match(component, /Victor Abrich, MD, FHRS/)
+    assert.match(component, /Electrophysiologist, MercyOne Waterloo Heart Care/)
+    assert.match(
+        component,
+        /https:\/\/github\.com\/OpenAdaptAI\/openadapt-web\/issues\/9/
+    )
+    assert.match(home, /<Testimonials \/>/)
+})


### PR DESCRIPTION
## Summary

Adds a **Testimonials** section to the homepage, closing #9 (open since May 2023). Placement follows the agreement in that issue: between the industries grid and the signup/launch CTA.

### The testimonial (documented source)

The quote is reproduced **verbatim** from the public record in issue #9 (posted 2023-05-30):

> My hospital had under-billed $75K worth of procedural RVUs which took me 20 hours of manual chart review over the course of 6 months to recover. OpenAdapt was able to do this job automatically with just a few clicks. The personalized service and support were phenomenal. I will definitely be using OpenAdapt to audit my procedures every month from now on.

The card leads with the figure ($75K in under-billed procedural RVUs recovered), carries the full quote, attribution limited to **Victor Abrich, Electrophysiologist** (no employer/institution names in public marketing copy without that institution's sign-off — full attribution details remain in the linked source of record), and a "Documented on GitHub" link to #9.

Note: the documented figure is a **$75K under-billing recovery** (20 hours of manual chart review over 6 months, replaced by a few clicks) — not "$75K saved per year". The copy sticks to what the source says.

### Structure

- `components/Testimonials.js` + `components/Testimonials.module.css` — **new, self-contained component** (data array + card layout). Wrapping flex row sized for 2-3 cards, so future documented testimonials drop in without structural changes; a single card centers cleanly today.
- `pages/index.js` — one import + one `<Testimonials />` line after `<IndustriesGrid />`.
- `tests/publicTruth.test.js` — new guard: the quote must match the documented source verbatim, the authorized attribution and source link must be present, no institution names may appear, and the section must be mounted. The data array documents that testimonials without a public source must not be added.

### Coordination with #189

#189 (`fix/funnel-quick-wins`) is actively restructuring homepage sections. This PR was deliberately built as a new component in its own files; the only shared file is `pages/index.js` (two added lines). If #189 lands first and touches those regions, this needs only a trivial rebase.

### Verification

- `npm test` — 32/32 pass (including the new testimonial-source guard)
- `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
