### PR TITLE
feat(nav): consolidate the top-level information architecture

### DIFF
--- a/components/NavHeader.js
+++ b/components/NavHeader.js
@@ -15,21 +15,43 @@ const externalEvent = (href) => {
     return null
 }
 
-const NAV_LINKS = [
+const isExternal = (href) => /^https?:\/\//.test(href)
+
+const SOLUTIONS_LINKS = [
     { label: 'Healthcare', href: '/solutions/healthcare' },
     { label: 'Lending', href: '/solutions/lending' },
     { label: 'Insurance', href: '/solutions/insurance' },
+]
+
+const PRODUCT_LINKS = [
+    { label: 'How it runs', href: '/#product-status' },
     { label: 'Safety', href: '/safety' },
     { label: 'Compare', href: '/compare' },
-    { label: 'How it runs', href: '/#product-status' },
+    { label: 'Templates', href: '/templates' },
     { label: 'Download', href: '/download' },
+]
+
+const NAV_LINKS = [
+    {
+        label: 'Solutions',
+        dropdown: SOLUTIONS_LINKS,
+        menuId: 'nav-solutions-menu',
+        align: 'left',
+    },
+    {
+        label: 'Product',
+        dropdown: PRODUCT_LINKS,
+        menuId: 'nav-product-menu',
+        align: 'left',
+    },
     { label: 'Launch', href: '/#pricing' },
-    { label: 'About', href: '/about' },
     { label: BLOG_LINK.label, href: BLOG_LINK.href, external: true },
-    // Rendered as the nested "Developers" dropdown (desktop) or a
-    // labeled group (mobile). Blog is already top-level, so the
-    // dropdown carries the remaining developer ecosystem links.
-    { label: 'Developers', dropdown: DEVELOPER_LINKS },
+    {
+        label: 'Developers',
+        dropdown: DEVELOPER_LINKS,
+        menuId: 'nav-developers-menu',
+        align: 'right',
+    },
     {
         label: 'Open source',
         href: 'https://github.com/OpenAdaptAI/OpenAdapt',
@@ -54,7 +76,24 @@ function ExternalNavLink({ item, className, location }) {
     )
 }
 
-function DevelopersDropdown({ links }) {
+function DropdownLink({ item, className, location }) {
+    if (isExternal(item.href)) {
+        return (
+            <ExternalNavLink
+                item={item}
+                className={className}
+                location={location}
+            />
+        )
+    }
+    return (
+        <Link href={item.href} className={className}>
+            {item.label}
+        </Link>
+    )
+}
+
+function NavDropdown({ label, links, menuId, align }) {
     const [open, setOpen] = useState(false)
     const rootRef = useRef(null)
     const triggerRef = useRef(null)
@@ -182,6 +221,11 @@ function DevelopersDropdown({ links }) {
         }
     }
 
+    const panelClassName =
+        align === 'left'
+            ? `${styles.dropdownPanel} ${styles.dropdownPanelLeft}`
+            : styles.dropdownPanel
+
     return (
         <div
             ref={rootRef}
@@ -197,10 +241,10 @@ function DevelopersDropdown({ links }) {
                 className={styles.dropdownTrigger}
                 aria-expanded={open}
                 aria-haspopup="true"
-                aria-controls="nav-developers-menu"
+                aria-controls={menuId}
                 onClick={onTriggerClick}
             >
-                Developers
+                {label}
                 <span className={styles.caret} aria-hidden="true">
                     ▾
                 </span>
@@ -208,16 +252,16 @@ function DevelopersDropdown({ links }) {
             {open && (
                 <div
                     ref={panelRef}
-                    id="nav-developers-menu"
-                    className={styles.dropdownPanel}
-                    aria-label="Developers"
+                    id={menuId}
+                    className={panelClassName}
+                    aria-label={label}
                 >
                     {links.map((item) => (
-                        <ExternalNavLink
+                        <DropdownLink
                             key={item.label}
                             item={item}
                             className={styles.dropdownItem}
-                            location="nav_developers"
+                            location={`nav_${label.toLowerCase()}`}
                         />
                     ))}
                 </div>
@@ -236,7 +280,13 @@ export default function NavHeader() {
     }, [router.asPath])
 
     return (
-        <header className={styles.header}>
+        <header
+            className={
+                menuOpen
+                    ? `${styles.header} ${styles.headerMenuOpen}`
+                    : styles.header
+            }
+        >
             <div className={styles.inner}>
                 <Link href="/" className={styles.wordmark}>
                     <span className="font-extralight">Open</span>
@@ -246,9 +296,12 @@ export default function NavHeader() {
                     {NAV_LINKS.map((item) => {
                         if (item.dropdown) {
                             return (
-                                <DevelopersDropdown
+                                <NavDropdown
                                     key={item.label}
+                                    label={item.label}
                                     links={item.dropdown}
+                                    menuId={item.menuId}
+                                    align={item.align}
                                 />
                             )
                         }
@@ -298,8 +351,8 @@ export default function NavHeader() {
                 >
                     {NAV_LINKS.map((item) => {
                         if (item.dropdown) {
-                            // The mobile panel is a flat list, so the
-                            // dropdown renders as a labeled group in place.
+                            // Each desktop dropdown becomes a labeled
+                            // group in the mobile panel.
                             return (
                                 <div
                                     key={item.label}
@@ -312,11 +365,11 @@ export default function NavHeader() {
                                         {item.label}
                                     </span>
                                     {item.dropdown.map((link) => (
-                                        <ExternalNavLink
+                                        <DropdownLink
                                             key={link.label}
                                             item={link}
                                             className={styles.mobileLink}
-                                            location="nav_mobile_developers"
+                                            location={`nav_mobile_${item.label.toLowerCase()}`}
                                         />
                                     ))}
                                 </div>

--- a/components/NavHeader.module.css
+++ b/components/NavHeader.module.css
@@ -1,6 +1,8 @@
 .header {
     position: sticky;
     top: 0;
+    left: 0;
+    width: 100%;
     z-index: 100;
     background: var(--panel);
     border-bottom: 1px solid var(--hairline);
@@ -96,6 +98,11 @@
     box-shadow: 0 10px 24px rgba(35, 40, 31, 0.08);
 }
 
+.dropdownPanelLeft {
+    left: -12px;
+    right: auto;
+}
+
 /* Invisible bridge over the 10px gap so hover survives the traversal
    from the trigger down into the panel. */
 .dropdownPanel::before {
@@ -159,9 +166,14 @@
     display: none;
 }
 
-/* The twelve-item desktop navigation (with Blog and the Developers
-   dropdown) no longer fits reliably below laptop widths. */
+/* Collapse before the navigation and CTA can crowd the wordmark. */
 @media (max-width: 1200px) {
+    .headerMenuOpen {
+        position: fixed;
+        inset: 0 0 auto;
+        width: 100%;
+    }
+
     .links {
         display: none;
     }
@@ -179,7 +191,10 @@
         display: flex;
         flex-direction: column;
         max-height: calc(100vh - 60px);
+        overscroll-behavior: contain;
         overflow-y: auto;
+        overflow-x: hidden;
+        scrollbar-gutter: stable;
         background: var(--panel);
         border-bottom: 1px solid var(--hairline);
         padding: 6px 16px 12px;
@@ -216,8 +231,7 @@
         padding: 12px 0 2px;
     }
 
-    /* Links inside the Developers group keep their divider even when
-       they are the group's last child, because more items follow. */
+    /* Group links retain their divider because more items follow. */
     .mobileGroup .mobileLink:last-child {
         border-bottom: 1px dotted var(--hairline-dotted);
     }
@@ -227,19 +241,24 @@
     .inner {
         gap: 8px;
         padding: 0 10px;
+        min-width: 0;
     }
 
     .wordmark {
         font-size: 17px;
+        flex: 0 1 auto;
+        min-width: 0;
     }
 
     .menuButton {
         padding: 6px 8px;
         font-size: 11px;
+        flex: 0 0 auto;
     }
 
     .cta {
         padding: 7px 11px;
         font-size: 12px;
+        flex: 0 0 auto;
     }
 }

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -41,9 +41,13 @@ describe('public product truth', () => {
         cy.get('a[href$="#open-source"]').should('exist')
         cy.get('a[href$="#product-status"]').should('exist')
         cy.get('a[href="/security"]').should('exist')
-        cy.get('nav[aria-label="Primary"]')
-            .find('a[href="/solutions/insurance"]')
-            .should('be.visible')
+        cy.get('nav[aria-label="Primary"]').within(() => {
+            cy.contains('button', 'Solutions').click()
+            cy.get('#nav-solutions-menu')
+                .find('a[href="/solutions/insurance"]')
+                .should('be.visible')
+        })
+        cy.get('h1').click()
         cy.get('[data-testid="github-proof"]')
             .should('have.attr', 'href', 'https://github.com/OpenAdaptAI/OpenAdapt')
         cy.get('[data-testid="github-proof"]')
@@ -51,20 +55,71 @@ describe('public product truth', () => {
             .and('contain.text', 'forks')
     })
 
-    it('surfaces Blog and the Developers dropdown in the primary nav', () => {
+    it('surfaces a concise, keyboard-accessible primary navigation', () => {
+        // A pointer hover may open a dropdown before the ensuing
+        // click. The click pins it open, including for touch browsers
+        // that synthesize hover events before click.
+        cy.contains('button', 'Solutions').trigger('mouseover')
+        cy.get('#nav-solutions-menu').should('be.visible')
+        cy.contains('button', 'Solutions').click().trigger('mouseout')
+        cy.get('#nav-solutions-menu').should('be.visible')
+        cy.get('h1').click()
+        cy.get('#nav-solutions-menu').should('not.exist')
+
+        // ArrowDown opens the menu and focuses its first item; focus
+        // moving outside the dropdown dismisses it.
+        cy.contains('button', 'Product').focus().type('{downarrow}')
+        cy.get('#nav-product-menu a').first().should('be.focused')
+        cy.focused().type('{downarrow}')
+        cy.get('#nav-product-menu a').eq(1).should('be.focused')
+        cy.contains('nav[aria-label="Primary"] a', 'Launch').focus()
+        cy.get('#nav-product-menu').should('not.exist')
+
         cy.get('nav[aria-label="Primary"]').within(() => {
+            cy.contains('a', 'Launch')
+                .should('be.visible')
+                .and('have.attr', 'href', '/#pricing')
             cy.contains('a', 'Blog')
                 .should('be.visible')
                 .and('have.attr', 'href', 'https://blog.openadapt.ai')
             cy.contains('a', 'Open source')
                 .should('be.visible')
                 .and('have.attr', 'href', 'https://github.com/OpenAdaptAI/OpenAdapt')
+            cy.contains('a', 'About').should('not.exist')
+
+            cy.contains('button', 'Solutions')
+                .should('be.visible')
+                .and('have.attr', 'aria-expanded', 'false')
+            cy.contains('button', 'Solutions').click()
+            cy.get('#nav-solutions-menu').within(() => {
+                cy.contains('a', 'Healthcare')
+                    .should('have.attr', 'href', '/solutions/healthcare')
+                cy.contains('a', 'Lending')
+                    .should('have.attr', 'href', '/solutions/lending')
+                cy.contains('a', 'Insurance')
+                    .should('have.attr', 'href', '/solutions/insurance')
+            })
+
+            cy.contains('button', 'Product').click()
+            cy.get('#nav-solutions-menu').should('not.exist')
+            cy.get('#nav-product-menu').within(() => {
+                cy.contains('a', 'How it runs')
+                    .should('have.attr', 'href', '/#product-status')
+                cy.contains('a', 'Safety')
+                    .should('have.attr', 'href', '/safety')
+                cy.contains('a', 'Compare')
+                    .should('have.attr', 'href', '/compare')
+                cy.contains('a', 'Templates')
+                    .should('have.attr', 'href', '/templates')
+                cy.contains('a', 'Download')
+                    .should('have.attr', 'href', '/download')
+            })
+
             cy.contains('button', 'Developers')
                 .should('be.visible')
                 .and('have.attr', 'aria-expanded', 'false')
-            cy.get('#nav-developers-menu').should('not.exist')
-
             cy.contains('button', 'Developers').click()
+            cy.get('#nav-product-menu').should('not.exist')
             cy.contains('button', 'Developers').should(
                 'have.attr',
                 'aria-expanded',
@@ -103,7 +158,7 @@ describe('public product truth', () => {
             })
         })
 
-        // Escape closes the dropdown.
+        // Escape closes and returns focus to the trigger.
         cy.contains('button', 'Developers').type('{esc}')
         cy.get('#nav-developers-menu').should('not.exist')
         cy.contains('button', 'Developers').should(
@@ -111,6 +166,7 @@ describe('public product truth', () => {
             'aria-expanded',
             'false'
         )
+        cy.contains('button', 'Developers').should('be.focused')
 
         // Reopen, then a click outside the dropdown closes it.
         cy.contains('button', 'Developers').click()
@@ -181,17 +237,41 @@ describe('public product truth', () => {
     it('keeps deployment and launch routes reachable on mobile', () => {
         cy.viewport(375, 667)
         cy.visit('/')
+        cy.get('header').then(($header) => {
+            expect($header[0].getBoundingClientRect().left).to.equal(0)
+        })
         cy.get('button[aria-controls="nav-mobile-menu"]').click()
+        cy.get('#nav-mobile-menu').should('be.visible')
         cy.get('#nav-mobile-menu').within(() => {
-            cy.contains('Insurance')
+            cy.contains('Solutions').scrollIntoView().should('be.visible')
+            cy.contains('a', 'Healthcare')
+                .should('have.attr', 'href')
+                .and('equal', '/solutions/healthcare')
+            cy.contains('a', 'Lending')
+                .should('have.attr', 'href')
+                .and('equal', '/solutions/lending')
+            cy.contains('a', 'Insurance')
                 .should('have.attr', 'href')
                 .and('equal', '/solutions/insurance')
-            cy.contains('How it runs').should(
+            cy.contains('Product').scrollIntoView().should('be.visible')
+            cy.contains('a', 'How it runs').should(
                 'have.attr',
                 'href',
                 '/#product-status'
             )
-            cy.contains('Launch').should('have.attr', 'href', '/#pricing')
+            cy.contains('a', 'Safety')
+                .should('have.attr', 'href')
+                .and('equal', '/safety')
+            cy.contains('a', 'Compare')
+                .should('have.attr', 'href')
+                .and('equal', '/compare')
+            cy.contains('a', 'Templates')
+                .should('have.attr', 'href')
+                .and('equal', '/templates')
+            cy.contains('a', 'Download')
+                .should('have.attr', 'href')
+                .and('equal', '/download')
+            cy.contains('a', 'Launch').should('have.attr', 'href', '/#pricing')
             cy.contains('a', 'Blog')
                 .should('have.attr', 'href')
                 .and('equal', 'https://blog.openadapt.ai')
@@ -223,11 +303,19 @@ describe('public product truth', () => {
                 .should('have.attr', 'href')
                 .and('equal', 'https://github.com/OpenAdaptAI/OpenAdapt')
         })
+        cy.get('#nav-mobile-menu').then(($menu) => {
+            expect($menu[0].scrollHeight).to.be.greaterThan(
+                $menu[0].clientHeight
+            )
+        })
+        cy.document().then((document) => {
+            expect(document.documentElement.scrollWidth).to.be.at.most(375)
+        })
 
         cy.viewport(1024, 768)
         cy.visit('/')
         cy.get('nav[aria-label="Primary"]')
-            .find('a[href="/solutions/insurance"]')
+            .contains('button', 'Solutions')
             .should('not.be.visible')
         cy.get('button[aria-controls="nav-mobile-menu"]')
             .should('be.visible')

--- a/tests/navContract.test.js
+++ b/tests/navContract.test.js
@@ -9,6 +9,7 @@ const read = (relative) =>
 const links = read('data/developerLinks.js')
 const nav = read('components/NavHeader.js')
 const developers = read('components/Developers.js')
+const footer = read('components/Footer.js')
 
 test('developer ecosystem links have a single canonical source', () => {
     // Canonical destinations live in data/developerLinks.js only.
@@ -41,21 +42,66 @@ test('developer ecosystem links have a single canonical source', () => {
     assert.doesNotMatch(nav, /https:\/\/docs\.openadapt\.ai/)
 })
 
-test('top navigation exposes Blog, a Developers dropdown, and Open source', () => {
-    // Blog is a top-level external item sourced from the shared module.
+test('top navigation consolidates solutions, product and developer destinations', () => {
+    for (const [label, href] of [
+        ['Healthcare', '/solutions/healthcare'],
+        ['Lending', '/solutions/lending'],
+        ['Insurance', '/solutions/insurance'],
+    ]) {
+        assert.ok(
+            nav.includes(`{ label: '${label}', href: '${href}' }`),
+            `Solutions carries ${label} → ${href}`
+        )
+    }
+    assert.match(nav, /dropdown: SOLUTIONS_LINKS/)
+
+    for (const [label, href] of [
+        ['How it runs', '/#product-status'],
+        ['Safety', '/safety'],
+        ['Compare', '/compare'],
+        ['Templates', '/templates'],
+        ['Download', '/download'],
+    ]) {
+        assert.ok(
+            nav.includes(`{ label: '${label}', href: '${href}' }`),
+            `Product carries ${label} → ${href}`
+        )
+    }
+    assert.match(nav, /dropdown: PRODUCT_LINKS/)
+
+    assert.match(nav, /\{ label: 'Launch', href: '\/#pricing' \}/)
     assert.match(nav, /label: BLOG_LINK\.label, href: BLOG_LINK\.href/)
 
-    // The Developers dropdown nests the developer ecosystem links.
-    assert.match(nav, /label: 'Developers', dropdown: DEVELOPER_LINKS/)
-    assert.match(nav, /aria-expanded=\{open\}/)
-    assert.match(nav, /aria-controls="nav-developers-menu"/)
-    assert.match(nav, /case 'Escape':/)
-    assert.match(nav, /case 'ArrowDown':/)
-    assert.match(nav, /addEventListener\('pointerdown', onPointerDown\)/)
-
-    // Open source stays top-level and keeps pointing at the flagship repo.
+    assert.match(nav, /label: 'Developers',\s+dropdown: DEVELOPER_LINKS/)
     assert.match(
         nav,
         /label: 'Open source',\s+href: 'https:\/\/github\.com\/OpenAdaptAI\/OpenAdapt'/
     )
+
+    assert.doesNotMatch(nav, /'\/about'/)
+    assert.match(footer, /href="\/about"/)
+})
+
+test('all dropdowns share the same keyboard, pointer and ARIA behavior', () => {
+    assert.equal(
+        nav.match(/aria-haspopup="true"/g).length,
+        1,
+        'one reusable dropdown trigger implementation'
+    )
+    assert.match(nav, /function NavDropdown\(\{ label, links, menuId, align \}\)/)
+    for (const menuId of [
+        'nav-solutions-menu',
+        'nav-product-menu',
+        'nav-developers-menu',
+    ]) {
+        assert.ok(nav.includes(`menuId: '${menuId}'`), menuId)
+    }
+
+    assert.match(nav, /aria-expanded=\{open\}/)
+    assert.match(nav, /aria-controls=\{menuId\}/)
+    assert.match(nav, /case 'Escape':/)
+    assert.match(nav, /case 'ArrowDown':/)
+    assert.match(nav, /case 'ArrowUp':/)
+    assert.match(nav, /addEventListener\('pointerdown', onPointerDown\)/)
+    assert.match(nav, /mobileGroupLabel/)
 })


### PR DESCRIPTION
## Outcome

- reduces the desktop header to Solutions, Product, Launch, Blog, Developers, Open source, and the pilot CTA
- groups Healthcare/Lending/Insurance under Solutions
- groups How it runs/Safety/Compare/Templates/Download under Product
- keeps all developer links in their canonical dropdown and About in the footer
- preserves touch click-pinning, keyboard navigation, focus dismissal, Escape, and ARIA state
- fixes 375px sticky-header displacement and gives the mobile menu bounded independent scrolling

## Verification

- 64/64 unit tests passed
- production build passed
- 22/22 full Cypress tests passed
- 15/15 focused navigation Cypress tests passed
- desktop 1440x900 and mobile 375x667 visually inspected
- verified zero browser api.github.com requests
- git diff --check passed