### PR TITLE
fix(site): keep reference footage animating after a reference tab click

### DIFF
--- a/components/DashboardShowcase.js
+++ b/components/DashboardShowcase.js
@@ -476,12 +476,30 @@ export default function DashboardShowcase() {
                                 </article>
 
                                 <div className={styles.referenceMedia}>
+                                    {/*
+                                     * Reference footage follows the same
+                                     * mechanism as the How-it-works Clips: an
+                                     * <img> pointed DIRECTLY at the animated
+                                     * GIF, which always plays and loops via
+                                     * the GIF's own loop flag. Footage
+                                     * playback is deliberately independent of
+                                     * the guided-tour state: selecting a
+                                     * reference or view pauses the tour, and
+                                     * an earlier version also swapped this
+                                     * src to the static .jpg still — freezing
+                                     * the footage after any tab click. Only
+                                     * prefers-reduced-motion shows the still.
+                                     * The key remounts the <img> per
+                                     * reference/view so a newly selected
+                                     * reference restarts from its first
+                                     * frame.
+                                     */}
                                     <img
-                                        key={`${reference.key}-${viewKey}-${tourPlaying}`}
+                                        key={`${reference.key}-${viewKey}`}
                                         src={
-                                            tourPlaying
-                                                ? media.animated
-                                                : media.still
+                                            reducedMotion
+                                                ? media.still
+                                                : media.animated
                                         }
                                         width="880"
                                         height="550"

--- a/cypress/e2e/dashboard-showcase.cy.js
+++ b/cypress/e2e/dashboard-showcase.cy.js
@@ -95,9 +95,12 @@ describe('Cloud product preview', () => {
                 .should('have.attr', 'aria-pressed', 'true')
             cy.contains('h4', 'Independent readback').should('be.visible')
             cy.contains('dt', 'SQL delta').should('be.visible')
+            // Footage keeps playing (animated GIF) even though selecting a
+            // reference/view pauses the guided tour — only reduced motion
+            // shows the static still.
             cy.get('[data-testid="dashboard-reference-media"]')
                 .should('have.attr', 'src')
-                .and('include', '/lending-demo/replay-frappe.jpg')
+                .and('include', '/lending-demo/replay-frappe.gif')
             cy.contains('button', 'Play tour').click()
             cy.get('[data-reference="lending"]').should(
                 'have.attr',

--- a/tests/dashboardShowcase.test.js
+++ b/tests/dashboardShowcase.test.js
@@ -43,6 +43,29 @@ test('homepage shows a code-native interactive Cloud preview', () => {
     assert.doesNotMatch(component, /mediaLabel/)
 })
 
+test('reference footage animates independently of the guided-tour state', () => {
+    const component = read('components/DashboardShowcase.js')
+
+    // Regression guard: an earlier version swapped the footage <img> to the
+    // static .jpg still whenever the tour was paused — and selecting any
+    // reference tab pauses the tour, so one click froze the footage. The GIF
+    // must be gated only on prefers-reduced-motion.
+    assert.match(
+        component,
+        /reducedMotion\s*\?\s*media\.still\s*:\s*media\.animated/
+    )
+    assert.doesNotMatch(
+        component,
+        /tourPlaying\s*\?\s*media\.animated\s*:\s*media\.still/
+    )
+    // Switching reference/view remounts the <img> so the newly selected
+    // footage restarts from its first frame.
+    assert.match(
+        component,
+        /key=\{`\$\{reference\.key\}-\$\{viewKey\}`\}/
+    )
+})
+
 test('dashboard preview reuses the three reference applications and provenance-backed media', () => {
     const component = read('components/DashboardShowcase.js')
     const howItWorks = JSON.parse(


### PR DESCRIPTION
## Problem

On the live homepage, the OpenEMR / Frappe Lending / openIMIS reference footage in the **Cloud product preview** section freezes to a static image the moment a visitor clicks any reference tab (or any Workflow/Run/Evidence/Report view tab), while the How-it-works section's footage keeps playing.

## Root cause (honest attribution)

**Not a #212 regression.** PR #212 (`feat/wow-factor-polish`) did not touch `DashboardShowcase`, and the reference GIF assets themselves are fine (multi-frame, infinite-loop `NETSCAPE2.0` extension, byte-identical between repo and production CDN).

The behavior shipped in **PR #211** (`54a5ec8`, which rewrote the Cloud preview into the three-reference interactive tour). It gated the footage `src` on the guided-tour state:

```js
src={tourPlaying ? media.animated : media.still}
```

and both `selectReference()` and `selectView()` call `setPlaying(false)`. So the section animates on first load (tour auto-playing), but **one click on any tab swaps the footage to its static `.jpg` still permanently** unless the visitor notices the small "Play tour" control. The Cypress spec even asserted the `.jpg` swap, encoding the bug as expected behavior.

By contrast, the How-it-works Clips (per the long-standing comment in `components/Clip.js`, from #163) point an `<img>` directly at the animated GIF with no gating — a GIF in an `<img>` always animates and loops by its own loop flag.

## Fix

`DashboardShowcase` footage now uses the same mechanism as the working sections:

- `<img>` always points at the animated GIF; it plays and loops regardless of tour state (no new dependencies, no observers).
- `prefers-reduced-motion` still shows the labeled static `.jpg` still (unchanged fallback, verified by the existing reduced-motion Cypress test).
- The `<img>` is keyed on `reference.key + viewKey`, so switching to a new reference (or view) remounts it and the newly selected footage **restarts from its first frame**.
- The guided tour (auto-advancing views) still pauses on interaction — only the footage playback is decoupled.
- All honesty labels and captions ("Real … reference footage", "Reference workflows using synthetic records", etc.) are unchanged.

## Tests

- `tests/dashboardShowcase.test.js`: new truth test guarding against re-gating footage on tour state and asserting the restart key. **68/68 unit tests pass** (publicTruth untouched).
- `cypress/e2e/dashboard-showcase.cy.js`: the assertion that expected the frozen `.jpg` after a tab click now expects the animated `.gif`; the reduced-motion `.jpg` assertions are unchanged.
- `npm run build` green; **full Cypress suite 30/30 green** against the production build (`next start`). (Note for reproducers: a stale `next-server` from an earlier session was squatting on port 3000 serving an old build — run against a fresh `next start` port.)
- The #212 Reveal fail-open-under-Cypress behavior is untouched.

## Before / after

- Before: load homepage → footage animates → click "Lending · Frappe Lending" → footage renders as a static screenshot.
- After: click any reference tab → that reference's GIF footage starts playing from its beginning and loops; reduced-motion users keep the static still.

🤖 Generated with [Claude Code](https://claude.com/claude-code)