### PR TITLE
feat(analytics): env-gated GA4 + Meta Pixel with UTM-attributed conversion events (E1 measurement)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,22 @@ NEXT_PUBLIC_POSTHOG_KEY=
 # PostHog API host (default: https://us.i.posthog.com; use https://eu.i.posthog.com for EU)
 NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 
+# --- Paid-acquisition measurement (E1) --------------------------------------
+# Both are publishable client-side ids, not secrets, and both are hard
+# no-ops when unset: no script loads, nothing renders. Only set them on
+# deploys that are actively running a paid-traffic test. See
+# docs/ANALYTICS.md ("Paid-acquisition measurement").
+
+# GA4 measurement id (Admin -> Data streams -> Web), e.g. G-XXXXXXXXXX.
+# Enables GA4 pageviews + generate_lead / book_call_click conversions and
+# the native GA4 -> BigQuery export used for lead reporting.
+NEXT_PUBLIC_GA_MEASUREMENT_ID=
+
+# Meta Pixel id (Meta Events Manager). Enables the pixel (PageView +
+# Lead / Contact / Schedule) ONLY while a Meta campaign is live. Never set
+# this on a surface that could receive PHI-adjacent traffic.
+NEXT_PUBLIC_META_PIXEL_ID=
+
 # --- OpenAdapt Hosted - Stripe Checkout -------------------------------------
 # The website creates Checkout Sessions. OpenAdapt Cloud retrieves and claims
 # those Sessions and owns the signed Stripe webhook and subscription state.

--- a/components/BookingEmbed.js
+++ b/components/BookingEmbed.js
@@ -1,10 +1,31 @@
 import Link from 'next/link'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 
 import {
     buildBookingUrlWithPrefill,
     getBookingConfig,
 } from 'utils/booking'
+import { trackBookingClick, trackBookingConfirmed } from 'utils/conversion'
+
+/**
+ * Best-effort "booked call" detection: the Cal.com iframe posts messages to
+ * the parent page when a booking completes. Formats vary across embed
+ * versions, so match on origin + the event name appearing anywhere in the
+ * payload, and treat this as a soft signal (the booking itself is the
+ * source of truth in Cal.com).
+ */
+function isCalBookingSuccess(event) {
+    try {
+        if (!event?.origin || !event.origin.includes('cal.com')) return false
+        const raw =
+            typeof event.data === 'string'
+                ? event.data
+                : JSON.stringify(event.data)
+        return typeof raw === 'string' && raw.includes('bookingSuccessful')
+    } catch (err) {
+        return false
+    }
+}
 
 export default function BookingEmbed({ name = '', email = '' }) {
     const { bookingUrl, provider } = useMemo(() => {
@@ -18,6 +39,18 @@ export default function BookingEmbed({ name = '', email = '' }) {
         () => buildBookingUrlWithPrefill(bookingUrl, { name, email }),
         [bookingUrl, name, email]
     )
+
+    // E1 qualified-lead conversion: a completed Cal.com booking.
+    useEffect(() => {
+        if (!bookingUrl || provider !== 'calcom') return undefined
+        const handleMessage = (event) => {
+            if (isCalBookingSuccess(event)) {
+                trackBookingConfirmed({ location: 'booking_embed' })
+            }
+        }
+        window.addEventListener('message', handleMessage)
+        return () => window.removeEventListener('message', handleMessage)
+    }, [bookingUrl, provider])
 
     if (!bookingUrl) {
         return (
@@ -57,6 +90,11 @@ export default function BookingEmbed({ name = '', email = '' }) {
                         target="_blank"
                         rel="noopener noreferrer"
                         className="btn-ink"
+                        onClick={() =>
+                            trackBookingClick({
+                                location: 'booking_embed_fallback',
+                            })
+                        }
                     >
                         Open Booking Link
                     </a>
@@ -88,6 +126,11 @@ export default function BookingEmbed({ name = '', email = '' }) {
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-accent underline hover:text-ink"
+                    onClick={() =>
+                        trackBookingClick({
+                            location: 'booking_embed_direct_link',
+                        })
+                    }
                 >
                     this direct booking link
                 </a>

--- a/components/ContactBookingSection.js
+++ b/components/ContactBookingSection.js
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import Link from 'next/link'
 
 import BookingEmbed from '@components/BookingEmbed'
+import { trackEmailCapture } from 'utils/conversion'
 
 const INITIAL_FORM = {
     name: '',
@@ -45,14 +46,6 @@ export default function ContactBookingSection({
         setIsSubmitting(true)
 
         try {
-            if (typeof window !== 'undefined' && window.gtag) {
-                window.gtag('event', 'submit_form', {
-                    event_category: 'Form',
-                    event_label: 'contact',
-                    value: 1,
-                })
-            }
-
             const formData = new URLSearchParams()
             formData.set('form-name', 'contact')
             formData.set('name', form.name)
@@ -75,6 +68,9 @@ export default function ContactBookingSection({
                 throw new Error(`Form submission failed with status ${response.status}`)
             }
 
+            // E1 qualified-lead conversion: contact intake captured. Carries
+            // first-touch utm_* attribution; never any form contents.
+            trackEmailCapture({ location: 'contact_form' })
             setIsSubmitted(true)
         } catch (submitError) {
             console.error(submitError)

--- a/components/EmailForm.js
+++ b/components/EmailForm.js
@@ -3,8 +3,9 @@ import { useRouter } from 'next/router'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPaperPlane } from '@fortawesome/free-solid-svg-icons'
 import styles from './EmailForm.module.css'
+import { trackEmailCapture } from 'utils/conversion'
 
-export default function EmailForm() {
+export default function EmailForm({ location = 'email_form' }) {
     const router = useRouter()
     const [email, setEmail] = useState('')
     const [isSubmitting, setIsSubmitting] = useState(false)
@@ -13,14 +14,6 @@ export default function EmailForm() {
     const handleSubmit = async (event) => {
         event.preventDefault()
         setIsSubmitting(true)
-
-        if (typeof window !== 'undefined' && window.gtag) {
-            window.gtag('event', 'submit_form', {
-                event_category: 'Form',
-                event_label: 'email',
-                value: 1,
-            })
-        }
 
         const formData = new FormData(event.target)
         /*
@@ -38,6 +31,9 @@ export default function EmailForm() {
                 setIsSubmitting(false)
                 if (response.ok) {
                     setFormHidden(true) // Hide form and show success message on successful submission
+                    // E1 qualified-lead conversion: email captured. Carries
+                    // first-touch utm_* attribution; never the email itself.
+                    trackEmailCapture({ location })
                     console.log('Form successfully submitted')
                     // Handle further actions here, e.g., showing a success message
                 } else {

--- a/components/analytics/GoogleAnalytics.js
+++ b/components/analytics/GoogleAnalytics.js
@@ -1,0 +1,73 @@
+import Script from 'next/script'
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+
+/**
+ * GA4 loader — reusable, env-gated page-level integration.
+ *
+ * Renders nothing and loads nothing unless NEXT_PUBLIC_GA_MEASUREMENT_ID is
+ * set (local dev, CI, and opted-out deploys stay analytics-free). Mounted
+ * once in pages/_app.js so every page — including campaign landing pages —
+ * is covered automatically; no per-page wiring needed.
+ *
+ * The initial page_view is sent by `gtag('config', ...)`; subsequent
+ * client-side route changes send page_view manually so SPA navigation is
+ * counted correctly. IP anonymization is default-on in GA4.
+ * Google Ads signals/remarketing are explicitly disabled — this is
+ * traffic + conversion measurement only. Consent posture is documented in
+ * docs/ANALYTICS.md.
+ */
+
+const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID
+
+export function gaPageview(url) {
+    try {
+        if (
+            GA_MEASUREMENT_ID &&
+            typeof window !== 'undefined' &&
+            typeof window.gtag === 'function'
+        ) {
+            window.gtag('event', 'page_view', {
+                page_path: url,
+                send_to: GA_MEASUREMENT_ID,
+            })
+        }
+    } catch (err) {
+        // Analytics must never break the page.
+    }
+}
+
+export default function GoogleAnalytics() {
+    const router = useRouter()
+
+    useEffect(() => {
+        if (!GA_MEASUREMENT_ID) return undefined
+        const handleRouteChange = (url) => gaPageview(url)
+        router.events.on('routeChangeComplete', handleRouteChange)
+        return () => router.events.off('routeChangeComplete', handleRouteChange)
+    }, [router.events])
+
+    if (!GA_MEASUREMENT_ID) return null
+
+    return (
+        <>
+            <Script
+                src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+                strategy="afterInteractive"
+            />
+            <Script id="ga4-init" strategy="afterInteractive">
+                {`
+                    window.dataLayer = window.dataLayer || [];
+                    function gtag(){dataLayer.push(arguments);}
+                    window.gtag = gtag;
+                    gtag('js', new Date());
+                    gtag('config', '${GA_MEASUREMENT_ID}', {
+                        send_page_view: true,
+                        allow_google_signals: false,
+                        allow_ad_personalization_signals: false
+                    });
+                `}
+            </Script>
+        </>
+    )
+}

--- a/components/analytics/MetaPixel.js
+++ b/components/analytics/MetaPixel.js
@@ -1,0 +1,63 @@
+import Script from 'next/script'
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+
+/**
+ * Meta (Facebook) Pixel loader — reusable, env-gated.
+ *
+ * Renders nothing and loads nothing unless NEXT_PUBLIC_META_PIXEL_ID is
+ * set, so the pixel only exists on deploys that are actively running a
+ * paid Meta test (E1). Mounted once in pages/_app.js.
+ *
+ * Fires PageView on load and on every client-side route change.
+ * Conversion events (Lead / Contact / Schedule) are fired through
+ * utils/conversion.js — never inline. Only ever use this on public
+ * marketing pages; never on any surface that could see PHI-adjacent
+ * traffic (see docs/ANALYTICS.md and the E1 runbook).
+ */
+
+const META_PIXEL_ID = process.env.NEXT_PUBLIC_META_PIXEL_ID
+
+function pixelPageview() {
+    try {
+        if (
+            META_PIXEL_ID &&
+            typeof window !== 'undefined' &&
+            typeof window.fbq === 'function'
+        ) {
+            window.fbq('track', 'PageView')
+        }
+    } catch (err) {
+        // Analytics must never break the page.
+    }
+}
+
+export default function MetaPixel() {
+    const router = useRouter()
+
+    useEffect(() => {
+        if (!META_PIXEL_ID) return undefined
+        const handleRouteChange = () => pixelPageview()
+        router.events.on('routeChangeComplete', handleRouteChange)
+        return () => router.events.off('routeChangeComplete', handleRouteChange)
+    }, [router.events])
+
+    if (!META_PIXEL_ID) return null
+
+    return (
+        <Script id="meta-pixel-init" strategy="afterInteractive">
+            {`
+                !function(f,b,e,v,n,t,s)
+                {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+                n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+                if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+                n.queue=[];t=b.createElement(e);t.async=!0;
+                t.src=v;s=b.getElementsByTagName(e)[0];
+                s.parentNode.insertBefore(t,s)}(window, document,'script',
+                'https://connect.facebook.net/en_US/fbevents.js');
+                fbq('init', '${META_PIXEL_ID}');
+                fbq('track', 'PageView');
+            `}
+        </Script>
+    )
+}

--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -65,3 +65,50 @@ tab selected (`macOS`/`Linux`/`Windows`), the copy variant
 Because persistence is in-memory, a funnel is measured within a single page
 session (a visitor navigating the SPA), which is exactly the launch-day
 behavior we care about.
+
+## Paid-acquisition measurement (E1: GA4 + Meta Pixel)
+
+Additive layer for capped paid-traffic tests (Meta ads + community
+placements driving a landing page). Everything here is **env-gated and off
+by default** — with neither id set, no script loads and nothing renders:
+
+| Env var | Loads | Component |
+| ------- | ----- | --------- |
+| `NEXT_PUBLIC_GA_MEASUREMENT_ID` | GA4 (gtag.js): SPA pageviews + conversions, feeds the native GA4 → BigQuery export | `components/analytics/GoogleAnalytics.js` |
+| `NEXT_PUBLIC_META_PIXEL_ID` | Meta Pixel: PageView + standard conversion events for campaign optimization | `components/analytics/MetaPixel.js` |
+
+Both are mounted once in `pages/_app.js`, so every page (including
+campaign landing pages such as `/dental`) is covered with no per-page
+wiring.
+
+### Conversion events
+
+Fired through the single fan-out module `utils/conversion.js` (never
+inline `gtag`/`fbq` calls):
+
+| Conversion | Fires when | PostHog | GA4 | Meta |
+| ---------- | ---------- | ------- | --- | ---- |
+| Email capture (**qualified lead**) | email/contact form submits successfully (`components/EmailForm.js`, `components/ContactBookingSection.js`) | `email_capture_submitted` | `generate_lead` | `Lead` |
+| Booking click | visitor reaches the scheduler (`pages/book.js`) or clicks a direct booking link (`components/BookingEmbed.js`) | `book_call_click` | `book_call_click` | `Contact` |
+| Booking confirmed (**qualified lead**) | Cal.com embed reports a completed booking — best-effort postMessage signal (`components/BookingEmbed.js`) | `book_call_confirmed` | `book_call_confirmed` | `Schedule` |
+
+### Attribution
+
+`utils/attribution.js` captures `utm_source/medium/campaign/term/content`
+(+ `fbclid`/`gclid`) from the first landing URL of the session into
+`sessionStorage` (first-touch; cleared when the tab closes; no cookies)
+and every conversion event carries them, so cost-per-qualified-lead can be
+attributed per campaign/ad set/placement.
+
+### Privacy posture (deltas vs the PostHog layer)
+
+- Event properties remain campaign labels + enum locations only — never
+  emails, names, or form contents.
+- GA4 is configured with `allow_google_signals: false` and
+  `allow_ad_personalization_signals: false` (measurement, not
+  remarketing). GA4 does not log or store IP addresses.
+- The Meta Pixel is inherently a third-party ad tracker: enable it only
+  while a Meta campaign is live, and never on any surface that could
+  receive PHI-adjacent traffic. The site has no CMP today; the consent
+  discussion and regional considerations live in the E1 tracking runbook
+  (private), which gates turning the pixel on.

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -7,7 +7,10 @@ import { useEffect } from 'react'
 import { useRouter } from 'next/router'
 
 import NavHeader from '@components/NavHeader'
+import GoogleAnalytics from '@components/analytics/GoogleAnalytics'
+import MetaPixel from '@components/analytics/MetaPixel'
 import { initAnalytics, capturePageview } from 'utils/analytics'
+import { captureAttribution } from 'utils/attribution'
 
 export default function MyApp({ Component, pageProps }) {
     const router = useRouter()
@@ -15,6 +18,9 @@ export default function MyApp({ Component, pageProps }) {
     // Initialize privacy-conscious funnel analytics (no-op without a key)
     // and capture a pageview on every client-side route change.
     useEffect(() => {
+        // First-touch utm_* capture for paid-acquisition tests (E1); no-op
+        // when the landing URL carries no campaign params.
+        captureAttribution()
         initAnalytics()
         capturePageview(window.location.pathname + window.location.search)
         const handleRouteChange = (url) => capturePageview(url)
@@ -77,6 +83,9 @@ export default function MyApp({ Component, pageProps }) {
                 <meta name="twitter:image" content="https://openadapt.ai/og.png" />
 
             </Head>
+            {/* Env-gated: render nothing without their NEXT_PUBLIC_* ids. */}
+            <GoogleAnalytics />
+            <MetaPixel />
             <NavHeader />
             <main className="font-sans">
                 <Component {...pageProps} />

--- a/pages/book.js
+++ b/pages/book.js
@@ -1,12 +1,20 @@
 import Link from 'next/link'
 import Head from 'next/head'
+import { useEffect } from 'react'
 import { useRouter } from 'next/router'
 
 import BookingEmbed from '@components/BookingEmbed'
 import Footer from '@components/Footer'
+import { trackBookingClick } from 'utils/conversion'
 
 export default function BookPage() {
     const router = useRouter()
+
+    // Reaching the scheduler page is the E1 "booking click" conversion —
+    // it covers every CTA that routes here without touching each CTA.
+    useEffect(() => {
+        trackBookingClick({ location: 'book_page' })
+    }, [])
     const name = typeof router.query.name === 'string' ? router.query.name : ''
     const email = typeof router.query.email === 'string' ? router.query.email : ''
 

--- a/tests/e1Tracking.test.js
+++ b/tests/e1Tracking.test.js
@@ -1,0 +1,105 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+// Truth tests for the E1 paid-acquisition measurement layer: the trackers
+// must stay env-gated (off by default), conversions must flow through the
+// single fan-out module, and no component may hand-roll gtag/fbq calls.
+
+function read(relativePath) {
+    return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+test('GA4 loader is gated on NEXT_PUBLIC_GA_MEASUREMENT_ID', () => {
+    const source = read('components/analytics/GoogleAnalytics.js')
+    assert.match(source, /process\.env\.NEXT_PUBLIC_GA_MEASUREMENT_ID/)
+    assert.match(
+        source,
+        /if \(!GA_MEASUREMENT_ID\) return null/,
+        'GA4 must render nothing without a measurement id'
+    )
+    assert.match(
+        source,
+        /allow_google_signals: false/,
+        'GA4 must not enable Google signals/remarketing'
+    )
+})
+
+test('Meta Pixel is gated on NEXT_PUBLIC_META_PIXEL_ID', () => {
+    const source = read('components/analytics/MetaPixel.js')
+    assert.match(source, /process\.env\.NEXT_PUBLIC_META_PIXEL_ID/)
+    assert.match(
+        source,
+        /if \(!META_PIXEL_ID\) return null/,
+        'the pixel must render nothing without a pixel id'
+    )
+})
+
+test('_app mounts both env-gated trackers and captures attribution', () => {
+    const source = read('pages/_app.js')
+    assert.match(source, /<GoogleAnalytics \/>/)
+    assert.match(source, /<MetaPixel \/>/)
+    assert.match(source, /captureAttribution\(\)/)
+})
+
+test('conversion fan-out attaches first-touch attribution', () => {
+    const source = read('utils/conversion.js')
+    assert.match(source, /getAttribution\(\)/)
+    assert.match(source, /generate_lead/, 'GA4 recommended lead event')
+    assert.match(source, /'Lead'/, 'Meta standard Lead event')
+    assert.match(source, /'Schedule'/, 'Meta standard Schedule event')
+})
+
+test('attribution captures the standard utm params, first-touch only', () => {
+    const source = read('utils/attribution.js')
+    for (const param of [
+        'utm_source',
+        'utm_medium',
+        'utm_campaign',
+        'utm_term',
+        'utm_content',
+    ]) {
+        assert.ok(source.includes(`'${param}'`), `missing ${param}`)
+    }
+    assert.match(
+        source,
+        /if \(storage\.getItem\(ATTRIBUTION_STORAGE_KEY\)\) return/,
+        'an existing first touch must never be overwritten'
+    )
+})
+
+test('lead forms and booking surfaces use the fan-out, not inline gtag/fbq', () => {
+    const conversionSurfaces = [
+        'components/EmailForm.js',
+        'components/ContactBookingSection.js',
+        'components/BookingEmbed.js',
+        'pages/book.js',
+    ]
+    for (const relativePath of conversionSurfaces) {
+        const source = read(relativePath)
+        assert.match(
+            source,
+            /from 'utils\/conversion'/,
+            `${relativePath} must import the conversion fan-out`
+        )
+        assert.doesNotMatch(
+            source,
+            /window\.gtag|window\.fbq/,
+            `${relativePath} must not call gtag/fbq directly`
+        )
+    }
+    assert.match(read('components/EmailForm.js'), /trackEmailCapture\(/)
+    assert.match(
+        read('components/ContactBookingSection.js'),
+        /trackEmailCapture\(/
+    )
+    assert.match(read('pages/book.js'), /trackBookingClick\(/)
+    assert.match(read('components/BookingEmbed.js'), /trackBookingConfirmed\(/)
+})
+
+test('.env.example documents both tracker ids as off-by-default', () => {
+    const source = read('.env.example')
+    assert.match(source, /NEXT_PUBLIC_GA_MEASUREMENT_ID=/)
+    assert.match(source, /NEXT_PUBLIC_META_PIXEL_ID=/)
+})

--- a/utils/attribution.js
+++ b/utils/attribution.js
@@ -1,0 +1,87 @@
+/**
+ * First-touch campaign attribution for paid-acquisition tests (E1).
+ *
+ * Captures utm_source / utm_medium / utm_campaign / utm_term / utm_content
+ * (plus the fbclid / gclid click ids) from the FIRST landing URL of the
+ * session and keeps them in sessionStorage so conversion events fired later
+ * in the visit (email capture, booking click) still carry the campaign that
+ * paid for the visit, even after client-side navigation.
+ *
+ * Privacy posture matches utils/analytics.js: sessionStorage only (cleared
+ * when the tab closes), no cookies, no cross-session identity, and only
+ * campaign labels we put in our own ad URLs — never user data.
+ */
+
+export const ATTRIBUTION_STORAGE_KEY = 'oa_first_touch_attribution'
+
+export const ATTRIBUTION_PARAMS = [
+    'utm_source',
+    'utm_medium',
+    'utm_campaign',
+    'utm_term',
+    'utm_content',
+    'fbclid',
+    'gclid',
+]
+
+function safeSessionStorage() {
+    try {
+        if (typeof window === 'undefined' || !window.sessionStorage) return null
+        return window.sessionStorage
+    } catch (err) {
+        // Storage can throw in private windows / blocked contexts.
+        return null
+    }
+}
+
+/**
+ * Read attribution params from the current URL and persist them if this is
+ * the first touch of the session. Safe to call on every route change: an
+ * existing first-touch record is never overwritten.
+ */
+export function captureAttribution(search) {
+    const storage = safeSessionStorage()
+    if (!storage) return
+    try {
+        if (storage.getItem(ATTRIBUTION_STORAGE_KEY)) return
+        const query =
+            search !== undefined
+                ? search
+                : typeof window !== 'undefined'
+                  ? window.location.search
+                  : ''
+        if (!query) return
+        const params = new URLSearchParams(query)
+        const found = {}
+        for (const key of ATTRIBUTION_PARAMS) {
+            const value = params.get(key)
+            if (value) {
+                // Campaign labels only; cap length defensively.
+                found[key] = String(value).slice(0, 200)
+            }
+        }
+        if (Object.keys(found).length === 0) return
+        found.landing_path =
+            typeof window !== 'undefined' ? window.location.pathname : ''
+        storage.setItem(ATTRIBUTION_STORAGE_KEY, JSON.stringify(found))
+    } catch (err) {
+        // Attribution must never break the page.
+    }
+}
+
+/**
+ * Return the stored first-touch attribution (utm_*, click ids, landing_path)
+ * or {} when none was captured. Always safe to spread into event properties.
+ */
+export function getAttribution() {
+    const storage = safeSessionStorage()
+    if (!storage) return {}
+    try {
+        const raw = storage.getItem(ATTRIBUTION_STORAGE_KEY)
+        if (!raw) return {}
+        const parsed = JSON.parse(raw)
+        return parsed && typeof parsed === 'object' ? parsed : {}
+    } catch (err) {
+        return {}
+    }
+}

--- a/utils/conversion.js
+++ b/utils/conversion.js
@@ -1,0 +1,95 @@
+/**
+ * Conversion-event fan-out for paid-acquisition tests (E1).
+ *
+ * One call site per conversion; this module forwards to every configured
+ * sink, each of which is independently env-gated and a hard no-op when
+ * absent:
+ *
+ *   - PostHog        via utils/analytics.js  (NEXT_PUBLIC_POSTHOG_KEY)
+ *   - GA4 (gtag)     loaded by components/analytics/GoogleAnalytics.js
+ *                    (NEXT_PUBLIC_GA_MEASUREMENT_ID)
+ *   - Meta Pixel     loaded by components/analytics/MetaPixel.js
+ *                    (NEXT_PUBLIC_META_PIXEL_ID)
+ *
+ * Every event carries the first-touch utm_* attribution captured by
+ * utils/attribution.js. Properties are campaign labels and enum locations
+ * only — never form contents, emails, or free text. See docs/ANALYTICS.md.
+ */
+
+import { track } from 'utils/analytics'
+import { getAttribution } from 'utils/attribution'
+
+// Conversion event names. GA4 uses its recommended `generate_lead` name so
+// the event is usable as a conversion without remapping; Meta uses standard
+// events (`Lead`, `Schedule`) so campaign optimization works out of the box.
+export const CONVERSION_EVENTS = {
+    EMAIL_CAPTURE: 'email_capture_submitted',
+    BOOKING_CLICK: 'book_call_click',
+    BOOKING_CONFIRMED: 'book_call_confirmed',
+}
+
+function sanitizeProps(properties) {
+    const props = {}
+    if (properties && typeof properties === 'object') {
+        for (const [key, value] of Object.entries(properties)) {
+            if (value === undefined || value === null) continue
+            props[key] = String(value).slice(0, 200)
+        }
+    }
+    return { ...getAttribution(), ...props }
+}
+
+function gtagEvent(name, props) {
+    try {
+        if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
+            window.gtag('event', name, props)
+        }
+    } catch (err) {
+        // Analytics must never break the page.
+    }
+}
+
+function fbqEvent(kind, name, props) {
+    try {
+        if (typeof window !== 'undefined' && typeof window.fbq === 'function') {
+            window.fbq(kind, name, props)
+        }
+    } catch (err) {
+        // Analytics must never break the page.
+    }
+}
+
+/**
+ * A visitor submitted an email-capture form (waitlist / updates / contact).
+ * This is one of the two E1 "qualified lead" conversions.
+ * `location` is an enum-ish label: 'email_form', 'contact_form',
+ * 'dental_landing', ...
+ */
+export function trackEmailCapture(properties) {
+    const props = sanitizeProps(properties)
+    track(CONVERSION_EVENTS.EMAIL_CAPTURE, props)
+    gtagEvent('generate_lead', props)
+    fbqEvent('track', 'Lead', props)
+}
+
+/**
+ * A visitor clicked through to the booking scheduler (CTA or direct link).
+ * Intent signal on the "booked call" conversion path.
+ */
+export function trackBookingClick(properties) {
+    const props = sanitizeProps(properties)
+    track(CONVERSION_EVENTS.BOOKING_CLICK, props)
+    gtagEvent(CONVERSION_EVENTS.BOOKING_CLICK, props)
+    fbqEvent('track', 'Contact', props)
+}
+
+/**
+ * The Cal.com embed reported a completed booking (best-effort postMessage
+ * signal). This is the other E1 "qualified lead" conversion.
+ */
+export function trackBookingConfirmed(properties) {
+    const props = sanitizeProps(properties)
+    track(CONVERSION_EVENTS.BOOKING_CONFIRMED, props)
+    gtagEvent(CONVERSION_EVENTS.BOOKING_CONFIRMED, props)
+    fbqEvent('track', 'Schedule', props)
+}


### PR DESCRIPTION
## What

Measurement layer for the capped E1 paid-acquisition test (Meta + community traffic to a landing page; kill at >$300/qualified lead after $1K spend). **Everything is env-gated and off by default** — with neither id set, no script loads, nothing renders, and dev/CI behavior is unchanged.

- **GA4** (`components/analytics/GoogleAnalytics.js`, gated on `NEXT_PUBLIC_GA_MEASUREMENT_ID`): SPA pageviews on route change; Google signals + ad personalization disabled (measurement only); feeds the native GA4 → BigQuery export used for lead reporting.
- **Meta Pixel** (`components/analytics/MetaPixel.js`, gated on `NEXT_PUBLIC_META_PIXEL_ID`): PageView + standard conversion events; only exists on deploys running a live Meta campaign.
- **First-touch attribution** (`utils/attribution.js`): `utm_source/medium/campaign/term/content` + `fbclid`/`gclid` captured from the landing URL into `sessionStorage` (no cookies, cleared on tab close); attached to every conversion event.
- **Conversion fan-out** (`utils/conversion.js`) — one call site per conversion, forwarded to PostHog + GA4 + Meta:
  | Conversion | PostHog | GA4 | Meta |
  |---|---|---|---|
  | Email capture (qualified lead) | `email_capture_submitted` | `generate_lead` | `Lead` |
  | Booking click | `book_call_click` | `book_call_click` | `Contact` |
  | Booking confirmed (qualified lead, best-effort Cal.com postMessage) | `book_call_confirmed` | `book_call_confirmed` | `Schedule` |
- Wired into `EmailForm`, `ContactBookingSection`, `BookingEmbed`, and `/book`. Both trackers mount once in `_app.js`, so the upcoming `/dental` landing page is covered automatically; its CTAs can also call `trackEmailCapture({ location: 'dental_landing' })` / `trackBookingClick(...)` directly.
- Removes the two vestigial inline `window.gtag` calls (a gtag script was never loaded, so they were dead code).

## Privacy

Event properties are campaign labels + enum locations only — never emails, names, or form contents (consistent with `docs/ANALYTICS.md`). The pixel is documented as marketing-pages-only, never on PHI-adjacent surfaces; the consent posture and go-live gate live in the private E1 tracking runbook.

## Additive by design

New files + minimal hooks into existing components; no changes to the PostHog layer, routes, or styling, to stay conflict-free with the parallel `/dental` landing-page PR.

## Testing

- `npm test` — 45 pass (7 new truth tests in `tests/e1Tracking.test.js`: env-gating, first-touch-only attribution, fan-out-only conversion calls)
- `next build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)