### PR TITLE
docs: converge site copy on canonical terminology and add honesty hedges

### DIFF
--- a/components/DriftOutcomes.js
+++ b/components/DriftOutcomes.js
@@ -55,7 +55,7 @@ export default function DriftOutcomes() {
                     ))}
                 </div>
                 <p className="mx-auto mt-6 max-w-3xl text-center text-xs leading-relaxed text-ink-3">
-                    Availability and refusal depend on recorded evidence and
+                    Availability and refusal depend on retained evidence and
                     configuration. Identity checks cover armed steps only;
                     system-of-record verification requires declared effects and
                     a configured verifier.{' '}

--- a/components/Faq.js
+++ b/components/Faq.js
@@ -1,7 +1,7 @@
 export const faqItems = [
     {
         question: 'What is OpenAdapt?',
-        answer: 'OpenAdapt is an open-source governed compiler for repeated GUI work. You demonstrate a task, it compiles the trace into a deterministic local program, and configured verification decides whether UI drift can be re-resolved, needs a proposed repair, or must halt. A healthy replay makes no model calls.',
+        answer: 'OpenAdapt is an open-source governed workflow compiler for repeated GUI work. You demonstrate a task, it compiles the trace into a deterministic local program, and configured verification decides whether UI drift can be re-resolved, needs a proposed repair, or must halt. A healthy replay makes no model calls.',
     },
     {
         question: 'How is OpenAdapt different from RPA tools like UiPath?',

--- a/components/InstallSection.js
+++ b/components/InstallSection.js
@@ -44,8 +44,8 @@ export default function InstallSection() {
             </div>
 
             <p className={styles.subtitle}>
-                One command installs the OpenAdapt launcher and governed compiler.
-                No account or hosted service is required.
+                One command installs the OpenAdapt launcher and governed
+                workflow compiler. No account or hosted service is required.
             </p>
 
             <div className={styles.codeContainer}>
@@ -130,7 +130,9 @@ export default function InstallSection() {
                         <span>
                             The clinical gate refuses this demo bundle and
                             exits non-zero — on purpose. Safeguards refuse
-                            instead of guessing.
+                            instead of guessing. Re-run with{' '}
+                            <code>--policy permissive</code> to see a clean
+                            pass.
                         </span>
                     </div>
                     <div className={styles.commandItem}>

--- a/components/MastHead.js
+++ b/components/MastHead.js
@@ -56,13 +56,16 @@ export default function Home({ githubStats }) {
                                 whose healthy replay makes no model calls. When the
                                 interface changes, OpenAdapt re-resolves from
                                 retained evidence, proposes a governed repair, or
-                                stops for an operator.
+                                halts for an operator.
                             </p>
                             <p className="mt-0 mb-6 mx-auto max-w-3xl font-sans font-normal text-base md:text-lg text-ink-3">
                                 Use the same compiled workflow model across browser,
                                 Windows, macOS, Linux, RDP, Citrix, and VDI targets,
                                 running locally, through OpenAdapt Cloud, or inside
-                                a customer-controlled boundary.{' '}
+                                a customer-controlled boundary. Browser workflows
+                                are proven today; Windows and macOS are
+                                experimental, and remote-display targets (RDP,
+                                Citrix, VDI) are research-stage.{' '}
                                 <Link href="#product-status">See how deployment works.</Link>
                             </p>
                             <div className="flex flex-col align-center justify-center px-4 min-w-0 max-w-full overflow-hidden">

--- a/data/templates.js
+++ b/data/templates.js
@@ -24,7 +24,7 @@ const FLOW_REPO = 'https://github.com/OpenAdaptAI/openadapt-flow'
 // The canonical end-user quickstart enters through the flagship OpenAdapt
 // package while source links below continue to point to the engine repository.
 const DEMO_QUICKSTART = [
-    { cmd: 'pip install openadapt', what: 'Install the OpenAdapt launcher and governed compiler.' },
+    { cmd: 'pip install openadapt', what: 'Install the OpenAdapt launcher and governed workflow compiler.' },
     { cmd: 'openadapt flow demo-record --out rec', what: 'Serve the bundled MockMed clinic app locally and record the canonical triage demonstration.' },
     { cmd: 'openadapt flow compile rec --out bundle --name triage-note', what: 'Compile the recording into a deterministic, locally executable bundle.' },
     { cmd: 'openadapt flow lint bundle', what: 'Report the bundle’s coverage gaps — expected: it finds the demo’s unarmed irreversible final click.' },
@@ -33,7 +33,7 @@ const DEMO_QUICKSTART = [
 ]
 
 const RECORD_YOUR_OWN = [
-    { cmd: 'pip install openadapt', what: 'Install the OpenAdapt launcher and governed compiler.' },
+    { cmd: 'pip install openadapt', what: 'Install the OpenAdapt launcher and governed workflow compiler.' },
     { cmd: 'openadapt flow record --url https://your.app --out rec', what: 'Open a headed browser on your app and demonstrate the workflow once; Ctrl-C to finish.' },
     { cmd: 'openadapt flow compile rec --out bundle --name my-task', what: 'Compile the recording into a deterministic bundle with auto-classified risk per step.' },
     { cmd: 'openadapt flow lint bundle && openadapt flow certify bundle --policy permissive', what: 'Surface coverage gaps, then gate the bundle against a policy before it ever deploys.' },

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -67,7 +67,7 @@ export default function MyApp({ Component, pageProps }) {
                 <meta property="og:type" content="website" />
                 <meta property="og:site_name" content="OpenAdapt.AI" />
                 <meta property="og:title" content="OpenAdapt — Governed, deterministic automation for repeated GUI work" />
-                <meta property="og:description" content="Compile a bounded demonstration into local deterministic replay, then resolve, review, or refuse interface drift. MIT licensed." />
+                <meta property="og:description" content="Compile a bounded demonstration into local deterministic replay, then resolve, repair, or halt interface drift. MIT licensed." />
                 <meta property="og:image" content="https://openadapt.ai/og.png" />
                 <meta property="og:image:type" content="image/png" />
                 <meta property="og:image:width" content="1024" />
@@ -78,7 +78,7 @@ export default function MyApp({ Component, pageProps }) {
                 <meta name="twitter:card" content="summary_large_image" />
                 <meta name="twitter:site" content="@OpenAdaptAI" />
                 <meta name="twitter:title" content="OpenAdapt — Governed, deterministic GUI automation" />
-                <meta name="twitter:description" content="Compile a bounded demonstration into local deterministic replay, then resolve, review, or refuse interface drift. MIT licensed." />
+                <meta name="twitter:description" content="Compile a bounded demonstration into local deterministic replay, then resolve, repair, or halt interface drift. MIT licensed." />
                 <meta name="twitter:image" content="https://openadapt.ai/og.png" />
 
             </Head>

--- a/pages/about.js
+++ b/pages/about.js
@@ -16,7 +16,7 @@ const organizationSchema = {
         height: 512,
     },
     description:
-        'MLDSAI Inc. builds OpenAdapt, an open-source demonstration compiler for GUI automation: compile a bounded workflow demonstration into deterministic replay, and resolve, review, or refuse interface drift under configured verification.',
+        'MLDSAI Inc. builds OpenAdapt, an open-source governed workflow compiler for GUI automation: compile a bounded workflow demonstration into deterministic replay, and resolve, repair, or halt interface drift under configured verification.',
     foundingDate: '2023',
     address: {
         '@type': 'PostalAddress',
@@ -59,7 +59,7 @@ export default function AboutPage() {
                 <title>About OpenAdapt | MLDSAI Inc.</title>
                 <meta
                     name="description"
-                    content="OpenAdapt is an open-source governed compiler for repeated GUI workflows, built in the open by MLDSAI Inc. in Toronto since 2023."
+                    content="OpenAdapt is an open-source governed workflow compiler for repeated GUI work, built in the open by MLDSAI Inc. in Toronto since 2023."
                 />
                 <link rel="canonical" href="https://openadapt.ai/about" />
                 <meta property="og:title" content="About OpenAdapt | MLDSAI Inc." />

--- a/pages/index.js
+++ b/pages/index.js
@@ -32,7 +32,7 @@ const organizationSchema = {
         height: 512,
     },
     description:
-        'Open-source governed compiler for repeated GUI work. OpenAdapt turns a recorded demonstration into a deterministic, locally executable workflow, proposes reviewable repairs under drift, and halts when configured verification fails.',
+        'Open-source governed workflow compiler for repeated GUI work. OpenAdapt turns a recorded demonstration into a deterministic, locally executable workflow, proposes reviewable repairs under drift, and halts when configured verification fails.',
     foundingDate: '2023',
     sameAs: [
         'https://github.com/OpenAdaptAI/OpenAdapt',
@@ -60,7 +60,7 @@ const softwareSchema = {
     applicationCategory: 'DeveloperApplication',
     operatingSystem: 'Windows, macOS, Linux (browser workflow path)',
     description:
-        'Open-source governed compiler for repeated GUI work. Record a browser workflow, compile it into a deterministic local program, and use configured verification to resolve, repair, or halt under interface drift.',
+        'Open-source governed workflow compiler for repeated GUI work. Record a browser workflow, compile it into a deterministic local program, and use configured verification to resolve, repair, or halt under interface drift.',
     url: 'https://openadapt.ai',
     downloadUrl: 'https://pypi.org/project/openadapt/',
     author: {
@@ -96,7 +96,7 @@ const websiteSchema = {
     alternateName: 'OpenAdapt',
     url: 'https://openadapt.ai',
     description:
-        'Open-source governed compiler: compile a bounded GUI demonstration into deterministic local replay, and resolve, review, or refuse interface drift.',
+        'Open-source governed workflow compiler: compile a bounded GUI demonstration into deterministic local replay, and resolve, repair, or halt interface drift.',
     publisher: {
         '@type': 'Organization',
         name: 'OpenAdapt.AI',

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,6 +1,6 @@
 # OpenAdapt.AI
 
-> Open-source governed compiler for repeated GUI work. OpenAdapt compiles a bounded demonstration into deterministic local replay. Healthy runs make no model calls. Under UI drift it deterministically re-resolves from retained evidence, optionally proposes a governed repair, accepts human teaching, or halts when configured verification cannot establish a safe path. MIT licensed.
+> Open-source governed workflow compiler for repeated GUI work. OpenAdapt compiles a bounded demonstration into deterministic local replay. Healthy runs make no model calls. Under UI drift it deterministically re-resolves from retained evidence, optionally proposes a governed repair, accepts human teaching, or halts when configured verification cannot establish a safe path. MIT licensed.
 
 ## Documentation
 - [Getting Started](https://docs.openadapt.ai): Installation, quick start, and CLI reference


### PR DESCRIPTION
Applies the openadapt-web-owned items from the 2026-07-19 copy-consistency audit (`.private/copy_consistency_audit_2026_07_19.md`), each **re-verified against current `origin/main`** because several items in the audit were written against stale checkouts.

## What changed (file:location — before → after)

**Canonical product noun → "governed workflow compiler" (audit 1a)**
- `pages/index.js:35,63,99` — "governed compiler" → "governed workflow compiler"
- `pages/about.js:19` — "demonstration compiler for GUI automation" → "governed workflow compiler for GUI automation"; `:62` meta desc "governed compiler for repeated GUI workflows" → "governed workflow compiler for repeated GUI work"
- `components/Faq.js:4` — "governed compiler" → "governed workflow compiler"
- `components/InstallSection.js:47` — "launcher and governed compiler" → "launcher and governed workflow compiler"
- `data/templates.js:27,36` — same
- `public/llms.txt:3` — same

**Retire the "resolve, review, or refuse" drift synonym → canonical "resolve, repair, or halt" (audit 1c / P2-4)**
- `pages/index.js:99`, `pages/about.js:19`, `pages/_app.js:70,81` (OG + Twitter meta)

**Hero maturity hedge (audit F5 / P1-5) + canonical halt verb**
- `components/MastHead.js` — substrate list now appends "Browser workflows are proven today; Windows and macOS are experimental, and remote-display targets (RDP, Citrix, VDI) are research-stage." (audit's recommended wording; matches LIMITS scoping). "stops for an operator" → "halts for an operator".

**Quickstart dead-end hint (audit F1 / P0-1)**
- `components/InstallSection.js` clinical-gate step — appended "Re-run with `--policy permissive` to see a clean pass." (the existing "on purpose" caption already resolved the core dead-end; this adds the missing recovery path).

**Canonical "retained evidence" (audit 1b/P1-2 term)**
- `components/DriftOutcomes.js:58` — "recorded evidence" → "retained evidence"

## Audit items already resolved on main (verified, no change needed)
- **F4 package identity** — public surfaces already use `pip install openadapt` / `pip uninstall openadapt`; publicTruth forbids `pip install openadapt-flow`.
- **P2-8 pricing title** — already "Pricing | OpenAdapt" (#217).
- **P2-3 "Evidence tier" column** — `ProductStatus.js` was redesigned; that column no longer exists.
- **CTA sprawl (1g/P1-6)** — main already converged on "Evaluate a workflow" / "Try locally" / "Read docs" (publicTruth now *forbids* "Qualify a workflow"/"Plan a pilot"). Not reintroduced.
- **F2/F3/F6 connect 1.7+ notes** — `openadapt connect` is not surfaced on web (docs/app lanes).

## publicTruth impact
**None weakened.** No test-pinned string changed; all edits are on unpinned meta/description/marketing copy. Verified none of "governed compiler", "resolve, review", "recorded evidence", or the hero substrate line are asserted in `tests/`.

## Gates
- `npm test` — 72/72 pass
- `npm run build` — clean
- Cypress — all 30 pass (basic, dashboard-showcase, download, link-accessibility, public-surface-coherence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM