### PR TITLE
docs(site): publish scoped Windows and macOS evidence

### DIFF
--- a/components/ProductStatus.js
+++ b/components/ProductStatus.js
@@ -3,6 +3,8 @@ import Link from 'next/link'
 const FLOW_URL = 'https://github.com/OpenAdaptAI/openadapt-flow'
 const LIMITS_URL = `${FLOW_URL}/blob/main/docs/LIMITS.md`
 const HOSTED_URL = 'https://docs.openadapt.ai/guides/hosted/'
+const WINDOWS_UIA_EVIDENCE_URL = `${FLOW_URL}/blob/defafbae758a75c8e149d9693f2cffe1f2264b8c/benchmark/windows_uia/results.json`
+const MACOS_TEXTEDIT_EVIDENCE_URL = `${FLOW_URL}/blob/ca1b522cad215875f7471782283f8f8bb8e6c998/benchmark/macos_native/textedit_counted_3plus1_b1b61a5_20260717.adjudication.json`
 
 const workflow = [
     {
@@ -59,14 +61,18 @@ const substrates = [
     {
         name: 'Windows UIA',
         availability: 'Partner qualification',
-        evidence: 'Acceptance in progress',
-        scope: 'A typed, fail-closed candidate driver is under real Windows qualification with an independent database oracle. It is not in the hosted browser launch candidate.',
+        evidence: 'Scoped acceptance passed',
+        scope: 'The counted 20260717-candidate-56759c8-v2 in-tree WinForms matrix completed 3/3 trials; an independent SQLite oracle confirmed 3/3 effects; stale-target and ambiguous-target controls each refused 3/3; 0 silent incorrect successes, 0 over-halts, and 0 model calls. The report preserves earlier rejected diagnostic runs; those are not counted acceptance trials. This qualifies that exact workflow and VM snapshot, not arbitrary Windows applications or hosted desktop.',
+        evidenceUrl: WINDOWS_UIA_EVIDENCE_URL,
+        evidenceLink: 'Review exact Windows evidence',
     },
     {
         name: 'Native macOS',
         availability: 'Partner qualification',
-        evidence: 'Acceptance in progress',
-        scope: 'A native exact-window candidate is under permissioned TextEdit qualification. Ambiguous or foreground-mismatched windows halt; broader application support is not established.',
+        evidence: 'Scoped TextEdit evidence accepted',
+        scope: 'On one macOS 15.7.3 arm64 host, candidate b1b61a5 completed 3/3 exact-byte TextEdit trials and refused a two-window ambiguity without changing either file; 0 silent incorrect successes and 0 over-halts. The immutable batch report remains failed because cleanup warnings counted as failure; its SHA-256-bound adjudication verified actual process and temporary-file cleanup and accepts only the effect and refusal evidence. This is not clean-machine, design-partner, production, or broad macOS evidence.',
+        evidenceUrl: MACOS_TEXTEDIT_EVIDENCE_URL,
+        evidenceLink: 'Review scoped macOS evidence',
     },
     {
         name: 'RDP',
@@ -165,6 +171,16 @@ export default function ProductStatus() {
                                         </td>
                                         <td className="border-b border-hairline px-5 py-4 leading-relaxed text-ink-2">
                                             {item.scope}
+                                            {item.evidenceUrl ? (
+                                                <a
+                                                    href={item.evidenceUrl}
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    className="mt-2 block text-xs text-accent underline"
+                                                >
+                                                    {item.evidenceLink}
+                                                </a>
+                                            ) : null}
                                         </td>
                                     </tr>
                                 ))}

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -66,9 +66,23 @@ describe('public product truth', () => {
             cy.contains('Availability').should('be.visible')
             cy.contains('Evidence state').should('be.visible')
             cy.contains('Partner qualification').should('be.visible')
+            cy.contains('Scoped acceptance passed').should('be.visible')
+            cy.contains('Scoped TextEdit evidence accepted').should('be.visible')
             cy.contains('Acceptance in progress').should('be.visible')
             cy.contains('Design partner needed').should('be.visible')
             cy.contains('No ICA/HDX evidence').should('be.visible')
+            cy.contains(
+                '20260717-candidate-56759c8-v2 in-tree WinForms matrix completed 3/3 trials'
+            ).should('be.visible')
+            cy.contains('candidate b1b61a5 completed 3/3 exact-byte TextEdit trials').should(
+                'be.visible'
+            )
+            cy.contains('Review exact Windows evidence')
+                .should('have.attr', 'href')
+                .and('include', 'defafbae758a75c8e149d9693f2cffe1f2264b8c')
+            cy.contains('Review scoped macOS evidence')
+                .should('have.attr', 'href')
+                .and('include', 'ca1b522cad215875f7471782283f8f8bb8e6c998')
             cy.contains('Research spike').should('not.exist')
             cy.contains('Product maturity').should('not.exist')
         })

--- a/tests/publicTruth.test.js
+++ b/tests/publicTruth.test.js
@@ -72,6 +72,8 @@ test('launch surfaces lead with capabilities instead of temporary gap labels', (
         'Partner qualification',
         'Design partner needed',
         'Reference lifecycle accepted',
+        'Scoped acceptance passed',
+        'Scoped TextEdit evidence accepted',
         'Acceptance in progress',
         'No ICA/HDX evidence',
     ]) {
@@ -81,6 +83,24 @@ test('launch surfaces lead with capabilities instead of temporary gap labels', (
     assert.match(product, /RDP evidence is not treated as Citrix evidence/)
     assert.match(product, /Evidence state/)
     assert.match(product, /not in the hosted browser launch candidate/)
+    assert.match(product, /20260717-candidate-56759c8-v2 in-tree WinForms matrix completed 3\/3 trials/)
+    assert.match(product, /independent SQLite oracle confirmed 3\/3 effects/)
+    assert.match(product, /stale-target and ambiguous-target controls each refused 3\/3/)
+    assert.match(product, /not arbitrary Windows applications or hosted desktop/)
+    assert.match(product, /preserves earlier rejected diagnostic runs/)
+    assert.match(product, /candidate b1b61a5 completed 3\/3 exact-byte TextEdit trials/)
+    assert.match(product, /immutable batch report remains failed/)
+    assert.match(product, /SHA-256-bound adjudication verified actual process and temporary-file cleanup/)
+    assert.match(product, /not clean-machine, design-partner, production, or broad macOS evidence/)
+    assert.match(product, /0 silent incorrect successes and 0 over-halts/)
+    assert.match(
+        product,
+        /blob\/defafbae758a75c8e149d9693f2cffe1f2264b8c\/benchmark\/windows_uia\/results\.json/
+    )
+    assert.match(
+        product,
+        /blob\/ca1b522cad215875f7471782283f8f8bb8e6c998\/benchmark\/macos_native\/textedit_counted_3plus1_b1b61a5_20260717\.adjudication\.json/
+    )
     assert.doesNotMatch(pricing, /Offer unavailable|Hosted checkout unavailable/)
     assert.match(pricing, /Start with our team/)
     assert.doesNotMatch(llms, /Product Maturity|launching now|not implied/i)


### PR DESCRIPTION
## What changed

- Publishes the scoped Windows UIA acceptance result: three counted WinForms trials, three independently confirmed SQLite effects, and three stale/ambiguity refusals with zero silent incorrect successes, over-halts, or model calls.
- Publishes the scoped native macOS result: three exact-byte TextEdit effects plus one two-window ambiguity refusal on one host.
- Links both rows to immutable, commit-pinned evidence.
- Keeps RDP at acceptance-in-progress and keeps Citrix at no ICA/HDX evidence.

## Why

The public substrate matrix still described Windows and macOS acceptance as in progress after the exact evidence and implementations merged into `openadapt-flow`. This refresh brings the site up to date without generalizing either result to arbitrary applications, hosted desktop, clean-machine native-app support, or production readiness.

The macOS row explicitly preserves the original batch's failed status and describes the narrower SHA-256-bound adjudication rather than rewriting that report.

## Validation

- `npm test` — 31 passed
- `npm run build` — production build passed
- Existing Cypress assertions were extended for the exact evidence and boundaries; no local GUI run was repeated for this publish-only change.

## Deferred by design

RDP wording remains pending until the exactly-three counted real-network trials and independent guest-file oracle complete. RDP evidence will not be presented as Citrix evidence.
