### PR TITLE
docs: align pricing page title with house style

### DIFF
--- a/pages/pricing.js
+++ b/pages/pricing.js
@@ -14,13 +14,13 @@ export default function PricingPage({ hostedOffer }) {
     return (
         <div className="min-h-screen bg-ground text-ink">
             <Head>
-                <title>Availability and commercial status | OpenAdapt.AI</title>
+                <title>Pricing | OpenAdapt</title>
                 <meta
                     name="description"
                     content="Launch OpenAdapt with the MIT engine, managed hosted browser execution, or a scoped customer-controlled deployment."
                 />
                 <link rel="canonical" href="https://openadapt.ai/pricing" />
-                <meta property="og:title" content="Availability and commercial status | OpenAdapt.AI" />
+                <meta property="og:title" content="Pricing | OpenAdapt" />
                 <meta
                     property="og:description"
                     content="OpenAdapt launch options: self-host the MIT engine, qualify managed browser execution, or scope a regulated deployment."


### PR DESCRIPTION
Part of the 2026-07-19 cross-surface copy-consistency review (`.private/copy_consistency_audit_2026_07_19.md`).

`/pricing` was titled **"Availability and commercial status | OpenAdapt.AI"** while every other product page uses the **"… | OpenAdapt"** suffix. Renames to **"Pricing | OpenAdapt"** (title + og:title only), which also names the page for what it is. No pinned publicTruth strings touched; `node --test tests/*.test.js` passes 72/72.