### PR TITLE
feat(nav): add Blog link and nested Developers dropdown to top navigation

### DIFF
--- a/components/Developers.js
+++ b/components/Developers.js
@@ -2,32 +2,15 @@ import React, { useEffect, useState } from 'react';
 import styles from './Developers.module.css';
 import InstallSection from '@components/InstallSection';
 import PyPIDownloadChart from './PyPIDownloadChart';
+import { BLOG_LINK, DEVELOPER_LINKS } from 'data/developerLinks';
 
+// Canonical hrefs live in data/developerLinks.js (shared with the nav
+// "Developers" dropdown). Keep the historical on-page order: Engine
+// source, Docs, Technical paper source, Blog, Discord, Report an issue.
 const ecosystemLinks = [
-    {
-        label: 'Engine source',
-        href: 'https://github.com/OpenAdaptAI/OpenAdapt',
-    },
-    {
-        label: 'Docs',
-        href: 'https://docs.openadapt.ai',
-    },
-    {
-        label: 'Technical paper source',
-        href: 'https://github.com/OpenAdaptAI/openadapt-flow/tree/main/paper',
-    },
-    {
-        label: 'Blog',
-        href: 'https://blog.openadapt.ai',
-    },
-    {
-        label: 'Discord',
-        href: 'https://discord.gg/yF527cQbDG',
-    },
-    {
-        label: 'Report an issue',
-        href: 'https://github.com/OpenAdaptAI/openadapt-flow/issues/new/choose',
-    },
+    ...DEVELOPER_LINKS.slice(0, 3),
+    BLOG_LINK,
+    ...DEVELOPER_LINKS.slice(3),
 ];
 
 export default function Developers() {

--- a/components/NavHeader.js
+++ b/components/NavHeader.js
@@ -1,13 +1,17 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 
 import { track, EVENTS } from 'utils/analytics'
+import { BLOG_LINK, DEVELOPER_LINKS } from 'data/developerLinks'
 import styles from './NavHeader.module.css'
 
 // Map an external nav link to its funnel event, if any.
 const externalEvent = (href) => {
-    if (href && href.includes('github.com')) return EVENTS.GITHUB_CLICK
+    if (!href) return null
+    if (href.includes('github.com')) return EVENTS.GITHUB_CLICK
+    if (href.includes('docs.openadapt.ai')) return EVENTS.DOCS_CLICK
+    if (href.includes('discord.gg')) return EVENTS.DISCORD_CLICK
     return null
 }
 
@@ -21,12 +25,206 @@ const NAV_LINKS = [
     { label: 'Download', href: '/download' },
     { label: 'Launch', href: '/#pricing' },
     { label: 'About', href: '/about' },
+    { label: BLOG_LINK.label, href: BLOG_LINK.href, external: true },
+    // Rendered as the nested "Developers" dropdown (desktop) or a
+    // labeled group (mobile). Blog is already top-level, so the
+    // dropdown carries the remaining developer ecosystem links.
+    { label: 'Developers', dropdown: DEVELOPER_LINKS },
     {
         label: 'Open source',
         href: 'https://github.com/OpenAdaptAI/OpenAdapt',
         external: true,
     },
 ]
+
+function ExternalNavLink({ item, className, location }) {
+    return (
+        <a
+            href={item.href}
+            className={className}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => {
+                const ev = externalEvent(item.href)
+                if (ev) track(ev, { location })
+            }}
+        >
+            {item.label}
+        </a>
+    )
+}
+
+function DevelopersDropdown({ links }) {
+    const [open, setOpen] = useState(false)
+    const rootRef = useRef(null)
+    const triggerRef = useRef(null)
+    const panelRef = useRef(null)
+    // Which item to focus once the panel opens: 'first' | 'last' | null.
+    const pendingFocus = useRef(null)
+    // True while the panel is open only because the pointer hovers it.
+    // A click on the trigger then pins the panel open instead of
+    // toggling it shut (clicks always follow the synthetic hover on
+    // touch devices, and mouse users hover before they click).
+    const hoverOpened = useRef(false)
+    const router = useRouter()
+
+    const close = () => {
+        hoverOpened.current = false
+        setOpen(false)
+    }
+
+    // Close whenever the route changes.
+    useEffect(() => {
+        hoverOpened.current = false
+        setOpen(false)
+    }, [router.asPath])
+
+    // Close on any pointer press outside the dropdown.
+    useEffect(() => {
+        if (!open) return undefined
+        const onPointerDown = (event) => {
+            if (rootRef.current && !rootRef.current.contains(event.target)) {
+                hoverOpened.current = false
+                setOpen(false)
+            }
+        }
+        document.addEventListener('pointerdown', onPointerDown)
+        return () => document.removeEventListener('pointerdown', onPointerDown)
+    }, [open])
+
+    // Honor a queued keyboard focus request once the panel exists.
+    useEffect(() => {
+        if (!open || !pendingFocus.current || !panelRef.current) return
+        const items = panelRef.current.querySelectorAll('a')
+        if (items.length > 0) {
+            const index =
+                pendingFocus.current === 'last' ? items.length - 1 : 0
+            items[index].focus()
+        }
+        pendingFocus.current = null
+    }, [open])
+
+    const moveFocus = (offset) => {
+        if (!panelRef.current) return
+        const items = Array.from(panelRef.current.querySelectorAll('a'))
+        if (items.length === 0) return
+        const current = items.indexOf(document.activeElement)
+        const next =
+            current === -1
+                ? offset > 0
+                    ? 0
+                    : items.length - 1
+                : (current + offset + items.length) % items.length
+        items[next].focus()
+    }
+
+    const onKeyDown = (event) => {
+        switch (event.key) {
+            case 'Escape':
+                event.preventDefault()
+                close()
+                triggerRef.current?.focus()
+                break
+            case 'ArrowDown':
+                event.preventDefault()
+                if (!open) {
+                    pendingFocus.current = 'first'
+                    setOpen(true)
+                } else {
+                    moveFocus(1)
+                }
+                break
+            case 'ArrowUp':
+                event.preventDefault()
+                if (!open) {
+                    pendingFocus.current = 'last'
+                    setOpen(true)
+                } else {
+                    moveFocus(-1)
+                }
+                break
+            default:
+                break
+        }
+    }
+
+    // Close when keyboard focus tabs out of the dropdown entirely.
+    const onBlur = (event) => {
+        if (rootRef.current && !rootRef.current.contains(event.relatedTarget)) {
+            close()
+        }
+    }
+
+    const onMouseEnter = () => {
+        if (!open) {
+            hoverOpened.current = true
+            setOpen(true)
+        }
+    }
+
+    // Only a hover-opened panel closes when the pointer leaves; a
+    // click-pinned one stays until Escape, tab-out, or outside click.
+    const onMouseLeave = () => {
+        if (hoverOpened.current) close()
+    }
+
+    const onTriggerClick = () => {
+        if (open && hoverOpened.current) {
+            // The hover that precedes every click already opened the
+            // panel; treat the click as intent to open, and pin it.
+            hoverOpened.current = false
+            return
+        }
+        if (open) {
+            close()
+        } else {
+            setOpen(true)
+        }
+    }
+
+    return (
+        <div
+            ref={rootRef}
+            className={styles.dropdown}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
+            onKeyDown={onKeyDown}
+            onBlur={onBlur}
+        >
+            <button
+                ref={triggerRef}
+                type="button"
+                className={styles.dropdownTrigger}
+                aria-expanded={open}
+                aria-haspopup="true"
+                aria-controls="nav-developers-menu"
+                onClick={onTriggerClick}
+            >
+                Developers
+                <span className={styles.caret} aria-hidden="true">
+                    ▾
+                </span>
+            </button>
+            {open && (
+                <div
+                    ref={panelRef}
+                    id="nav-developers-menu"
+                    className={styles.dropdownPanel}
+                    aria-label="Developers"
+                >
+                    {links.map((item) => (
+                        <ExternalNavLink
+                            key={item.label}
+                            item={item}
+                            className={styles.dropdownItem}
+                            location="nav_developers"
+                        />
+                    ))}
+                </div>
+            )}
+        </div>
+    )
+}
 
 export default function NavHeader() {
     const router = useRouter()
@@ -45,21 +243,22 @@ export default function NavHeader() {
                     <span className="font-semibold">Adapt</span>
                 </Link>
                 <nav className={styles.links} aria-label="Primary">
-                    {NAV_LINKS.map((item) =>
-                        item.external ? (
-                            <a
+                    {NAV_LINKS.map((item) => {
+                        if (item.dropdown) {
+                            return (
+                                <DevelopersDropdown
+                                    key={item.label}
+                                    links={item.dropdown}
+                                />
+                            )
+                        }
+                        return item.external ? (
+                            <ExternalNavLink
                                 key={item.label}
-                                href={item.href}
+                                item={item}
                                 className={styles.link}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                onClick={() => {
-                                    const ev = externalEvent(item.href)
-                                    if (ev) track(ev, { location: 'nav' })
-                                }}
-                            >
-                                {item.label}
-                            </a>
+                                location="nav"
+                            />
                         ) : (
                             <Link
                                 key={item.label}
@@ -69,7 +268,7 @@ export default function NavHeader() {
                                 {item.label}
                             </Link>
                         )
-                    )}
+                    })}
                 </nav>
                 <button
                     type="button"
@@ -97,21 +296,39 @@ export default function NavHeader() {
                     className={styles.mobilePanel}
                     aria-label="Primary mobile"
                 >
-                    {NAV_LINKS.map((item) =>
-                        item.external ? (
-                            <a
+                    {NAV_LINKS.map((item) => {
+                        if (item.dropdown) {
+                            // The mobile panel is a flat list, so the
+                            // dropdown renders as a labeled group in place.
+                            return (
+                                <div
+                                    key={item.label}
+                                    className={styles.mobileGroup}
+                                >
+                                    <span
+                                        className={styles.mobileGroupLabel}
+                                        aria-hidden="true"
+                                    >
+                                        {item.label}
+                                    </span>
+                                    {item.dropdown.map((link) => (
+                                        <ExternalNavLink
+                                            key={link.label}
+                                            item={link}
+                                            className={styles.mobileLink}
+                                            location="nav_mobile_developers"
+                                        />
+                                    ))}
+                                </div>
+                            )
+                        }
+                        return item.external ? (
+                            <ExternalNavLink
                                 key={item.label}
-                                href={item.href}
+                                item={item}
                                 className={styles.mobileLink}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                onClick={() => {
-                                    const ev = externalEvent(item.href)
-                                    if (ev) track(ev, { location: 'nav_mobile' })
-                                }}
-                            >
-                                {item.label}
-                            </a>
+                                location="nav_mobile"
+                            />
                         ) : (
                             <Link
                                 key={item.label}
@@ -121,7 +338,7 @@ export default function NavHeader() {
                                 {item.label}
                             </Link>
                         )
-                    )}
+                    })}
                 </nav>
             )}
         </header>

--- a/components/NavHeader.module.css
+++ b/components/NavHeader.module.css
@@ -49,6 +49,79 @@
     text-decoration: none;
 }
 
+.dropdown {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.dropdownTrigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    background: transparent;
+    border: none;
+    padding: 0;
+    font-family: inherit;
+    font-size: 13.5px;
+    color: var(--ink);
+    line-height: inherit;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.dropdownTrigger:hover,
+.dropdownTrigger[aria-expanded='true'] {
+    color: var(--accent);
+}
+
+.caret {
+    font-size: 9px;
+    line-height: 1;
+    transform: translateY(1px);
+}
+
+.dropdownPanel {
+    position: absolute;
+    top: calc(100% + 10px);
+    right: -12px;
+    z-index: 110;
+    display: flex;
+    flex-direction: column;
+    min-width: 220px;
+    padding: 6px;
+    background: var(--panel);
+    border: 1px solid var(--hairline);
+    border-radius: 10px;
+    box-shadow: 0 10px 24px rgba(35, 40, 31, 0.08);
+}
+
+/* Invisible bridge over the 10px gap so hover survives the traversal
+   from the trigger down into the panel. */
+.dropdownPanel::before {
+    content: '';
+    position: absolute;
+    top: -12px;
+    left: 0;
+    right: 0;
+    height: 12px;
+}
+
+.dropdownItem {
+    font-size: 13.5px;
+    color: var(--ink);
+    text-decoration: none;
+    white-space: nowrap;
+    padding: 8px 10px;
+    border-radius: 6px;
+}
+
+.dropdownItem:hover {
+    color: var(--accent);
+    background: var(--ground);
+    text-decoration: none;
+}
+
 .cta {
     display: inline-block;
     padding: 7px 16px;
@@ -86,8 +159,9 @@
     display: none;
 }
 
-/* The ten-link desktop navigation no longer fits reliably at tablet widths. */
-@media (max-width: 1120px) {
+/* The twelve-item desktop navigation (with Blog and the Developers
+   dropdown) no longer fits reliably below laptop widths. */
+@media (max-width: 1200px) {
     .links {
         display: none;
     }
@@ -126,6 +200,26 @@
     .mobileLink:hover {
         color: var(--accent);
         text-decoration: none;
+    }
+
+    .mobileGroup {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .mobileGroupLabel {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--ink-3);
+        padding: 12px 0 2px;
+    }
+
+    /* Links inside the Developers group keep their divider even when
+       they are the group's last child, because more items follow. */
+    .mobileGroup .mobileLink:last-child {
+        border-bottom: 1px dotted var(--hairline-dotted);
     }
 }
 

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -51,6 +51,74 @@ describe('public product truth', () => {
             .and('contain.text', 'forks')
     })
 
+    it('surfaces Blog and the Developers dropdown in the primary nav', () => {
+        cy.get('nav[aria-label="Primary"]').within(() => {
+            cy.contains('a', 'Blog')
+                .should('be.visible')
+                .and('have.attr', 'href', 'https://blog.openadapt.ai')
+            cy.contains('a', 'Open source')
+                .should('be.visible')
+                .and('have.attr', 'href', 'https://github.com/OpenAdaptAI/OpenAdapt')
+            cy.contains('button', 'Developers')
+                .should('be.visible')
+                .and('have.attr', 'aria-expanded', 'false')
+            cy.get('#nav-developers-menu').should('not.exist')
+
+            cy.contains('button', 'Developers').click()
+            cy.contains('button', 'Developers').should(
+                'have.attr',
+                'aria-expanded',
+                'true'
+            )
+            cy.get('#nav-developers-menu').within(() => {
+                cy.contains('a', 'Engine source')
+                    .should('be.visible')
+                    .and(
+                        'have.attr',
+                        'href',
+                        'https://github.com/OpenAdaptAI/OpenAdapt'
+                    )
+                cy.contains('a', 'Docs')
+                    .should('be.visible')
+                    .and('have.attr', 'href', 'https://docs.openadapt.ai')
+                cy.contains('a', 'Technical paper source')
+                    .should('be.visible')
+                    .and(
+                        'have.attr',
+                        'href',
+                        'https://github.com/OpenAdaptAI/openadapt-flow/tree/main/paper'
+                    )
+                cy.contains('a', 'Discord')
+                    .should('be.visible')
+                    .and('have.attr', 'href', 'https://discord.gg/yF527cQbDG')
+                cy.contains('a', 'Report an issue')
+                    .should('be.visible')
+                    .and(
+                        'have.attr',
+                        'href',
+                        'https://github.com/OpenAdaptAI/openadapt-flow/issues/new/choose'
+                    )
+                // Blog is top-level, not duplicated inside the dropdown.
+                cy.contains('a', 'Blog').should('not.exist')
+            })
+        })
+
+        // Escape closes the dropdown.
+        cy.contains('button', 'Developers').type('{esc}')
+        cy.get('#nav-developers-menu').should('not.exist')
+        cy.contains('button', 'Developers').should(
+            'have.attr',
+            'aria-expanded',
+            'false'
+        )
+
+        // Reopen, then a click outside the dropdown closes it.
+        cy.contains('button', 'Developers').click()
+        cy.get('#nav-developers-menu').should('be.visible')
+        cy.get('h1').click()
+        cy.get('#nav-developers-menu').should('not.exist')
+    })
+
     it('explains the governed workflow and execution choices', () => {
         cy.contains('What “repair” means, and where it stops').should('be.visible')
         cy.contains('Unsupported drift').should('be.visible')
@@ -124,7 +192,34 @@ describe('public product truth', () => {
                 '/#product-status'
             )
             cy.contains('Launch').should('have.attr', 'href', '/#pricing')
+            cy.contains('a', 'Blog')
+                .should('have.attr', 'href')
+                .and('equal', 'https://blog.openadapt.ai')
+            // The Developers dropdown renders as a labeled flat group.
+            cy.contains('Developers').scrollIntoView().should('be.visible')
+            cy.contains('a', 'Engine source')
+                .should('have.attr', 'href')
+                .and('equal', 'https://github.com/OpenAdaptAI/OpenAdapt')
+            cy.contains('a', 'Docs')
+                .should('have.attr', 'href')
+                .and('equal', 'https://docs.openadapt.ai')
+            cy.contains('a', 'Technical paper source')
+                .should('have.attr', 'href')
+                .and(
+                    'equal',
+                    'https://github.com/OpenAdaptAI/openadapt-flow/tree/main/paper'
+                )
+            cy.contains('a', 'Discord')
+                .should('have.attr', 'href')
+                .and('equal', 'https://discord.gg/yF527cQbDG')
+            cy.contains('a', 'Report an issue')
+                .should('have.attr', 'href')
+                .and(
+                    'equal',
+                    'https://github.com/OpenAdaptAI/openadapt-flow/issues/new/choose'
+                )
             cy.contains('Open source')
+                .scrollIntoView()
                 .should('have.attr', 'href')
                 .and('equal', 'https://github.com/OpenAdaptAI/OpenAdapt')
         })

--- a/data/developerLinks.js
+++ b/data/developerLinks.js
@@ -1,0 +1,36 @@
+/**
+ * Canonical developer ecosystem destinations.
+ *
+ * Single source of truth shared by the top-navigation "Developers"
+ * dropdown (components/NavHeader.js) and the lower-page open-source
+ * section (components/Developers.js) so the two surfaces can never
+ * drift apart.
+ */
+
+export const BLOG_LINK = {
+    label: 'Blog',
+    href: 'https://blog.openadapt.ai',
+}
+
+export const DEVELOPER_LINKS = [
+    {
+        label: 'Engine source',
+        href: 'https://github.com/OpenAdaptAI/OpenAdapt',
+    },
+    {
+        label: 'Docs',
+        href: 'https://docs.openadapt.ai',
+    },
+    {
+        label: 'Technical paper source',
+        href: 'https://github.com/OpenAdaptAI/openadapt-flow/tree/main/paper',
+    },
+    {
+        label: 'Discord',
+        href: 'https://discord.gg/yF527cQbDG',
+    },
+    {
+        label: 'Report an issue',
+        href: 'https://github.com/OpenAdaptAI/openadapt-flow/issues/new/choose',
+    },
+]

--- a/tests/howItWorksIndustryPanels.test.js
+++ b/tests/howItWorksIndustryPanels.test.js
@@ -137,7 +137,11 @@ test('primary navigation exposes Insurance and collapses before links crowd', ()
     const css = read('components/NavHeader.module.css')
 
     assert.match(nav, /label: 'Insurance', href: '\/solutions\/insurance'/)
-    assert.match(css, /@media \(max-width: 1120px\)/)
+    // 1200px: the twelve-item nav (Blog + Developers dropdown included)
+    // collapses to the mobile menu before links crowd, while the
+    // 1280px-wide desktop contract in cypress/e2e/basic.cy.js still
+    // sees the full link row.
+    assert.match(css, /@media \(max-width: 1200px\)/)
     assert.match(css, /max-height: calc\(100vh - 60px\)/)
     assert.match(css, /overflow-y: auto/)
     assert.match(css, /@media \(max-width: 420px\)/)

--- a/tests/navContract.test.js
+++ b/tests/navContract.test.js
@@ -1,0 +1,61 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+const read = (relative) =>
+    fs.readFileSync(path.join(process.cwd(), relative), 'utf8')
+
+const links = read('data/developerLinks.js')
+const nav = read('components/NavHeader.js')
+const developers = read('components/Developers.js')
+
+test('developer ecosystem links have a single canonical source', () => {
+    // Canonical destinations live in data/developerLinks.js only.
+    assert.match(links, /https:\/\/blog\.openadapt\.ai/)
+    for (const [label, href] of [
+        ['Engine source', 'https://github.com/OpenAdaptAI/OpenAdapt'],
+        ['Docs', 'https://docs.openadapt.ai'],
+        [
+            'Technical paper source',
+            'https://github.com/OpenAdaptAI/openadapt-flow/tree/main/paper',
+        ],
+        ['Discord', 'https://discord.gg/yF527cQbDG'],
+        [
+            'Report an issue',
+            'https://github.com/OpenAdaptAI/openadapt-flow/issues/new/choose',
+        ],
+    ]) {
+        assert.match(links, new RegExp(`label: '${label}'`))
+        assert.ok(links.includes(`href: '${href}'`), `${label} → ${href}`)
+    }
+
+    // Both surfaces consume the shared module rather than restating hrefs.
+    for (const source of [nav, developers]) {
+        assert.match(
+            source,
+            /import \{ BLOG_LINK, DEVELOPER_LINKS \} from 'data\/developerLinks'/
+        )
+    }
+    assert.doesNotMatch(developers, /https:\/\/docs\.openadapt\.ai/)
+    assert.doesNotMatch(nav, /https:\/\/docs\.openadapt\.ai/)
+})
+
+test('top navigation exposes Blog, a Developers dropdown, and Open source', () => {
+    // Blog is a top-level external item sourced from the shared module.
+    assert.match(nav, /label: BLOG_LINK\.label, href: BLOG_LINK\.href/)
+
+    // The Developers dropdown nests the developer ecosystem links.
+    assert.match(nav, /label: 'Developers', dropdown: DEVELOPER_LINKS/)
+    assert.match(nav, /aria-expanded=\{open\}/)
+    assert.match(nav, /aria-controls="nav-developers-menu"/)
+    assert.match(nav, /case 'Escape':/)
+    assert.match(nav, /case 'ArrowDown':/)
+    assert.match(nav, /addEventListener\('pointerdown', onPointerDown\)/)
+
+    // Open source stays top-level and keeps pointing at the flagship repo.
+    assert.match(
+        nav,
+        /label: 'Open source',\s+href: 'https:\/\/github\.com\/OpenAdaptAI\/OpenAdapt'/
+    )
+})


### PR DESCRIPTION
## What

Upgrades the openadapt.ai top navigation so the developer ecosystem is reachable without scrolling to the lower-page open-source section:

- **Blog** becomes a top-level external nav item → https://blog.openadapt.ai
- A new nested **Developers ▾** dropdown surfaces the links from the page's Developers section:
  - Engine source → https://github.com/OpenAdaptAI/OpenAdapt
  - Docs → https://docs.openadapt.ai
  - Technical paper source → https://github.com/OpenAdaptAI/openadapt-flow/tree/main/paper
  - Discord → https://discord.gg/yF527cQbDG
  - Report an issue → https://github.com/OpenAdaptAI/openadapt-flow/issues/new/choose
  - (Blog is top-level, so it is intentionally **not** duplicated inside the dropdown)
- **Open source** stays top-level, unchanged, pointing at the flagship OpenAdapt repo.
- Canonical hrefs now live in `data/developerLinks.js`, imported by both `NavHeader.js` and `Developers.js`, so the nav and the on-page section can never drift apart. The on-page Developers section renders exactly as before.

## Dropdown behavior

- Matches the design system: `--panel` surface, `--hairline` border, `--ink`/`--accent` link colors, same 13.5px nav type.
- Opens on **hover and click**. A hover-opened panel is *pinned* by a click instead of toggled shut — this also makes it work on touch devices, where the synthetic hover always precedes the tap's click.
- Closes on **Escape** (focus returns to the trigger), **outside pointer press**, **tab-out**, **mouse leave** (hover-opened only), and **route change**.
- Keyboard accessible: focusable `<button>` trigger with `aria-expanded`/`aria-haspopup`/`aria-controls`; ArrowDown/ArrowUp open the panel and cycle focus through items; Tab walks through items.
- An invisible hover bridge spans the 10px gap between trigger and panel so hover survives the traversal.

## Mobile

No new mobile system — the dropdown integrates with the existing hamburger panel: it renders in place as a flat, labeled **DEVELOPERS** group using the existing `mobileLink` styling (dividers preserved around the group), and Blog appears as a regular mobile link. The desktop row now collapses to the hamburger at **1200px** (was 1120px) so the twelve-item row never crowds; the 1280px-wide desktop contract still sees the full row.

## Tests

- `cypress/e2e/basic.cy.js`: new desktop contract — Blog href, trigger `aria-expanded` toggling, all five dropdown hrefs, no Blog duplication, close on Escape and on outside click; mobile-menu contract extended with Blog + the Developers group hrefs.
- `tests/navContract.test.js` (new): pins the canonical link source and the nav structure at source level.
- `tests/howItWorksIndustryPanels.test.js`: breakpoint pin updated 1120 → 1200 with rationale.

## Verification

- `npm test`: 62/62 pass
- `npm run build`: green
- Full Cypress suite against `next start` (CI-identical): 20/20 pass, including desktop (1280×900) and mobile (375×667 / 1024×768) viewports
- Screenshot-verified the open dropdown at 1440×900 and the mobile panel at 375×667

🤖 Generated with [Claude Code](https://claude.com/claude-code)
