### PR TITLE
test(web): isolate hosted checkout gate environment

### DIFF
--- a/tests/hostedCheckoutQualification.test.js
+++ b/tests/hostedCheckoutQualification.test.js
@@ -6,8 +6,22 @@ const {
 } = require('../lib/hostedCheckoutQualification')
 
 test('checkout qualification is an explicit fail-closed launch gate', () => {
-    for (const value of [undefined, '', 'false', 'TRUE', '1', 'yes']) {
-        assert.equal(isHostedCheckoutQualified(value), false)
+    const original = process.env.HOSTED_CHECKOUT_QUALIFIED
+    delete process.env.HOSTED_CHECKOUT_QUALIFIED
+
+    try {
+        for (const value of [undefined, '', 'false', 'TRUE', '1', 'yes']) {
+            assert.equal(isHostedCheckoutQualified(value), false)
+        }
+        assert.equal(isHostedCheckoutQualified('true'), true)
+
+        process.env.HOSTED_CHECKOUT_QUALIFIED = 'true'
+        assert.equal(isHostedCheckoutQualified(), true)
+    } finally {
+        if (original === undefined) {
+            delete process.env.HOSTED_CHECKOUT_QUALIFIED
+        } else {
+            process.env.HOSTED_CHECKOUT_QUALIFIED = original
+        }
     }
-    assert.equal(isHostedCheckoutQualified('true'), true)
 })


### PR DESCRIPTION
## Summary
- isolate the hosted checkout qualification unit test from the deploy environment
- verify fail-closed values explicitly
- cover the enabled production environment path

## Verification
- `HOSTED_CHECKOUT_QUALIFIED=true npm test` (35/35)
- `npm run build`
- `git diff --check`

This unblocks production builds after enabling the approved live $500/month checkout gate.