### PR TITLE
fix(site): point primary open-source CTAs at the flagship OpenAdapt repo

### DIFF
--- a/components/AudiencePaths.js
+++ b/components/AudiencePaths.js
@@ -8,7 +8,7 @@ const paths = [
         primary: { label: 'Run the quickstart', href: '#open-source' },
         secondary: {
             label: 'Read the engine source',
-            href: 'https://github.com/OpenAdaptAI/openadapt-flow',
+            href: 'https://github.com/OpenAdaptAI/OpenAdapt',
             external: true,
         },
     },

--- a/components/Developers.js
+++ b/components/Developers.js
@@ -6,7 +6,7 @@ import PyPIDownloadChart from './PyPIDownloadChart';
 const ecosystemLinks = [
     {
         label: 'Engine source',
-        href: 'https://github.com/OpenAdaptAI/openadapt-flow',
+        href: 'https://github.com/OpenAdaptAI/OpenAdapt',
     },
     {
         label: 'Docs',

--- a/components/InstallSection.js
+++ b/components/InstallSection.js
@@ -208,7 +208,7 @@ export default function InstallSection() {
                     browser path is the only shipped end-to-end backend today.
                     Source and measured limits on{' '}
                     <a
-                        href="https://github.com/OpenAdaptAI/openadapt-flow"
+                        href="https://github.com/OpenAdaptAI/OpenAdapt"
                         target="_blank"
                         rel="noopener noreferrer"
                         style={{ textDecoration: 'underline' }}

--- a/components/NavHeader.js
+++ b/components/NavHeader.js
@@ -23,7 +23,7 @@ const NAV_LINKS = [
     { label: 'About', href: '/about' },
     {
         label: 'Open source',
-        href: 'https://github.com/OpenAdaptAI/openadapt-flow',
+        href: 'https://github.com/OpenAdaptAI/OpenAdapt',
         external: true,
     },
 ]

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -9,7 +9,7 @@ const { monthlyRunCapLabel } = require('../lib/hostedOfferContract')
  * configured product and price before payment.
  */
 
-const GITHUB_URL = 'https://github.com/OpenAdaptAI/openadapt-flow'
+const GITHUB_URL = 'https://github.com/OpenAdaptAI/OpenAdapt'
 
 function Check() {
     return (

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -126,7 +126,7 @@ describe('public product truth', () => {
             cy.contains('Launch').should('have.attr', 'href', '/#pricing')
             cy.contains('Open source')
                 .should('have.attr', 'href')
-                .and('include', 'openadapt-flow')
+                .and('equal', 'https://github.com/OpenAdaptAI/OpenAdapt')
         })
 
         cy.viewport(1024, 768)

--- a/pages/download.js
+++ b/pages/download.js
@@ -114,7 +114,7 @@ export default function DownloadPage() {
                 <p className="mt-5 max-w-2xl text-base text-ink-2 md:text-lg">
                     The open-source{' '}
                     <a
-                        href="https://github.com/OpenAdaptAI/openadapt-flow"
+                        href="https://github.com/OpenAdaptAI/OpenAdapt"
                         className="font-medium underline underline-offset-4"
                         target="_blank"
                         rel="noopener noreferrer"

--- a/pages/index.js
+++ b/pages/index.js
@@ -73,7 +73,7 @@ const softwareSchema = {
         url: 'https://openadapt.ai',
     },
     license: 'https://opensource.org/licenses/MIT',
-    codeRepository: 'https://github.com/OpenAdaptAI/openadapt-flow',
+    codeRepository: 'https://github.com/OpenAdaptAI/OpenAdapt',
     programmingLanguage: 'Python',
     offers: {
         '@type': 'Offer',


### PR DESCRIPTION
Primary Open Source / GitHub CTAs → OpenAdaptAI/OpenAdapt (flagship stars/forks); file-path links (docs, benchmarks, advisories) remain on -flow so nothing 404s. 50/50 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)