### PR TITLE
fix(site): animate process stages over each reference app

### DIFF
--- a/components/HowItWorks.js
+++ b/components/HowItWorks.js
@@ -16,6 +16,23 @@ const referenceWorkflows = {
             'Recorded and replayed OpenEMR footage for a bounded healthcare browser workflow.',
         record: manifest.steps.record_openemr,
         replay: manifest.steps.run_openemr,
+        stageMedia: {
+            compile: {
+                src: '/how-it-works/record_openemr.gif',
+                alt: 'Live OpenEMR demonstration footage behind OpenAdapt’s animated compile view.',
+                sourceLabel: 'OpenEMR demonstration',
+            },
+            resolve: {
+                src: '/how-it-works/run_openemr.gif',
+                alt: 'Live OpenEMR replay footage behind OpenAdapt’s animated target-resolution view.',
+                sourceLabel: 'OpenEMR replay',
+            },
+            verify: {
+                src: '/how-it-works/run_openemr.gif',
+                alt: 'Live OpenEMR replay footage behind OpenAdapt’s animated audit-contract view.',
+                sourceLabel: 'OpenEMR replay',
+            },
+        },
         compile: {
             workflow: 'openemr-browser-reference',
             parameters: 'workflow-defined inputs',
@@ -66,6 +83,23 @@ const referenceWorkflows = {
             alt: 'OpenAdapt deterministically replaying the compiled synthetic loan application workflow in Frappe Lending.',
             caption:
                 'Replay — Frappe Lending reference · model-free and independently checked',
+        },
+        stageMedia: {
+            compile: {
+                src: '/lending-demo/record-frappe.gif',
+                alt: 'Frappe Lending demonstration footage behind OpenAdapt’s animated compile view.',
+                sourceLabel: 'Frappe Lending demonstration',
+            },
+            resolve: {
+                src: '/lending-demo/replay-frappe.gif',
+                alt: 'Frappe Lending replay footage behind OpenAdapt’s animated target-resolution view.',
+                sourceLabel: 'Frappe Lending replay',
+            },
+            verify: {
+                src: '/lending-demo/replay-frappe.gif',
+                alt: 'Frappe Lending replay footage behind OpenAdapt’s animated verified-effect audit view.',
+                sourceLabel: 'Frappe Lending replay',
+            },
         },
         compile: {
             workflow: 'create-loan-application',
@@ -121,6 +155,23 @@ const referenceWorkflows = {
             alt: 'OpenAdapt deterministically replaying the compiled claims-intake workflow in openIMIS with a fresh claim number.',
             caption:
                 'Replay — openIMIS claims reference · model-free and independently checked',
+        },
+        stageMedia: {
+            compile: {
+                src: '/insurance-demo/record-openimis.gif',
+                alt: 'openIMIS claim-entry demonstration footage behind OpenAdapt’s animated compile view.',
+                sourceLabel: 'openIMIS demonstration',
+            },
+            resolve: {
+                src: '/insurance-demo/replay-openimis.gif',
+                alt: 'openIMIS claim-entry replay footage behind OpenAdapt’s animated target-resolution view.',
+                sourceLabel: 'openIMIS replay',
+            },
+            verify: {
+                src: '/insurance-demo/replay-openimis.gif',
+                alt: 'openIMIS claim-entry replay footage behind OpenAdapt’s animated verified-effect audit view.',
+                sourceLabel: 'openIMIS replay',
+            },
         },
         compile: {
             workflow: 'openimis-claim-intake',
@@ -242,10 +293,10 @@ export default function HowItWorks({ showUseCases = false }) {
                             </Link>
                         </div>
                         <p className={styles.visualScopeNote}>
-                            Record and Replay are real reference footage. Compile,
-                            Resolve or halt, and Verify are crafted, app-labelled
-                            contract views; they do not claim unrecorded
-                            application footage.
+                            Every stage uses the selected reference application.
+                            Compile, Resolve or halt, and Verify layer animated
+                            OpenAdapt contract views over that application’s real
+                            demonstration or replay footage.
                         </p>
                     </div>
                 )}

--- a/components/ReferenceStagePanel.js
+++ b/components/ReferenceStagePanel.js
@@ -1,11 +1,20 @@
 import styles from './ReferenceStagePanel.module.css'
 
+const stageLabels = {
+    compile: 'compile',
+    resolve: 'resolve or halt',
+    verify: 'audit',
+}
+
 function PanelFrame({ reference, stage, badge, children, caption }) {
+    const media = reference.stageMedia[stage]
+
     return (
         <figure
             className={styles.figure}
             data-testid={`reference-${stage}-panel`}
             data-reference={reference.key}
+            data-stage-source={media.src}
         >
             <div className={styles.titlebar}>
                 <span className={styles.dots} aria-hidden="true">
@@ -16,8 +25,28 @@ function PanelFrame({ reference, stage, badge, children, caption }) {
                 <span className={styles.system}>{reference.system}</span>
                 <span className={styles.badge}>{badge}</span>
             </div>
-            <div className={styles.content}>{children}</div>
-            <figcaption className={styles.caption}>{caption}</figcaption>
+            <div className={styles.scene}>
+                <img
+                    className={styles.application}
+                    src={media.src}
+                    alt={media.alt}
+                    width="880"
+                    height="550"
+                    loading="lazy"
+                    decoding="async"
+                />
+                <span className={styles.sourceChip}>
+                    <i aria-hidden="true" />
+                    {media.sourceLabel}
+                </span>
+                <div className={styles.stageOverlay}>{children}</div>
+            </div>
+            <figcaption className={styles.caption}>
+                <strong>
+                    {stageLabels[stage]} — {media.sourceLabel}
+                </strong>
+                <span>{caption}</span>
+            </figcaption>
         </figure>
     )
 }
@@ -29,35 +58,36 @@ function CompilePanel({ reference }) {
         <PanelFrame
             reference={reference}
             stage="compile"
-            badge="contract"
-            caption={`Crafted contract view for ${reference.system}. It illustrates the compiled structure; it is not captured application output.`}
+            badge="compiling"
+            caption="Selected-app footage with an animated view of the inspectable workflow OpenAdapt produces."
         >
-            <div className={styles.panelHeading}>
-                <span>workflow.json</span>
-                <strong>inspectable</strong>
+            <div className={`${styles.glassCard} ${styles.compileCard}`}>
+                <div className={styles.panelHeading}>
+                    <span>workflow.json</span>
+                    <strong>inspectable</strong>
+                </div>
+                <dl className={styles.contract}>
+                    <div>
+                        <dt>workflow</dt>
+                        <dd>{contract.workflow}</dd>
+                    </div>
+                    <div>
+                        <dt>parameters</dt>
+                        <dd>{contract.parameters}</dd>
+                    </div>
+                    <div>
+                        <dt>target</dt>
+                        <dd>{contract.target}</dd>
+                    </div>
+                    <div>
+                        <dt>effect</dt>
+                        <dd>{contract.effect}</dd>
+                    </div>
+                </dl>
+                <div className={styles.compileProgress} aria-hidden="true">
+                    <i />
+                </div>
             </div>
-            <dl className={styles.contract}>
-                <div>
-                    <dt>workflow</dt>
-                    <dd>{contract.workflow}</dd>
-                </div>
-                <div>
-                    <dt>parameters</dt>
-                    <dd>{contract.parameters}</dd>
-                </div>
-                <div>
-                    <dt>target</dt>
-                    <dd>{contract.target}</dd>
-                </div>
-                <div>
-                    <dt>declared effect</dt>
-                    <dd>{contract.effect}</dd>
-                </div>
-                <div>
-                    <dt>healthy replay</dt>
-                    <dd>deterministic · local · zero model calls</dd>
-                </div>
-            </dl>
         </PanelFrame>
     )
 }
@@ -67,24 +97,32 @@ function ResolvePanel({ reference }) {
         <PanelFrame
             reference={reference}
             stage="resolve"
-            badge="policy"
-            caption={`Crafted governed-resolution policy for ${reference.system}. No application-specific drift trial is claimed.`}
+            badge="resolving"
+            caption="Selected-app replay footage with the target-evidence ladder and explicit halt path animated in context."
         >
-            <div className={styles.panelHeading}>
-                <span>target resolution</span>
-                <strong>fail closed</strong>
-            </div>
-            <ol className={styles.ladder}>
-                {reference.resolve.evidence.map((item, index) => (
-                    <li key={item}>
-                        <span>{String(index + 1).padStart(2, '0')}</span>
-                        <strong>{item}</strong>
-                    </li>
-                ))}
-            </ol>
-            <div className={styles.haltRule}>
-                <span>ambiguous or unverifiable</span>
-                <strong>HALT · propose reviewable repair</strong>
+            <span className={styles.targetMarker} aria-hidden="true">
+                <i />
+            </span>
+            <div className={`${styles.glassCard} ${styles.resolveCard}`}>
+                <div className={styles.panelHeading}>
+                    <span>target evidence</span>
+                    <strong>unique match required</strong>
+                </div>
+                <ol className={styles.ladder}>
+                    {reference.resolve.evidence.map((item, index) => (
+                        <li
+                            key={item}
+                            style={{ '--evidence-index': index }}
+                        >
+                            <span>{String(index + 1).padStart(2, '0')}</span>
+                            <strong>{item}</strong>
+                        </li>
+                    ))}
+                </ol>
+                <div className={styles.haltRule}>
+                    <span>ambiguous or unverifiable</span>
+                    <strong>HALT · REVIEW</strong>
+                </div>
             </div>
         </PanelFrame>
     )
@@ -100,34 +138,39 @@ function VerifyPanel({ reference }) {
             badge={verification.badge}
             caption={verification.caption}
         >
-            <div className={styles.panelHeading}>
-                <span>independent effect evidence</span>
-                <strong>{verification.status}</strong>
-            </div>
-            <ul className={styles.checks}>
-                {verification.checks.map(([label, value]) => (
-                    <li key={label}>
-                        <span
-                            className={
-                                verification.qualified
-                                    ? styles.check
-                                    : styles.pending
-                            }
-                            aria-hidden="true"
+            <div className={`${styles.glassCard} ${styles.verifyCard}`}>
+                <div className={styles.panelHeading}>
+                    <span>run audit</span>
+                    <strong>{verification.status}</strong>
+                </div>
+                <ul className={styles.checks}>
+                    {verification.checks.map(([label, value], index) => (
+                        <li
+                            key={label}
+                            style={{ '--check-index': index }}
                         >
-                            {verification.qualified ? '✓' : '—'}
-                        </span>
-                        <span>
-                            <strong>{label}</strong>
-                            <small>{value}</small>
-                        </span>
-                    </li>
-                ))}
-            </ul>
-            <div className={styles.metrics}>
-                {verification.metrics.map((metric) => (
-                    <span key={metric}>{metric}</span>
-                ))}
+                            <span
+                                className={
+                                    verification.qualified
+                                        ? styles.check
+                                        : styles.pending
+                                }
+                                aria-hidden="true"
+                            >
+                                {verification.qualified ? '✓' : '—'}
+                            </span>
+                            <span>
+                                <strong>{label}</strong>
+                                <small>{value}</small>
+                            </span>
+                        </li>
+                    ))}
+                </ul>
+                <div className={styles.metrics}>
+                    {verification.metrics.map((metric) => (
+                        <span key={metric}>{metric}</span>
+                    ))}
+                </div>
             </div>
         </PanelFrame>
     )

--- a/components/ReferenceStagePanel.module.css
+++ b/components/ReferenceStagePanel.module.css
@@ -45,9 +45,9 @@
 
 .badge {
     padding: 2px 7px;
-    border: 1px solid color-mix(in srgb, var(--accent) 35%, transparent);
+    border: 1px solid color-mix(in srgb, var(--accent) 38%, transparent);
     border-radius: 999px;
-    background: color-mix(in srgb, var(--accent) 8%, transparent);
+    background: color-mix(in srgb, var(--accent) 10%, var(--ground));
     color: var(--accent);
     font-family: var(--font-mono);
     font-size: 9px;
@@ -55,46 +55,141 @@
     text-transform: uppercase;
 }
 
-.content {
+.scene {
+    position: relative;
+    aspect-ratio: 880 / 550;
     min-height: 244px;
-    padding: 15px 16px 14px;
+    overflow: hidden;
+    background: var(--ground);
+}
+
+.application {
+    position: absolute;
+    inset: 0;
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.scene::after {
+    position: absolute;
+    z-index: 1;
+    inset: 0;
+    background:
+        linear-gradient(90deg, rgba(8, 15, 31, 0.12), rgba(8, 15, 31, 0.02)),
+        linear-gradient(0deg, rgba(8, 15, 31, 0.28), transparent 48%);
+    content: '';
+    pointer-events: none;
+}
+
+.sourceChip {
+    position: absolute;
+    z-index: 3;
+    top: 10px;
+    left: 10px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    max-width: calc(100% - 20px);
+    padding: 5px 8px;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.32);
+    border-radius: 999px;
+    background: rgba(8, 15, 31, 0.74);
+    color: #fff;
+    font-family: var(--font-mono);
+    font-size: 8px;
+    letter-spacing: 0.04em;
+    text-overflow: ellipsis;
+    text-transform: uppercase;
+    white-space: nowrap;
+    backdrop-filter: blur(7px);
+}
+
+.sourceChip i {
+    display: block;
+    width: 6px;
+    height: 6px;
+    flex: 0 0 auto;
+    border-radius: 50%;
+    background: #59e194;
+    box-shadow: 0 0 0 0 rgba(89, 225, 148, 0.7);
+    animation: livePulse 1.8s ease-out infinite;
+}
+
+.stageOverlay {
+    position: absolute;
+    z-index: 2;
+    inset: 0;
+    pointer-events: none;
+}
+
+.glassCard {
+    position: absolute;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.34);
+    border-radius: 8px;
+    background: rgba(8, 15, 31, 0.88);
+    box-shadow: 0 14px 30px rgba(2, 8, 23, 0.3);
+    color: #fff;
+    backdrop-filter: blur(9px);
+}
+
+.compileCard {
+    right: 12px;
+    bottom: 12px;
+    width: min(76%, 350px);
+    padding: 10px 11px 9px;
+    animation: cardEnter 6s ease-in-out infinite;
 }
 
 .panelHeading {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 12px;
-    padding-bottom: 11px;
-    border-bottom: 1px solid var(--hairline);
-    color: var(--ink-3);
+    gap: 9px;
+    padding-bottom: 7px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.18);
+    color: rgba(255, 255, 255, 0.7);
     font-family: var(--font-mono);
-    font-size: 10px;
+    font-size: 8px;
     letter-spacing: 0.05em;
     text-transform: uppercase;
 }
 
 .panelHeading strong {
-    color: var(--accent);
-    font-size: 9px;
+    color: #7ee3a8;
+    font-size: 7px;
     text-align: right;
 }
 
 .contract {
     display: grid;
-    margin: 7px 0 0;
+    margin: 5px 0 0;
 }
 
 .contract div {
     display: grid;
-    grid-template-columns: minmax(88px, 0.65fr) minmax(0, 1.5fr);
-    gap: 10px;
-    padding: 7px 0;
-    border-bottom: 1px solid var(--hairline);
+    grid-template-columns: minmax(62px, 0.52fr) minmax(0, 1.55fr);
+    gap: 7px;
+    padding: 4px 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    opacity: 0;
+    animation: lineReveal 6s ease-out infinite;
 }
 
-.contract div:last-child {
+.contract div:nth-child(2) {
+    animation-delay: 0.18s;
+}
+
+.contract div:nth-child(3) {
+    animation-delay: 0.36s;
+}
+
+.contract div:nth-child(4) {
     border-bottom: 0;
+    animation-delay: 0.54s;
 }
 
 .contract dt,
@@ -102,92 +197,181 @@
     min-width: 0;
     margin: 0;
     font-family: var(--font-mono);
-    font-size: 10px;
-    line-height: 1.45;
+    font-size: 7px;
+    line-height: 1.35;
 }
 
 .contract dt {
-    color: var(--ink-3);
+    color: rgba(255, 255, 255, 0.56);
 }
 
 .contract dd {
-    color: var(--ink);
+    color: #fff;
     overflow-wrap: anywhere;
+}
+
+.compileProgress {
+    height: 2px;
+    margin-top: 5px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.14);
+}
+
+.compileProgress i {
+    display: block;
+    width: 100%;
+    height: 100%;
+    border-radius: inherit;
+    background: #59e194;
+    transform-origin: left;
+    animation: compileProgress 6s ease-in-out infinite;
+}
+
+.resolveCard {
+    right: 10px;
+    bottom: 10px;
+    width: min(72%, 326px);
+    padding: 9px 10px;
+}
+
+.targetMarker {
+    position: absolute;
+    top: 27%;
+    left: 19%;
+    width: 34%;
+    height: 19%;
+    border: 2px solid #59e194;
+    border-radius: 4px;
+    box-shadow: 0 0 0 999px rgba(8, 15, 31, 0.13);
+    animation: targetResolve 5.4s ease-in-out infinite;
+}
+
+.targetMarker::before,
+.targetMarker::after,
+.targetMarker i::before,
+.targetMarker i::after {
+    position: absolute;
+    width: 7px;
+    height: 7px;
+    border-color: #fff;
+    content: '';
+}
+
+.targetMarker::before {
+    top: -3px;
+    left: -3px;
+    border-top: 2px solid;
+    border-left: 2px solid;
+}
+
+.targetMarker::after {
+    top: -3px;
+    right: -3px;
+    border-top: 2px solid;
+    border-right: 2px solid;
+}
+
+.targetMarker i::before {
+    bottom: -3px;
+    left: -3px;
+    border-bottom: 2px solid;
+    border-left: 2px solid;
+}
+
+.targetMarker i::after {
+    right: -3px;
+    bottom: -3px;
+    border-right: 2px solid;
+    border-bottom: 2px solid;
 }
 
 .ladder {
     display: grid;
-    gap: 7px;
-    margin: 13px 0 0;
+    gap: 4px;
+    margin: 7px 0 0;
     padding: 0;
     list-style: none;
 }
 
 .ladder li {
     display: grid;
-    grid-template-columns: 28px minmax(0, 1fr);
+    grid-template-columns: 20px minmax(0, 1fr);
     align-items: center;
-    gap: 9px;
-    padding: 8px 10px;
-    border: 1px solid var(--hairline);
-    border-radius: 7px;
-    background: var(--ground);
+    gap: 6px;
+    padding: 5px 6px;
+    border: 1px solid rgba(255, 255, 255, 0.13);
+    border-radius: 5px;
+    background: rgba(255, 255, 255, 0.06);
+    opacity: 0;
+    animation: evidenceResolve 5.4s ease-in-out infinite;
+    animation-delay: calc(var(--evidence-index) * 0.28s);
 }
 
 .ladder li span {
-    color: var(--accent);
+    color: #7ee3a8;
     font-family: var(--font-mono);
-    font-size: 9px;
+    font-size: 7px;
 }
 
 .ladder li strong {
-    color: var(--ink-2);
-    font-size: 11px;
+    color: #fff;
+    font-size: 8px;
     font-weight: 500;
-    line-height: 1.35;
+    line-height: 1.25;
 }
 
 .haltRule {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 10px;
-    margin-top: 9px;
-    padding: 8px 10px;
-    border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--hairline));
-    border-radius: 7px;
-    background: color-mix(in srgb, var(--accent) 7%, var(--ground));
+    gap: 7px;
+    margin-top: 5px;
+    padding: 5px 6px;
+    border: 1px solid rgba(255, 193, 7, 0.48);
+    border-radius: 5px;
+    background: rgba(255, 193, 7, 0.1);
     font-family: var(--font-mono);
-    font-size: 9px;
-    line-height: 1.4;
+    font-size: 7px;
+    line-height: 1.3;
 }
 
 .haltRule span {
-    color: var(--ink-3);
+    color: rgba(255, 255, 255, 0.72);
 }
 
 .haltRule strong {
-    color: var(--accent);
+    color: #ffd979;
     text-align: right;
+}
+
+.verifyCard {
+    right: 10px;
+    bottom: 10px;
+    left: 10px;
+    padding: 9px 10px;
 }
 
 .checks {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 8px;
-    margin: 13px 0 0;
+    gap: 5px;
+    margin: 7px 0 0;
     padding: 0;
     list-style: none;
 }
 
 .checks li {
     display: flex;
-    gap: 8px;
+    gap: 6px;
     min-width: 0;
-    padding: 9px;
-    border: 1px solid var(--hairline);
-    border-radius: 7px;
-    background: var(--ground);
+    padding: 6px;
+    border: 1px solid rgba(255, 255, 255, 0.13);
+    border-radius: 5px;
+    background: rgba(255, 255, 255, 0.06);
+    opacity: 0;
+    animation: checkReveal 5.8s ease-out infinite;
+    animation-delay: calc(var(--check-index) * 0.3s);
 }
 
 .check,
@@ -197,78 +381,204 @@
 }
 
 .check {
-    color: var(--accent);
+    color: #7ee3a8;
 }
 
 .pending {
-    color: var(--ink-3);
+    color: rgba(255, 255, 255, 0.6);
 }
 
 .checks strong,
 .checks small {
     display: block;
     overflow-wrap: anywhere;
-    line-height: 1.35;
+    line-height: 1.25;
 }
 
 .checks strong {
-    color: var(--ink);
-    font-size: 11px;
+    color: #fff;
+    font-size: 8px;
 }
 
 .checks small {
-    margin-top: 2px;
-    color: var(--ink-3);
+    margin-top: 1px;
+    color: rgba(255, 255, 255, 0.62);
     font-family: var(--font-mono);
-    font-size: 9px;
+    font-size: 7px;
 }
 
 .metrics {
     display: flex;
     flex-wrap: wrap;
-    gap: 5px;
-    margin-top: 10px;
+    gap: 4px;
+    margin-top: 6px;
 }
 
 .metrics span {
-    padding: 4px 6px;
-    border-radius: 5px;
-    background: color-mix(in srgb, var(--accent) 8%, var(--ground));
-    color: var(--ink-2);
+    padding: 3px 5px;
+    border-radius: 4px;
+    background: rgba(89, 225, 148, 0.12);
+    color: #b3f5ce;
     font-family: var(--font-mono);
-    font-size: 8px;
-    line-height: 1.35;
+    font-size: 6px;
+    line-height: 1.3;
 }
 
 .caption {
     display: block;
     min-height: 48px;
     margin: 0;
-    padding: 9px 12px;
+    padding: 8px 11px;
     border-top: 1px solid var(--hairline);
     color: var(--ink-3);
     font-family: var(--font-mono);
-    font-size: 10px;
+    font-size: 9px;
     line-height: 1.45;
 }
 
+.caption strong,
+.caption span {
+    display: block;
+}
+
+.caption strong {
+    margin-bottom: 2px;
+    color: var(--ink-2);
+    font-size: 9px;
+    text-transform: capitalize;
+}
+
+@keyframes livePulse {
+    0% {
+        box-shadow: 0 0 0 0 rgba(89, 225, 148, 0.7);
+    }
+    70%,
+    100% {
+        box-shadow: 0 0 0 6px rgba(89, 225, 148, 0);
+    }
+}
+
+@keyframes cardEnter {
+    0%,
+    7% {
+        opacity: 0.35;
+        transform: translateY(12px);
+    }
+    16%,
+    88% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    100% {
+        opacity: 0.35;
+        transform: translateY(12px);
+    }
+}
+
+@keyframes lineReveal {
+    0%,
+    8% {
+        opacity: 0;
+        transform: translateX(8px);
+    }
+    18%,
+    88% {
+        opacity: 1;
+        transform: translateX(0);
+    }
+    100% {
+        opacity: 0;
+        transform: translateX(8px);
+    }
+}
+
+@keyframes compileProgress {
+    0% {
+        transform: scaleX(0);
+    }
+    52%,
+    88% {
+        transform: scaleX(1);
+    }
+    100% {
+        transform: scaleX(0);
+    }
+}
+
+@keyframes targetResolve {
+    0%,
+    12% {
+        opacity: 0;
+        transform: scale(1.18);
+    }
+    25%,
+    78% {
+        opacity: 1;
+        transform: scale(1);
+    }
+    92%,
+    100% {
+        opacity: 0;
+        transform: scale(0.96);
+    }
+}
+
+@keyframes evidenceResolve {
+    0%,
+    10% {
+        opacity: 0;
+        transform: translateX(7px);
+    }
+    24%,
+    82% {
+        opacity: 1;
+        transform: translateX(0);
+    }
+    100% {
+        opacity: 0;
+        transform: translateX(7px);
+    }
+}
+
+@keyframes checkReveal {
+    0%,
+    8% {
+        opacity: 0;
+        transform: translateY(6px);
+    }
+    22%,
+    86% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    100% {
+        opacity: 0;
+        transform: translateY(6px);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .sourceChip i,
+    .compileCard,
+    .contract div,
+    .compileProgress i,
+    .targetMarker,
+    .ladder li,
+    .checks li {
+        animation: none;
+        opacity: 1;
+        transform: none;
+    }
+}
+
 @media (max-width: 640px) {
-    .content {
-        min-height: 0;
-        padding: 13px 12px;
+    .scene {
+        min-height: 230px;
     }
 
-    .checks {
-        grid-template-columns: 1fr;
-    }
-
-    .haltRule {
-        align-items: flex-start;
-        flex-direction: column;
-    }
-
-    .haltRule strong {
-        text-align: left;
+    .compileCard,
+    .resolveCard {
+        width: calc(100% - 20px);
     }
 
     .caption {

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -226,7 +226,7 @@ describe('public product truth', () => {
         cy.get('#how-it-works').within(() => {
             cy.contains('button', 'Healthcare')
                 .should('have.attr', 'aria-pressed', 'true')
-            cy.get('img[alt*="OpenEMR"]').should('have.length', 2)
+            cy.get('img[alt*="OpenEMR"]').should('have.length', 5)
             cy.get('[data-testid^="reference-"]')
                 .should('have.length', 3)
                 .each(($panel) => {
@@ -239,14 +239,32 @@ describe('public product truth', () => {
             cy.get('[data-testid="reference-compile-panel"]')
                 .should('contain.text', 'OpenEMR browser reference')
                 .and('contain.text', 'deployment-specific oracle required')
+                .and(
+                    'have.attr',
+                    'data-stage-source',
+                    '/how-it-works/record_openemr.gif'
+                )
+                .find('img')
+                .should('have.attr', 'src', '/how-it-works/record_openemr.gif')
             cy.get('[data-testid="reference-resolve-panel"]')
                 .should('contain.text', 'OpenEMR browser reference')
-                .and('contain.text', 'No application-specific drift trial is claimed')
+                .and(
+                    'have.attr',
+                    'data-stage-source',
+                    '/how-it-works/run_openemr.gif'
+                )
+                .find('img')
+                .should('have.attr', 'src', '/how-it-works/run_openemr.gif')
             cy.get('[data-testid="reference-verify-panel"]')
                 .should('contain.text', 'qualification required')
                 .and('contain.text', 'No application-specific audit result claimed')
-            cy.get('img[src^="/how-it-works/compile"], img[src^="/how-it-works/heal"], img[src^="/how-it-works/audit"]')
-                .should('not.exist')
+                .and(
+                    'have.attr',
+                    'data-stage-source',
+                    '/how-it-works/run_openemr.gif'
+                )
+                .find('img')
+                .should('have.attr', 'src', '/how-it-works/run_openemr.gif')
 
             cy.contains('button', 'Lending').click()
             cy.contains('button', 'Lending')
@@ -268,11 +286,32 @@ describe('public product truth', () => {
             cy.get('[data-testid="reference-compile-panel"]')
                 .should('contain.text', 'Frappe Lending reference')
                 .and('contain.text', 'create-loan-application')
+                .and(
+                    'have.attr',
+                    'data-stage-source',
+                    '/lending-demo/record-frappe.gif'
+                )
+                .find('img')
+                .should('have.attr', 'src', '/lending-demo/record-frappe.gif')
             cy.get('[data-testid="reference-resolve-panel"]')
                 .should('contain.text', 'Frappe Loan Application evidence')
+                .and(
+                    'have.attr',
+                    'data-stage-source',
+                    '/lending-demo/replay-frappe.gif'
+                )
+                .find('img')
+                .should('have.attr', 'src', '/lending-demo/replay-frappe.gif')
             cy.get('[data-testid="reference-verify-panel"]')
                 .should('contain.text', '6 / 6 verified')
                 .and('contain.text', '0 silent incorrect successes')
+                .and(
+                    'have.attr',
+                    'data-stage-source',
+                    '/lending-demo/replay-frappe.gif'
+                )
+                .find('img')
+                .should('have.attr', 'src', '/lending-demo/replay-frappe.gif')
 
             cy.contains('button', 'Insurance').click()
             cy.contains('button', 'Insurance')
@@ -294,11 +333,44 @@ describe('public product truth', () => {
             cy.get('[data-testid="reference-compile-panel"]')
                 .should('contain.text', 'openIMIS claims reference')
                 .and('contain.text', 'openimis-claim-intake')
+                .and(
+                    'have.attr',
+                    'data-stage-source',
+                    '/insurance-demo/record-openimis.gif'
+                )
+                .find('img')
+                .should(
+                    'have.attr',
+                    'src',
+                    '/insurance-demo/record-openimis.gif'
+                )
             cy.get('[data-testid="reference-resolve-panel"]')
                 .should('contain.text', 'openIMIS claim-form evidence')
+                .and(
+                    'have.attr',
+                    'data-stage-source',
+                    '/insurance-demo/replay-openimis.gif'
+                )
+                .find('img')
+                .should(
+                    'have.attr',
+                    'src',
+                    '/insurance-demo/replay-openimis.gif'
+                )
             cy.get('[data-testid="reference-verify-panel"]')
                 .should('contain.text', '3 / 3 verified')
                 .and('contain.text', '0 duplicate claims')
+                .and(
+                    'have.attr',
+                    'data-stage-source',
+                    '/insurance-demo/replay-openimis.gif'
+                )
+                .find('img')
+                .should(
+                    'have.attr',
+                    'src',
+                    '/insurance-demo/replay-openimis.gif'
+                )
             cy.contains('View the bounded use case')
                 .should('have.attr', 'href')
                 .and('equal', '/solutions/insurance')

--- a/tests/howItWorksIndustryPanels.test.js
+++ b/tests/howItWorksIndustryPanels.test.js
@@ -10,6 +10,7 @@ const read = (relativePath) =>
 test('every homepage process visual follows the selected real reference app', () => {
     const howItWorks = read('components/HowItWorks.js')
     const panels = read('components/ReferenceStagePanel.js')
+    const panelStyles = read('components/ReferenceStagePanel.module.css')
 
     assert.match(howItWorks, /import ReferenceStagePanel/)
     for (const key of ['healthcare', 'lending', 'insurance']) {
@@ -23,12 +24,43 @@ test('every homepage process visual follows the selected real reference app', ()
     assert.doesNotMatch(howItWorks, /manifest\.steps\.(compile|heal|audit)/)
     assert.doesNotMatch(howItWorks, /MockMed|shared engine lifecycle/)
 
+    const selectedAppSources = {
+        healthcare: [
+            '/how-it-works/record_openemr.gif',
+            '/how-it-works/run_openemr.gif',
+        ],
+        lending: [
+            '/lending-demo/record-frappe.gif',
+            '/lending-demo/replay-frappe.gif',
+        ],
+        insurance: [
+            '/insurance-demo/record-openimis.gif',
+            '/insurance-demo/replay-openimis.gif',
+        ],
+    }
+    for (const sources of Object.values(selectedAppSources)) {
+        for (const source of sources) {
+            assert.match(howItWorks, new RegExp(source.replaceAll('/', '\\/')))
+        }
+    }
+    assert.equal(
+        new Set(Object.values(selectedAppSources).flat()).size,
+        6,
+        'each reference app must use its own media sources'
+    )
+
     for (const stage of ['compile', 'resolve', 'verify']) {
         assert.match(panels, new RegExp(`stage="${stage}"`))
     }
     assert.match(panels, /data-reference=\{reference\.key\}/)
-    assert.match(panels, /not captured application output/)
-    assert.match(panels, /No application-specific drift trial is claimed/)
+    assert.match(panels, /data-stage-source=\{media\.src\}/)
+    assert.match(panels, /src=\{media\.src\}/)
+    assert.match(panels, /className=\{styles\.application\}/)
+    assert.match(panels, /OpenAdapt produces/)
+    assert.doesNotMatch(panels, /MockMed/)
+    assert.match(panelStyles, /animation: cardEnter/)
+    assert.match(panelStyles, /animation: targetResolve/)
+    assert.match(panelStyles, /animation: checkReveal/)
 })
 
 test('industry panels distinguish bounded evidence from required qualification', () => {
@@ -46,7 +78,7 @@ test('industry panels distinguish bounded evidence from required qualification',
     assert.match(howItWorks, /0 duplicate claims/)
     assert.match(
         howItWorks,
-        /do not claim unrecorded\s+application footage/
+        /Every stage uses the selected reference application/
     )
 })
 


### PR DESCRIPTION
## What changed

- Renders Compile over the selected app's demonstration GIF.
- Renders Resolve or halt over the selected app's replay GIF with an animated
  target/evidence ladder and explicit halt state.
- Renders Audit/Verify over the selected app's replay GIF with animated
  verification receipts.
- Switches all five homepage process visuals between OpenEMR, Frappe Lending,
  and openIMIS.
- Retains source-aware captions so the overlays are not presented as newly
  captured stage-specific footage.
- Adds unit and Cypress assertions for the distinct app source used by every
  stage.

## Why

The three crafted stages changed their labels when the industry selector changed
but remained generic enough to read as the old MockMed visuals. The actual
reference application now remains visible throughout the whole five-stage
story.

## Impact

Selecting Healthcare, Lending, or Insurance now changes the underlying
application footage in Record, Compile, Replay, Resolve or halt, and
Audit/Verify. GIFs are rendered directly as images, so they autoplay under the
same browser behavior as the existing Record and Replay stages.

## Validation

- `npm test` — 38/38 passed.
- `npm run build` — production build passed using the existing workspace
  dependency installation.
- Headless Cypress `basic.cy.js` — 13/14 passed; every homepage industry-stage
  assertion passed. The sole failure is the already-known stale
  comparison-copy assertion on current `main` (`browser workflows` versus the
  current `GUI workflows`), tracked independently in #197.
- `git diff --check` — passed.

## Media tradeoff

There is real selected-app footage for demonstration and compiled replay, but
no separate raw capture for the Compile, Resolve, and Audit UI themselves.
Those stages therefore use animated OpenAdapt overlays on the selected app's
real demonstration/replay footage rather than claiming newly recorded
stage-specific app footage. No MockMed asset is used by these selector panels.
