### PR TITLE
feat(site): add workflow template gallery at /templates

### DIFF
--- a/data/templates.js
+++ b/data/templates.js
@@ -1,0 +1,280 @@
+/**
+ * Workflow template registry — the single source of truth for /templates.
+ *
+ * Adding a template later = adding ONE entry here. The index page, the
+ * per-template static pages, their metadata, and their JSON-LD all render
+ * from this file; tests/templatesGallery.test.js enforces that sitemap.xml
+ * and llms.txt list every entry.
+ *
+ * HONESTY BAR (enforced by tests/templatesGallery.test.js):
+ * - `proof: 'reference'`  — the workflow runs today against the named
+ *   open-source reference app, in the openadapt-flow repo, with the named
+ *   verification. Steps are the real demonstrated steps.
+ * - `proof: 'field'`      — additionally measured in a field run (see
+ *   `evidence`), with the field-test caveats stated on the page.
+ * - `proof: 'pattern'`    — a workflow SHAPE you compile from a recording of
+ *   your own team; anchored to a proven reference via `anchors`. No canned
+ *   connector for any specific commercial portal is implied or shipped.
+ * - `runsOn` may only name applications we have actually driven
+ *   (MockMed, OpenEMR, Frappe Lending, openIMIS) or the customer's own app.
+ */
+
+const FLOW_REPO = 'https://github.com/OpenAdaptAI/openadapt-flow'
+
+// The canonical CLI quickstart (mirrors the openadapt-flow README "Try it").
+const DEMO_QUICKSTART = [
+    { cmd: 'pip install openadapt-flow', what: 'Install the open-source compiler and runtime.' },
+    { cmd: 'openadapt-flow demo-record --out rec', what: 'Serve the bundled MockMed clinic app locally and record the canonical triage demonstration.' },
+    { cmd: 'openadapt-flow compile rec --out bundle --name triage-note', what: 'Compile the recording into a deterministic, locally executable bundle.' },
+    { cmd: 'openadapt-flow lint bundle', what: 'Report the bundle’s coverage gaps — expected: it finds the demo’s unarmed irreversible final click.' },
+    { cmd: 'openadapt-flow certify bundle --policy clinical-write', what: 'Enforce the strict clinical-write policy — expected: refusal. That is the safety boundary working.' },
+    { cmd: 'openadapt-flow replay bundle', what: 'Replay locally, $0, no model calls; writes report.json and an illustrated REPORT.md.' },
+]
+
+const RECORD_YOUR_OWN = [
+    { cmd: 'pip install openadapt-flow', what: 'Install the open-source compiler and runtime.' },
+    { cmd: 'openadapt-flow record --url https://your.app --out rec', what: 'Open a headed browser on your app and demonstrate the workflow once; Ctrl-C to finish.' },
+    { cmd: 'openadapt-flow compile rec --out bundle --name my-task', what: 'Compile the recording into a deterministic bundle with auto-classified risk per step.' },
+    { cmd: 'openadapt-flow lint bundle && openadapt-flow certify bundle --policy permissive', what: 'Surface coverage gaps, then gate the bundle against a policy before it ever deploys.' },
+    { cmd: 'openadapt-flow replay bundle --url https://your.app --param name=value', what: 'Replay against your app; recorded values are defaults and --param overrides them.' },
+]
+
+const templates = [
+    // ------------------------------------------------------------------
+    // Proven references
+    // ------------------------------------------------------------------
+    {
+        slug: 'patient-triage-note',
+        title: 'Automate patient triage note entry',
+        vertical: 'healthcare',
+        proof: 'reference',
+        summary:
+            'The canonical OpenAdapt tutorial: a nurse’s triage-note workflow demonstrated once in a synthetic clinic app, compiled into a deterministic local program, and replayed with the note text as a parameter — including the policy gate that refuses to certify it for clinical writes.',
+        metaDescription:
+            'Automate patient triage note entry: record the workflow once, compile it into deterministic local replay, and see the clinical-write policy gate refuse an under-verified bundle. Runs today with two commands.',
+        runsOn:
+            'MockMed, the synthetic clinic application bundled with the openadapt-flow CLI — no setup and no real patient data. It ships so you can run this entire template in about two minutes.',
+        steps: [
+            'Sign in to the clinic app',
+            'Open the first referral in the task list',
+            'Start a new encounter for the patient',
+            'Select the Triage encounter type',
+            'Enter the triage note — recorded as the parameter "note", overridable at every replay',
+            'Save the encounter',
+        ],
+        parameters: ['note — the triage note text'],
+        verification:
+            'Replay writes report.json and an illustrated REPORT.md for every run. lint reports the demonstration’s coverage gaps — including its unarmed irreversible final click — and certify with the strict clinical-write policy refuses the bundle. That refusal is deliberate: the bundled tutorial is runnable but intentionally not certified for clinical writes, so you see the governance boundary working before you trust it with a workflow that matters.',
+        verificationOracles: ['per-step postconditions', 'lint coverage report', 'policy certification gate (permissive passes, clinical-write refuses)'],
+        quickstart: DEMO_QUICKSTART,
+        source: `${FLOW_REPO}#try-it`,
+        evidence:
+            'A nightly clean-machine test runs this complete install-to-uninstall journey on Linux, macOS, and Windows.',
+        cta: { href: '/solutions/healthcare', label: 'Healthcare execution infrastructure' },
+    },
+    {
+        slug: 'openemr-patient-note',
+        title: 'Automate patient note entry in OpenEMR',
+        vertical: 'healthcare',
+        proof: 'field',
+        summary:
+            'The flagship healthcare reference: an 18-step add-patient-note workflow on OpenEMR — log in, find the patient, open the chart, navigate to Patient Messages, enter a parameterized note, save — with the write confirmed against the record itself, never the screen.',
+        metaDescription:
+            'Automate patient note entry in OpenEMR: an 18-step demonstrated workflow compiled into deterministic replay, verified against the system of record, with a published field run of 20/20 compiled trials at zero model calls.',
+        runsOn:
+            'OpenEMR, the open-source EMR — demonstrated against the third-party OpenEMR public demo (fake patients only; never point this at a real install without qualification) and reproduced in CI against a fixture system of record.',
+        steps: [
+            'Log in as the demo admin',
+            'Search for the demo patient',
+            'Open the patient’s chart',
+            'Scroll the dense Medical Record Dashboard to the Messages card',
+            'Open Patient Messages',
+            'Enter the note — a distinct parameterized value per run, so a pass proves parameter substitution against real state, not replay of a baked-in literal',
+            'Save and confirm',
+        ],
+        parameters: ['note — the message text written to the patient record'],
+        verification:
+            'The Save step carries system-of-record effect contracts (record_written and a field_equals check on the note). The CI-reproducible harness proves the whole loop composes: a clean replay is CONFIRMED against the record; under an injected fault the screen still paints “Saved” while the record drops the note — effect verification REFUTES the run and it halts. Screen-only checking would have passed. An unexpected consent modal likewise halts the run, the operator’s correction is taught back as a governed, gated branch, and the taught program re-runs the same drift to success.',
+        verificationOracles: ['record_written effect contract', 'field_equals on the saved note (record, not screen)', 'halt on refuted effect', 'governed teach-and-promote loop'],
+        quickstart: RECORD_YOUR_OWN,
+        source: `${FLOW_REPO}/tree/main/benchmark/openemr_e2e`,
+        evidence:
+            'Field run on the real third-party OpenEMR public demo: compiled replay went 20/20 versus 10/10 for a computer-use agent, faster and with zero model calls. Field test, not CI-reproducible — the public demo is shared, resets daily, and the agent sample is small; the verifier and task-prompt units run in CI.',
+        cta: { href: '/solutions/healthcare', label: 'Healthcare execution infrastructure' },
+    },
+    {
+        slug: 'frappe-loan-application',
+        title: 'Automate loan application entry in Frappe Lending',
+        vertical: 'lending',
+        proof: 'reference',
+        summary:
+            'The lending reference: a loan application entered once on Frappe Lending, compiled into model-free replay, and accepted only when a separately authenticated read-only REST session, a direct SQL read-back, and an exact table-delta audit all agree that exactly one application was written.',
+        metaDescription:
+            'Automate loan application entry: a demonstrated Frappe Lending workflow compiled into deterministic, model-free replay and verified by independent REST, SQL, and exact table-delta oracles. 6/6 compiled trials correct, 0 silent incorrect successes, 0 model calls.',
+        runsOn:
+            'Frappe Lending v16.2.0, run locally as a pinned, fully synthetic fixture — every trial restores the same SHA-256-bound database snapshot. Frappe exposes a good REST API, so a real deployment should prefer the API; the browser arm isolates what compiled replay is worth when a UI path is required.',
+        steps: [
+            'On the Loan Application opened for the fixture customer, enter the applicant contact email',
+            'Enter the applicant contact phone',
+            'Scroll from the contact inputs to the lower loan controls — the demonstrated navigation is preserved in the compiled program, not hidden',
+            'Select the loan product, waiting for the exact visible suggestion before confirming',
+            'Enter the loan amount',
+            'Enter the number of repayment periods',
+            'Save exactly one application',
+        ],
+        parameters: ['email', 'phone', 'loan product', 'amount', 'repayment periods'],
+        verification:
+            'Three independent oracles, none of which is the writer: a read-only REST session authenticated as a separate fixture user, a direct SQL read-back of the target fields, and an exact per-table row-count contract — the only accepted change is exactly one new Loan Application row; every other table must stay untouched. A duplicate write, a wrong-customer write, or a collateral insert fails the run loudly. Pixels and actor self-report never establish success.',
+        verificationOracles: ['separately authenticated read-only REST', 'direct SQL read-back', 'exact table-delta audit (tabLoan Application: +1, all else +0)'],
+        quickstart: RECORD_YOUR_OWN,
+        source: `${FLOW_REPO}/tree/main/benchmark/frappe_lending`,
+        evidence:
+            '6/6 compiled trials correct across the pinned baseline and a cosmetic-drift variant — 0 silent incorrect successes, 0 over-halts, 0 model calls, $0 model cost. An initial engineering matrix, not a publication benchmark; the full comparative matrix (paid agent arm, 10 fresh trials per cell) is still open.',
+        cta: { href: '/solutions/lending', label: 'Lending operations reference' },
+    },
+    {
+        slug: 'openimis-claim-intake',
+        title: 'Automate health insurance claim intake in openIMIS',
+        vertical: 'insurance',
+        proof: 'reference',
+        summary:
+            'The insurance reference: a health-facility claim entered once in openIMIS — the open-source system used by national health-insurance schemes — compiled, and replayed with a fresh claim number, with success established only by a direct SQL read of the claim row.',
+        metaDescription:
+            'Automate insurance claim intake: a demonstrated openIMIS claims workflow compiled into deterministic replay and accepted only when the claims database shows exactly one new claim row in status Entered for the right policyholder and facility.',
+        runsOn:
+            'openIMIS 25.10, run locally from digest-pinned images with the upstream synthetic demo dataset — fictional insurees, facilities, and tariffs; everything binds to localhost. openIMIS is a browser UI over a supported GraphQL API, so a real openIMIS deployment should prefer the API; the browser demonstration stands in for the many commercial claims platforms that expose no such API.',
+        steps: [
+            'On the blank Health Facility Claim form, enter the insuree number — which resolves the policyholder and her in-force policy',
+            'Enter the claim number — a parameter, substituted fresh at every replay',
+            'Enter the main diagnosis code',
+            'Enter the explanation note — a parameter',
+            'Add the service (auto-tariffed by the system)',
+            'Save the claim into status “Entered” — the step before checking and adjudication',
+        ],
+        parameters: ['insurance_no', 'claim_no', 'explanation'],
+        verification:
+            'A direct SQL oracle on the claims database: the run is accepted only when exactly one non-voided claim row exists with the replayed claim number, in status Entered, for the demonstrated insuree and health facility. The costly failure in claims operations is not a crash — it is the claim silently entered twice, or against the wrong policyholder, surfacing weeks later in reconciliation. A duplicate or missing row fails this run loudly instead of reporting success.',
+        verificationOracles: ['direct SQL claim-row oracle (exactly one non-voided row, status Entered, right insuree and facility)'],
+        quickstart: RECORD_YOUR_OWN,
+        source: `${FLOW_REPO}/tree/main/benchmark/openimis_claims`,
+        evidence:
+            'A reference environment, deliberately not a benchmark: no timing matrix and no agent arm. Any future reliability claim requires the full matched protocol the Frappe Lending and OpenEMR references define.',
+        cta: { href: '/solutions/insurance', label: 'Insurance claims execution' },
+    },
+
+    // ------------------------------------------------------------------
+    // Pattern templates — compiled from a recording of YOUR team
+    // ------------------------------------------------------------------
+    {
+        slug: 'dental-insurance-eligibility',
+        title: 'Automate dental insurance eligibility checks',
+        vertical: 'dental',
+        proof: 'pattern',
+        anchors: ['openimis-claim-intake', 'patient-triage-note'],
+        summary:
+            'The front-desk workflow every practice runs dozens of times a day: sign in to the payer portal, look up the patient, read coverage and benefits, and carry the answer into the practice management system — demonstrated once by your own team, then compiled and replayed per patient.',
+        metaDescription:
+            'Automate dental insurance eligibility checks: compile your front desk’s own payer-portal verification workflow into deterministic local replay that halts and asks instead of guessing wrong. Runs on your front-desk computer.',
+        runsOn:
+            'Your practice’s own payer portals and practice management system, from a recording of your team performing one verification. There is no canned connector for any specific payer portal — each workflow is compiled from your demonstration and qualified against your applications. The verified-write mechanics are proven on the openIMIS insurance reference, where policyholder resolution and the resulting write are checked against the insurance database itself.',
+        steps: [
+            'Sign in to the payer portal — credentials are secret parameters, never written to the recording or the bundle',
+            'Look up the patient by member ID and date of birth — the per-patient parameters',
+            'Open the coverage and benefits view',
+            'Read the eligibility result and the benefit fields your practice actually uses',
+            'Record the result where your workflow puts it — the PMS, a worksheet, or the schedule',
+        ],
+        parameters: ['member ID', 'date of birth', 'payer selection — as demonstrated by your team'],
+        verification:
+            'Every step carries identity checks derived from the demonstration — the compiled program verifies it is looking at the right member before it reads or writes anything, and halts and asks instead of proceeding when the portal shows something it never saw demonstrated. Where the result lands in a system with a database, API, or export you control, the write is bound to an effect contract and checked against that system of record, not the screen.',
+        verificationOracles: ['pre-action target-identity checks', 'halt on undemonstrated portal state', 'effect contract on the recorded result where a system of record exists'],
+        quickstart: RECORD_YOUR_OWN,
+        source: `${FLOW_REPO}/tree/main/benchmark/openimis_claims`,
+        evidence: null,
+        cta: { href: '/dental', label: 'Automated verification for dental practices — founding cohort' },
+    },
+    {
+        slug: 'insurance-eligibility-check',
+        title: 'Automate insurance eligibility and coverage checks',
+        vertical: 'insurance',
+        proof: 'pattern',
+        anchors: ['openimis-claim-intake', 'frappe-loan-application'],
+        summary:
+            'For agencies, billers, and back-office teams: the repeated carrier-portal lookup — member or policy number in, coverage answer out — demonstrated once, compiled into a deterministic program, and replayed per case with halting instead of silent wrong answers.',
+        metaDescription:
+            'Automate insurance eligibility and coverage checks: compile your team’s own carrier-portal lookup into deterministic replay with per-case parameters, identity checks on every step, and a halt instead of a silently wrong answer.',
+        runsOn:
+            'Your organization’s own carrier portals and systems, from a recording of your team performing one check. No canned carrier connectors are implied — each workflow is compiled from your demonstration and qualified against your applications. The underlying mechanics — policy resolution against a live insurance system and database-verified writes — are proven on the openIMIS reference.',
+        steps: [
+            'Sign in to the carrier portal — credentials are secret parameters, redacted from the recording and injected from the environment at replay',
+            'Look up the member or policy — the per-case parameters',
+            'Open the coverage, benefits, or status view',
+            'Read the fields your process needs',
+            'Record the answer into your system of record or worksheet',
+        ],
+        parameters: ['member or policy number', 'any per-case identifiers your team demonstrated'],
+        verification:
+            'The compiled program verifies target identity before every consequential action — the wrong policyholder on screen is a halt, not a wrong answer written downstream. Anything the demonstration never covered (an unexpected modal, a changed portal state) halts and asks. Where the answer is written into a system with a database, API, or file export, that write is bound to an effect contract and confirmed against the system of record.',
+        verificationOracles: ['pre-action target-identity checks', 'halt on undemonstrated state', 'effect contract on the downstream write where a system of record exists'],
+        quickstart: RECORD_YOUR_OWN,
+        source: `${FLOW_REPO}/tree/main/benchmark/openimis_claims`,
+        evidence: null,
+        cta: { href: '/solutions/insurance', label: 'Insurance claims execution' },
+    },
+    {
+        slug: 'new-patient-record',
+        title: 'Automate new patient record entry',
+        vertical: 'healthcare',
+        proof: 'pattern',
+        anchors: ['openemr-patient-note', 'patient-triage-note'],
+        summary:
+            'Registration and intake re-keying — demographics from a referral, a form, or an existing structured source entered into the EMR or PMS — demonstrated once by your team, compiled, and replayed per patient with the fields as parameters.',
+        metaDescription:
+            'Automate new patient record entry: compile your team’s own registration workflow into deterministic replay with per-patient parameters and identity checks, anchored to the OpenEMR reference where writes are verified against the record itself.',
+        runsOn:
+            'Your clinic’s own EMR or practice management system, from a recording of your team entering one record. The write-verification mechanics are proven on OpenEMR, the open-source EMR, where a compiled note write is confirmed against the patient record itself — and a fault that paints “Saved” on screen while dropping the write is caught and halted.',
+        steps: [
+            'Open the new-patient or registration form in your EMR or PMS',
+            'Enter the demographic fields — each one a parameter, substituted per patient at replay',
+            'Enter coverage or referral details as demonstrated',
+            'Save the record',
+        ],
+        parameters: ['the demographic and coverage fields your team demonstrated — one parameter each'],
+        verification:
+            'Write-shaped steps are auto-classified as irreversible at compile time, which arms the low-confidence refusal: the program halts rather than saving into ambiguity. lint reports any step that acts without an identity check before you deploy, and certify can refuse the bundle under a strict policy. Where your EMR exposes a database, API, or export, the save is bound to an effect contract and confirmed against the record — the OpenEMR reference demonstrates exactly this, including catching a silent dropped write behind a “Saved” screen.',
+        verificationOracles: ['irreversible-write classification and refusal arming', 'lint coverage gate before deploy', 'effect contract on the saved record where a system of record exists'],
+        quickstart: RECORD_YOUR_OWN,
+        source: `${FLOW_REPO}/tree/main/benchmark/openemr_e2e`,
+        evidence: null,
+        cta: { href: '/solutions/healthcare', label: 'Healthcare execution infrastructure' },
+    },
+    {
+        slug: 'report-export-verification',
+        title: 'Automate report exports and verify the file actually arrived',
+        vertical: 'operations',
+        proof: 'pattern',
+        anchors: ['frappe-loan-application'],
+        summary:
+            'The scheduled export nobody trusts: run the report, download or drop the file, and — the part the screen can’t prove — verify that exactly one conforming file actually landed, with the right name, a plausible size, a fresh timestamp, and optionally the exact expected content.',
+        metaDescription:
+            'Automate report exports with arrival verification: compile the export workflow once, then accept each run only when exactly one new conforming file actually arrived — name, size, freshness, and optional content hash — instead of trusting an “Export complete” screen.',
+        runsOn:
+            'Your own reporting application and output folder or SFTP endpoint, from a recording of your team running one export. The file-arrival and document-hash verifiers are part of the shipping runtime and run live in CI; local directories are first-class and SFTP endpoints are supported.',
+        steps: [
+            'Open the report in your application',
+            'Set the demonstrated filters or date range — parameters at replay',
+            'Trigger the export',
+            'Let the effect contract — not the screen — establish whether the file arrived',
+        ],
+        parameters: ['report filters or date range as demonstrated'],
+        verification:
+            'An “Export complete” message proves nothing; the truth is whether a file matching the contract actually arrived. The file-arrival verifier checks name pattern, non-trivial size, fresh modification time, and optionally content — and its exactly-one-new-file contract catches the double export that quietly writes “report (1).csv”. When the expected bytes are known, the document-hash verifier confirms content identity by SHA-256, catching a truncated or partial write even though the file exists. A missing or unreadable output folder is indeterminate and halts — never “no file expected”.',
+        verificationOracles: ['file-arrival contract (exactly one new conforming file: name, size, freshness)', 'SHA-256 document-hash content check', 'halt on unreadable export target'],
+        quickstart: RECORD_YOUR_OWN,
+        source: `${FLOW_REPO}/blob/main/openadapt_flow/runtime/effects/file_arrival.py`,
+        evidence: null,
+        cta: { href: '/#book', label: 'Qualify a workflow' },
+    },
+]
+
+module.exports = { templates, FLOW_REPO }

--- a/pages/templates/[slug].js
+++ b/pages/templates/[slug].js
@@ -1,0 +1,234 @@
+import Head from 'next/head'
+import Link from 'next/link'
+
+import Footer from '@components/Footer'
+import { templates } from 'data/templates'
+
+const PROOF_LABELS = {
+    reference: 'Proven reference',
+    field: 'Proven reference + field run',
+    pattern: 'Pattern — compile it from your own recording',
+}
+
+const PROOF_EXPLANATIONS = {
+    reference:
+        'This workflow runs today, end to end, against the named open-source reference application in the openadapt-flow repository. The steps below are the real demonstrated steps and the verification is the real oracle.',
+    field:
+        'This workflow runs today against the named application, and has additionally been measured in a field run — with the field-test caveats stated below.',
+    pattern:
+        'This is a workflow shape, not a canned connector: you compile it from a recording of your own team in your own applications. The execution and verification mechanics it relies on are proven on the linked reference templates.',
+}
+
+export default function TemplatePage({ template, anchorTemplates }) {
+    const t = template
+    const url = `https://openadapt.ai/templates/${t.slug}`
+
+    const howToSchema = {
+        '@context': 'https://schema.org',
+        '@type': 'HowTo',
+        name: `${t.title} with OpenAdapt`,
+        description: t.metaDescription,
+        totalTime: 'PT15M',
+        supply: [],
+        tool: [
+            {
+                '@type': 'HowToTool',
+                name: 'openadapt-flow (open-source CLI, MIT licensed)',
+            },
+        ],
+        step: t.quickstart.map((q, i) => ({
+            '@type': 'HowToStep',
+            position: i + 1,
+            name: q.cmd,
+            text: q.what,
+        })),
+    }
+
+    return (
+        <div className="min-h-screen bg-ground text-ink">
+            <Head>
+                <title>{`${t.title} | OpenAdapt`}</title>
+                <meta name="description" content={t.metaDescription} />
+                <link rel="canonical" href={url} />
+                <meta property="og:title" content={`${t.title} | OpenAdapt`} />
+                <meta property="og:description" content={t.metaDescription} />
+                <meta property="og:url" content={url} />
+                <script
+                    type="application/ld+json"
+                    dangerouslySetInnerHTML={{ __html: JSON.stringify(howToSchema) }}
+                />
+            </Head>
+
+            <div className="mx-auto max-w-4xl px-4 py-14">
+                <p className="text-sm text-ink-3">
+                    <Link href="/templates">← All workflow templates</Link>
+                </p>
+
+                <div className="mt-6 flex flex-wrap items-center gap-2">
+                    <span className="eyebrow">Workflow template</span>
+                    <span className="rounded-full border border-hairline px-2 py-0.5 text-[11px] text-ink-3">
+                        {PROOF_LABELS[t.proof]}
+                    </span>
+                </div>
+                <h1 className="font-display mt-3 text-3xl font-semibold tracking-tight text-ink md:text-4xl">
+                    {t.title}
+                </h1>
+                <p className="mt-5 max-w-3xl text-base text-ink-2 md:text-lg">
+                    {t.summary}
+                </p>
+                <p className="mt-4 max-w-3xl text-sm leading-relaxed text-ink-3 md:text-base">
+                    {PROOF_EXPLANATIONS[t.proof]}
+                </p>
+
+                {/* Runs on */}
+                <div className="mt-8 rounded-2xl border border-hairline bg-panel p-6">
+                    <h2 className="eyebrow">Runs on</h2>
+                    <p className="mt-2 text-sm leading-relaxed text-ink-2 md:text-base">
+                        {t.runsOn}
+                    </p>
+                    <p className="mt-3 text-sm">
+                        <a href={t.source}>Source in openadapt-flow →</a>
+                    </p>
+                </div>
+
+                {/* Steps */}
+                <h2 className="mt-12 font-display text-xl font-semibold tracking-tight text-ink">
+                    The demonstrated steps
+                </h2>
+                <ol className="mt-4 space-y-3">
+                    {t.steps.map((step, i) => (
+                        <li
+                            key={step}
+                            className="flex gap-4 rounded-xl border border-hairline bg-panel p-4 text-sm leading-relaxed text-ink-2 md:text-base"
+                        >
+                            <span className="font-display font-semibold text-ink">
+                                {i + 1}
+                            </span>
+                            <span>{step}</span>
+                        </li>
+                    ))}
+                </ol>
+                {t.parameters?.length > 0 && (
+                    <p className="mt-4 text-sm leading-relaxed text-ink-3">
+                        <strong className="text-ink-2">Parameters:</strong>{' '}
+                        {t.parameters.join(' · ')} — recorded values are the
+                        defaults; every replay can override them.
+                    </p>
+                )}
+
+                {/* Verification */}
+                <h2 className="mt-12 font-display text-xl font-semibold tracking-tight text-ink">
+                    How the outcome is verified
+                </h2>
+                <p className="mt-3 max-w-3xl text-sm leading-relaxed text-ink-2 md:text-base">
+                    {t.verification}
+                </p>
+                <ul className="mt-4 flex flex-wrap gap-2">
+                    {t.verificationOracles.map((oracle) => (
+                        <li
+                            key={oracle}
+                            className="rounded-full border border-hairline bg-panel px-3 py-1 text-xs text-ink-2"
+                        >
+                            {oracle}
+                        </li>
+                    ))}
+                </ul>
+
+                {/* Evidence */}
+                {t.evidence && (
+                    <div className="mt-8 rounded-2xl border border-hairline bg-panel p-6">
+                        <h2 className="eyebrow">Evidence and scope</h2>
+                        <p className="mt-2 text-sm leading-relaxed text-ink-2 md:text-base">
+                            {t.evidence}
+                        </p>
+                    </div>
+                )}
+
+                {/* Anchors for pattern templates */}
+                {anchorTemplates.length > 0 && (
+                    <div className="mt-8">
+                        <h2 className="eyebrow">Proven on</h2>
+                        <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                            {anchorTemplates.map((a) => (
+                                <Link
+                                    key={a.slug}
+                                    href={`/templates/${a.slug}`}
+                                    className="rounded-xl border border-hairline bg-panel p-4 text-sm text-ink-2 no-underline transition-colors hover:border-ink"
+                                >
+                                    <span className="font-medium text-ink">
+                                        {a.title}
+                                    </span>
+                                    <span className="mt-1 block text-xs text-ink-3">
+                                        {PROOF_LABELS[a.proof]}
+                                    </span>
+                                </Link>
+                            ))}
+                        </div>
+                    </div>
+                )}
+
+                {/* Quickstart */}
+                <h2 className="mt-12 font-display text-xl font-semibold tracking-tight text-ink">
+                    Try it from the command line
+                </h2>
+                <p className="mt-3 max-w-3xl text-sm leading-relaxed text-ink-2 md:text-base">
+                    The compiler and runtime are open source and MIT licensed.
+                    Healthy runs are local and make no model calls.
+                </p>
+                <div className="mt-4 space-y-3">
+                    {t.quickstart.map((q) => (
+                        <div
+                            key={q.cmd}
+                            className="rounded-xl border border-hairline bg-panel p-4"
+                        >
+                            <pre className="overflow-x-auto text-sm text-ink">
+                                <code>{q.cmd}</code>
+                            </pre>
+                            <p className="mt-2 text-xs leading-relaxed text-ink-3 md:text-sm">
+                                {q.what}
+                            </p>
+                        </div>
+                    ))}
+                </div>
+
+                {/* CTA */}
+                <div className="mt-14 rounded-2xl border-2 border-ink bg-panel p-6 text-center md:p-8">
+                    <h2 className="font-display text-xl font-semibold tracking-tight text-ink">
+                        Put this workflow into production
+                    </h2>
+                    <p className="mx-auto mt-3 max-w-2xl text-sm text-ink-2 md:text-base">
+                        Bring your version of this workflow and the record that
+                        proves its outcome. We&apos;ll map the deployment,
+                        verification, shadow run, and supervised rollout.
+                    </p>
+                    <div className="mt-5 flex flex-wrap justify-center gap-3">
+                        <Link href={t.cta.href} className="btn-ink">
+                            {t.cta.label}
+                        </Link>
+                        <Link href="/#book" className="btn-ghost-ink">
+                            Book a demo
+                        </Link>
+                    </div>
+                </div>
+            </div>
+
+            <Footer />
+        </div>
+    )
+}
+
+export function getStaticPaths() {
+    return {
+        paths: templates.map((t) => ({ params: { slug: t.slug } })),
+        fallback: false,
+    }
+}
+
+export function getStaticProps({ params }) {
+    const template = templates.find((t) => t.slug === params.slug)
+    const anchorTemplates = (template.anchors || [])
+        .map((slug) => templates.find((t) => t.slug === slug))
+        .filter(Boolean)
+        .map(({ slug, title, proof }) => ({ slug, title, proof }))
+    return { props: { template, anchorTemplates } }
+}

--- a/pages/templates/index.js
+++ b/pages/templates/index.js
@@ -1,0 +1,137 @@
+import Head from 'next/head'
+import Link from 'next/link'
+
+import Footer from '@components/Footer'
+import { templates } from 'data/templates'
+
+const PROOF_LABELS = {
+    reference: 'Proven reference',
+    field: 'Proven reference + field run',
+    pattern: 'Pattern — compile it from your own recording',
+}
+
+const VERTICAL_LABELS = {
+    healthcare: 'Healthcare',
+    lending: 'Lending',
+    insurance: 'Insurance',
+    dental: 'Dental',
+    operations: 'Back-office operations',
+}
+
+export default function TemplatesIndexPage() {
+    const itemListSchema = {
+        '@context': 'https://schema.org',
+        '@type': 'ItemList',
+        name: 'OpenAdapt workflow template gallery',
+        description:
+            'Runnable workflow templates: demonstrated GUI workflows compiled into deterministic, locally executable programs with verification against the system of record.',
+        itemListElement: templates.map((t, i) => ({
+            '@type': 'ListItem',
+            position: i + 1,
+            name: t.title,
+            url: `https://openadapt.ai/templates/${t.slug}`,
+        })),
+    }
+
+    return (
+        <div className="min-h-screen bg-ground text-ink">
+            <Head>
+                <title>Workflow Template Gallery — Verified GUI Automation | OpenAdapt</title>
+                <meta
+                    name="description"
+                    content="Runnable workflow templates for healthcare, lending, insurance, and back-office operations. Each template is a demonstrated GUI workflow compiled into deterministic local replay and verified against the system of record — no page for a workflow we haven't actually run."
+                />
+                <link rel="canonical" href="https://openadapt.ai/templates" />
+                <meta property="og:title" content="Workflow Template Gallery | OpenAdapt" />
+                <meta
+                    property="og:description"
+                    content="Real, runnable workflow templates: patient notes in OpenEMR, loan applications in Frappe Lending, claim intake in openIMIS, eligibility checks, verified report exports."
+                />
+                <meta property="og:url" content="https://openadapt.ai/templates" />
+                <script
+                    type="application/ld+json"
+                    dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListSchema) }}
+                />
+            </Head>
+
+            <div className="mx-auto max-w-5xl px-4 py-14">
+                <p className="eyebrow">Workflow templates</p>
+                <h1 className="font-display mt-3 max-w-3xl text-3xl font-semibold tracking-tight text-ink md:text-4xl">
+                    Workflows you can compile, replay, and verify — starting
+                    today.
+                </h1>
+                <p className="mt-5 max-w-3xl text-base text-ink-2 md:text-lg">
+                    Every template here corresponds to something that actually
+                    runs. The proven references execute end to end against real
+                    open-source applications in the{' '}
+                    <a href="https://github.com/OpenAdaptAI/openadapt-flow">
+                        openadapt-flow
+                    </a>{' '}
+                    repository, with success established by the system of
+                    record — a database row, an independent API read, a file
+                    that actually arrived — never by pixels or self-report. The
+                    patterns are workflow shapes you compile from a recording
+                    of your own team, anchored to those references.
+                </p>
+                <p className="mt-4 max-w-3xl text-sm leading-relaxed text-ink-3 md:text-base">
+                    Our honesty bar: no template for a workflow we haven&apos;t
+                    actually run, and no logos of applications we haven&apos;t
+                    driven.
+                </p>
+
+                <div className="mt-10 grid gap-4 md:grid-cols-2">
+                    {templates.map((t) => (
+                        <Link
+                            key={t.slug}
+                            href={`/templates/${t.slug}`}
+                            className="group flex flex-col rounded-2xl border border-hairline bg-panel p-6 no-underline transition-colors hover:border-ink"
+                        >
+                            <div className="flex flex-wrap items-center gap-2">
+                                <span className="eyebrow">
+                                    {VERTICAL_LABELS[t.vertical]}
+                                </span>
+                                <span className="rounded-full border border-hairline px-2 py-0.5 text-[11px] text-ink-3">
+                                    {PROOF_LABELS[t.proof]}
+                                </span>
+                            </div>
+                            <h2 className="font-display mt-3 text-lg font-semibold tracking-tight text-ink">
+                                {t.title}
+                            </h2>
+                            <p className="mt-2 text-sm leading-relaxed text-ink-2">
+                                {t.summary}
+                            </p>
+                            <p className="mt-auto pt-4 text-sm font-medium text-ink group-hover:underline">
+                                View template →
+                            </p>
+                        </Link>
+                    ))}
+                </div>
+
+                <div className="mt-14 rounded-2xl border-2 border-ink bg-panel p-6 text-center md:p-8">
+                    <h2 className="font-display text-xl font-semibold tracking-tight text-ink">
+                        Have a workflow that isn&apos;t here?
+                    </h2>
+                    <p className="mx-auto mt-3 max-w-2xl text-sm text-ink-2 md:text-base">
+                        If your team does it the same way every time in a
+                        browser, a Windows application, or a remote desktop,
+                        it is a candidate. Bring one repeated workflow and the
+                        record that proves its outcome.
+                    </p>
+                    <div className="mt-5 flex flex-wrap justify-center gap-3">
+                        <Link href="/#book" className="btn-ink">
+                            Qualify a workflow
+                        </Link>
+                        <a
+                            href="https://github.com/OpenAdaptAI/openadapt-flow#try-it"
+                            className="btn-ghost-ink"
+                        >
+                            Try the CLI quickstart
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <Footer />
+        </div>
+    )
+}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -20,6 +20,18 @@
 - [Insurance Claims Execution](https://openadapt.ai/solutions/insurance): A demonstrated openIMIS claims-intake workflow compiled into model-free replay and checked against a direct SQL claim-row oracle
 - [Other Regulated Back-Offices](https://openadapt.ai/#industries): Demonstrated browser workflows that require repeatable execution, review, and explicit data boundaries
 
+## Workflow Templates
+Real, runnable workflow templates. Every template corresponds to something that actually runs: proven references execute end to end against real open-source applications in the openadapt-flow repository with system-of-record verification; pattern templates are workflow shapes compiled from a recording of the customer's own team, anchored to those references. No template exists for a workflow that has not actually been run.
+- [Template Gallery](https://openadapt.ai/templates): All workflow templates with proof level, demonstrated steps, verification oracles, and CLI quickstart
+- [Patient Triage Note](https://openadapt.ai/templates/patient-triage-note): The canonical tutorial on the bundled synthetic clinic app, including the clinical-write policy gate refusing an under-verified bundle
+- [OpenEMR Patient Note](https://openadapt.ai/templates/openemr-patient-note): 18-step add-patient-note workflow verified against the record itself, with a published field run of 20/20 compiled trials at zero model calls
+- [Frappe Lending Loan Application](https://openadapt.ai/templates/frappe-loan-application): Loan application entry verified by independent REST, SQL, and exact table-delta oracles
+- [openIMIS Claim Intake](https://openadapt.ai/templates/openimis-claim-intake): Health-facility claim intake verified by a direct SQL claim-row oracle
+- [Dental Insurance Eligibility Checks](https://openadapt.ai/templates/dental-insurance-eligibility): Pattern — a practice's own payer-portal verification workflow, compiled from its own recording
+- [Insurance Eligibility and Coverage Checks](https://openadapt.ai/templates/insurance-eligibility-check): Pattern — repeated carrier-portal lookups with per-case parameters and halt-on-ambiguity
+- [New Patient Record Entry](https://openadapt.ai/templates/new-patient-record): Pattern — registration re-keying with per-patient parameters, anchored to the OpenEMR reference
+- [Report Export with Arrival Verification](https://openadapt.ai/templates/report-export-verification): Pattern — exports accepted only when exactly one conforming file actually arrived, with optional SHA-256 content identity
+
 ## Source Code
 - [Engine Source](https://github.com/OpenAdaptAI/openadapt-flow): MIT licensed, open source
 - [PyPI Package](https://pypi.org/project/openadapt-flow/): Standalone governed compiler and runtime

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -79,6 +79,60 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://openadapt.ai/templates</loc>
+    <lastmod>2026-07-18</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://openadapt.ai/templates/patient-triage-note</loc>
+    <lastmod>2026-07-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://openadapt.ai/templates/openemr-patient-note</loc>
+    <lastmod>2026-07-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://openadapt.ai/templates/frappe-loan-application</loc>
+    <lastmod>2026-07-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://openadapt.ai/templates/openimis-claim-intake</loc>
+    <lastmod>2026-07-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://openadapt.ai/templates/dental-insurance-eligibility</loc>
+    <lastmod>2026-07-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://openadapt.ai/templates/insurance-eligibility-check</loc>
+    <lastmod>2026-07-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://openadapt.ai/templates/new-patient-record</loc>
+    <lastmod>2026-07-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://openadapt.ai/templates/report-export-verification</loc>
+    <lastmod>2026-07-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://openadapt.ai/privacy-policy</loc>
     <lastmod>2026-05-25</lastmod>
     <changefreq>yearly</changefreq>

--- a/tests/templatesGallery.test.js
+++ b/tests/templatesGallery.test.js
@@ -1,0 +1,159 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+const root = path.join(__dirname, '..')
+const read = (relativePath) =>
+    fs.readFileSync(path.join(root, relativePath), 'utf8')
+
+const { templates } = require('../data/templates')
+
+// The only applications templates may claim to run on. Everything else must
+// be phrased as the customer's OWN application ("your ...") — never a named
+// integration we have not actually driven.
+const DRIVEN_APPS = ['MockMed', 'OpenEMR', 'Frappe Lending', 'openIMIS']
+
+test('registry entries are complete, unique, and search-titled', () => {
+    assert.ok(templates.length >= 6, 'launch gallery has at least 6 templates')
+
+    const slugs = templates.map((t) => t.slug)
+    assert.equal(new Set(slugs).size, slugs.length, 'slugs are unique')
+
+    for (const t of templates) {
+        assert.match(t.slug, /^[a-z0-9]+(-[a-z0-9]+)*$/, `${t.slug}: kebab-case slug`)
+        assert.match(t.title, /^Automate /, `${t.slug}: task-language title`)
+        assert.ok(t.summary.length > 80, `${t.slug}: substantive summary`)
+        assert.ok(
+            t.metaDescription.length > 60 && t.metaDescription.length <= 320,
+            `${t.slug}: meta description present and bounded`
+        )
+        assert.ok(t.runsOn.length > 40, `${t.slug}: honest runs-on line`)
+        assert.ok(t.steps.length >= 3, `${t.slug}: real step list`)
+        assert.ok(t.verification.length > 80, `${t.slug}: verification story`)
+        assert.ok(t.verificationOracles.length >= 1, `${t.slug}: named oracle(s)`)
+        assert.ok(t.quickstart.length >= 3, `${t.slug}: CLI quickstart`)
+        assert.equal(
+            t.quickstart[0].cmd,
+            'pip install openadapt-flow',
+            `${t.slug}: quickstart starts from the real published package`
+        )
+        assert.match(
+            t.source,
+            /^https:\/\/github\.com\/OpenAdaptAI\/openadapt-flow/,
+            `${t.slug}: source links into the engine repo`
+        )
+        assert.ok(
+            ['reference', 'field', 'pattern'].includes(t.proof),
+            `${t.slug}: declared proof level`
+        )
+        assert.ok(t.cta && t.cta.href && t.cta.label, `${t.slug}: CTA present`)
+    }
+})
+
+test('proven templates name only applications we have actually driven', () => {
+    for (const t of templates.filter((x) => x.proof !== 'pattern')) {
+        assert.ok(
+            DRIVEN_APPS.some((app) => t.runsOn.includes(app)),
+            `${t.slug}: runs-on names a driven reference app`
+        )
+    }
+})
+
+test('pattern templates are anchored to proven references and claim no canned connectors', () => {
+    const provenSlugs = new Set(
+        templates.filter((t) => t.proof !== 'pattern').map((t) => t.slug)
+    )
+    for (const t of templates.filter((x) => x.proof === 'pattern')) {
+        assert.ok(
+            Array.isArray(t.anchors) && t.anchors.length >= 1,
+            `${t.slug}: pattern is anchored`
+        )
+        for (const anchor of t.anchors) {
+            assert.ok(
+                provenSlugs.has(anchor),
+                `${t.slug}: anchor ${anchor} is a proven reference`
+            )
+        }
+        assert.match(
+            t.runsOn,
+            /[Yy]our/,
+            `${t.slug}: pattern runs on the customer's own applications`
+        )
+        assert.match(
+            `${t.runsOn} ${t.summary}`,
+            /no canned (connector|carrier connectors)|recording of your|your own/i,
+            `${t.slug}: pattern framing is honest`
+        )
+    }
+})
+
+test('template copy keeps the public slogan discipline', () => {
+    const sources = [
+        'data/templates.js',
+        'pages/templates/index.js',
+        'pages/templates/[slug].js',
+    ]
+        .map(read)
+        .join('\n')
+
+    // Same banned claims the rest of the site enforces, plus fabrication bait.
+    assert.doesNotMatch(sources, /record once|runs? forever|self[- ]heal|milliseconds/i)
+    assert.doesNotMatch(sources, /any app\b|every app\b|works with everything/i)
+    assert.doesNotMatch(sources, /\bEpic\b|\bCerner\b|\bAvaility\b|\bDentrix\b|\bEaglesoft\b|\bZapier\b/, 'no integrations we have not driven')
+    assert.doesNotMatch(sources, /100% reliable|never fails|guaranteed accuracy/i)
+})
+
+test('field-proven claims carry their caveats', () => {
+    const openemr = templates.find((t) => t.slug === 'openemr-patient-note')
+    assert.match(openemr.evidence, /20\/20/)
+    assert.match(openemr.evidence, /not CI-reproducible/i)
+    const frappe = templates.find((t) => t.slug === 'frappe-loan-application')
+    assert.match(frappe.evidence, /not a publication benchmark/i)
+})
+
+test('sitemap lists the gallery and every template page', () => {
+    const sitemap = read('public/sitemap.xml')
+    assert.match(sitemap, /https:\/\/openadapt\.ai\/templates<\/loc>/)
+    for (const t of templates) {
+        assert.match(
+            sitemap,
+            new RegExp(`https://openadapt\\.ai/templates/${t.slug}</loc>`),
+            `sitemap lists ${t.slug}`
+        )
+    }
+})
+
+test('llms.txt lists the gallery and every template page', () => {
+    const llms = read('public/llms.txt')
+    assert.match(llms, /## Workflow Templates/)
+    assert.match(llms, /https:\/\/openadapt\.ai\/templates\)/)
+    for (const t of templates) {
+        assert.ok(
+            llms.includes(`https://openadapt.ai/templates/${t.slug}`),
+            `llms.txt lists ${t.slug}`
+        )
+    }
+})
+
+test('template pages render every registry field they promise', () => {
+    const page = read('pages/templates/[slug].js')
+    for (const field of [
+        't.runsOn',
+        't.steps',
+        't.verification',
+        't.verificationOracles',
+        't.quickstart',
+        't.source',
+        't.cta.href',
+    ]) {
+        assert.ok(page.includes(field), `[slug].js renders ${field}`)
+    }
+    assert.match(page, /application\/ld\+json/)
+    assert.match(page, /HowTo/)
+
+    const index = read('pages/templates/index.js')
+    assert.match(index, /application\/ld\+json/)
+    assert.match(index, /ItemList/)
+    assert.match(index, /honesty bar/i)
+})


### PR DESCRIPTION
## What changed

The E3 workflow template gallery — the ~$0 compounding acquisition channel from the scalable-acquisition plan: real, runnable workflow templates as individually-linkable pages that can rank for "[task] automation" queries and convert to the CLI quickstart and the vertical offers.

- **`/templates`** — gallery index (ItemList JSON-LD), honesty-bar statement up top.
- **`/templates/[slug]`** — eight statically generated template pages, each with:
  - a task-language, search-tuned title ("Automate patient note entry in OpenEMR", "Automate dental insurance eligibility checks", …),
  - the demonstrated step list from the real bundle/benchmark,
  - the verification story (effect contracts and named oracles — REST/SQL/table-delta/claim-row/file-arrival/document-hash),
  - an honest "Runs on" line naming only the reference app actually driven (plus a source link into openadapt-flow),
  - the CLI quickstart (`pip install openadapt-flow` + the real commands),
  - per-page title/meta/OG + HowTo JSON-LD,
  - a vertical CTA (`/dental` for the dental eligibility page; `/solutions/*` elsewhere).
- **`data/templates.js`** — the single registry. **Adding a template later = one registry entry**; the index, the static page, its metadata, and its JSON-LD all derive from it (the pSEO expansion path). Header comments document the honesty bar per proof level.
- **`public/sitemap.xml`** — `/templates` + all eight template URLs.
- **`public/llms.txt`** — new "Workflow Templates" section listing all nine URLs.
- **`tests/templatesGallery.test.js`** — truth guards for the gallery: unique kebab slugs, "Automate …" titles, real steps/oracles/quickstarts, proven templates may only name driven apps (MockMed, OpenEMR, Frappe Lending, openIMIS), pattern templates must be anchored to proven references and phrased as "your own recording" with no canned connectors, field claims must carry their caveats (20/20 marked not CI-reproducible; Frappe marked not a publication benchmark), the site-wide slogan bans, and sitemap/llms.txt coverage.

## Launch templates

| Slug | Proof | Source in openadapt-flow |
|---|---|---|
| `patient-triage-note` | reference | bundled MockMed tutorial (`demo-record` → compile → lint → certify → replay) |
| `openemr-patient-note` | reference + field run | `benchmark/openemr_e2e` + the 20/20 field benchmark (caveats stated) |
| `frappe-loan-application` | reference | `benchmark/frappe_lending` (REST + SQL + exact table-delta oracles) |
| `openimis-claim-intake` | reference | `benchmark/openimis_claims` (SQL claim-row oracle) |
| `dental-insurance-eligibility` | pattern → CTA `/dental` | anchored to openIMIS + MockMed references |
| `insurance-eligibility-check` | pattern → CTA `/solutions/insurance` | anchored to openIMIS + Frappe references |
| `new-patient-record` | pattern → CTA `/solutions/healthcare` | anchored to OpenEMR + MockMed references |
| `report-export-verification` | pattern → CTA `/#book` | file-arrival + document-hash verifiers (run live in CI) |

## Honesty & guard compliance

- No fabricated integrations, no named commercial portals/EMRs we haven't driven (guard-tested), no logos.
- Copy respects the existing `publicTruth` slogan bans (no "record once / runs forever / self-heals / milliseconds") and the llms.txt bans; all 58 tests pass (`npm test`), `next build` prerenders all 8 slug pages.
- Additive only: no existing page, component, or test was modified.

## Coordination

- Checked `gh pr list` and recent commits before building: draft PR #201 (home-page workflow × execution-environment animations) does not touch `/templates`, `data/`, sitemap, or llms.txt — no overlap.
- sitemap/llms.txt changes are pure additions, so merge conflicts with in-flight site PRs should be trivial if any arrive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
