### PR TITLE
feat: add /workflows reference catalog (not a marketplace)

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -160,6 +160,9 @@ export default function Footer({ repositoryStats = OPENADAPT_STATS_SNAPSHOT }) {
                         <a href="/solutions/insurance" className={styles.link}>
                             Insurance
                         </a>
+                        <a href="/workflows" className={styles.link}>
+                            Workflows
+                        </a>
                         <a href="/compare" className={styles.link}>
                             Compare
                         </a>

--- a/components/NavHeader.js
+++ b/components/NavHeader.js
@@ -25,6 +25,7 @@ const SOLUTIONS_LINKS = [
 
 const PRODUCT_LINKS = [
     { label: 'How it runs', href: '/#product-status' },
+    { label: 'Workflows', href: '/workflows' },
     { label: 'Safety', href: '/safety' },
     { label: 'Compare', href: '/compare' },
     { label: 'Templates', href: '/templates' },

--- a/data/workflowCatalog.js
+++ b/data/workflowCatalog.js
@@ -1,0 +1,261 @@
+// Reference catalog of the workflows OpenAdapt has actually recorded, compiled,
+// and replayed under an independent effect oracle. This is a REFERENCE CATALOG,
+// not a marketplace: every entry is a synthetic, pinned local fixture and none
+// is customer-proven. Numbers below are copied from the openadapt-flow benchmark
+// READMEs and the committed evidence provenance manifests
+// (public/lending-demo/provenance.json, public/insurance-demo/provenance.json).
+// Do NOT hand-inflate results; every figure must trace to committed evidence.
+
+const FLOW_REPO = 'https://github.com/OpenAdaptAI/openadapt-flow'
+
+// Canonical substrate maturity labels from the qualification review. All three
+// catalog entries run through the browser substrate, whose reference path is
+// Beta. Windows UIA / native macOS / RDP are scoped partner-qualification only,
+// and Citrix is design-partner-only; none of those substrates appears here yet.
+export const SUBSTRATE_MATURITY = {
+    browser: 'Beta',
+    windows: 'Partner qualification (scoped)',
+    macos: 'Partner qualification (scoped)',
+    rdp: 'Partner qualification (scoped)',
+    citrix: 'Design partner only',
+}
+
+// Shared honesty envelope. Every catalog entry sets these explicitly so the
+// page can never imply customer proof, publication-grade reliability, or that a
+// synthetic fixture is a production deployment.
+const HONESTY_DEFAULTS = {
+    syntheticFixture: true,
+    customerProven: false,
+    publicationReady: false,
+    environment: 'One pinned local macOS arm64 fixture, loopback-only.',
+}
+
+export const CATALOG = [
+    {
+        id: 'openemr',
+        industry: 'Healthcare',
+        solutionHref: '/solutions/healthcare',
+        application: 'OpenEMR',
+        applicationRole: 'Open-source electronic health record (EMR)',
+        version: 'v8.0.0.3',
+        versionDetail:
+            'OpenEMR tag v8.0.0.3 (commit 7c96c8eefe460d6fadbccbe93d0fa6bf819acd69), ' +
+            'official image sha256:0aa4d3d5…f19f3ab, MariaDB 11.8.',
+        substrate: 'browser',
+        substrateLabel: 'Browser (Playwright)',
+        maturity: SUBSTRATE_MATURITY.browser,
+        task:
+            'Create exactly one fictional patient (name, DOB, sex, address, ' +
+            'phone, and a reserved example.invalid email) and save it.',
+        recording:
+            'benchmark/openemr_local — recorded browser demonstration, ' +
+            'compiled to a bundle. Baseline SHA-256 ' +
+            '8d2901490a0a6a6044e94b6a8a1663436b7dacedda4f2fe1fb8c48405165011d; ' +
+            'raw results in the git-ignored local directory ' +
+            'results-model-free-corrected5-20260716/.',
+        recordingHref: `${FLOW_REPO}/tree/main/benchmark/openemr_local`,
+        policy:
+            'Model-free run: healthy compiled replay makes 0 model calls at ' +
+            '$0 model cost. The paid computer-use agent arm is intentionally ' +
+            'omitted, so full_matrix_complete and publication_ready are false.',
+        identityContract:
+            'Two distinct OAuth clients. The actor holds ' +
+            'openid api:oemr user/patient.crus; the oracle holds ' +
+            'openid api:oemr user/patient.rs (read-only, cannot ' +
+            'create/update/delete). The oracle is never the writer.',
+        effectOracle:
+            'Separately authenticated read-only REST patient readback compared ' +
+            'field-for-field with direct SQL from patient_data, plus an exact ' +
+            'before/after table-delta inventory and an unchanged-digest check on ' +
+            'every non-target patient_data row. Exactly one new patient_data row ' +
+            'is required; pixels and actor self-report never establish success.',
+        trialResults: {
+            headline: '12/12 model-free rows correct',
+            detail:
+                'Compiled and direct-API arms, baseline + ui_cosmetic_v1 drift, ' +
+                '3 trials per cell (compiled 6/6, direct-API 6/6). ' +
+                '0 silent incorrect successes, 0 over-halts, 0 model calls, $0.',
+            scope:
+                'Matched local model-free engineering subset (2026-07-16), not ' +
+                'a complete three-arm comparison and not publication evidence.',
+        },
+        secondaryEvidence:
+            'A separate historical field showcase on the shared OpenEMR public ' +
+            'demo ran compiled 20/20 vs. computer-use agent 10/10 (2026-07-08); ' +
+            'that is a field result on a daily-resetting shared instance, not a ' +
+            'CI-reproducible benchmark.',
+        knownLimits: [
+            'Agent arm omitted; not a full three-arm comparison.',
+            'Synthetic PHI-shaped data only (all values fictional); not ' +
+                'regulated, clean-machine, or design-partner evidence.',
+            'Not customer-proven and not a broad reliability claim.',
+        ],
+        scope:
+            'Synthetic fixtures only; one pinned local macOS arm64 environment; ' +
+            '12 model-free trials; not customer-proven.',
+        reproduction:
+            '.venv/bin/python scripts/openemr_local_demo.py run --profile ' +
+            'initial --model-free --bundle benchmark/openemr_local/out/bundle ' +
+            '--out benchmark/openemr_local/out/model-free-initial-YYYYMMDD',
+        methodologyHref: `${FLOW_REPO}/tree/main/benchmark/openemr_local`,
+        license: 'OpenEMR is GPL-licensed and is run, not redistributed.',
+        ...HONESTY_DEFAULTS,
+    },
+    {
+        id: 'frappe-lending',
+        industry: 'Lending',
+        solutionHref: '/solutions/lending',
+        application: 'Frappe Lending',
+        applicationRole: 'Open-source loan-origination reference (Loan Application)',
+        version: 'v16.2.0',
+        versionDetail:
+            'Lending v16.2.0 (commit caed066b…c0e188), Frappe Framework ' +
+            'v16.27.0 (73decbb…f514e), ERPNext v16.27.0 (9d5c7605…daeb1), ' +
+            'frappe_docker c004361e…a8960.',
+        substrate: 'browser',
+        substrateLabel: 'Browser (Playwright)',
+        maturity: SUBSTRATE_MATURITY.browser,
+        task:
+            'Create exactly one synthetic Loan Application — product ' +
+            '“OpenAdapt Synthetic Term Loan”, amount 125000, 18 repayment ' +
+            'periods, and the declared contact fields — and save one application.',
+        recording:
+            'benchmark/frappe_lending — recording-live-valid11, compiled to a ' +
+            'bundle. Baseline SHA-256 ' +
+            '7fd6c965f6b7a11f54e451cdc73fdf65f88d9883dc5f8eb5b2055b3cd4be8b83; ' +
+            'raw results in the git-ignored local directory ' +
+            'results-model-free-corrected3-20260716/.',
+        recordingHref: `${FLOW_REPO}/tree/main/benchmark/frappe_lending`,
+        policy:
+            'Model-free run: 0 model calls at $0 model cost. Frappe exposes a ' +
+            'good REST API, so a real deployment should prefer the API arm; the ' +
+            'browser arm isolates the value of compiled replay when a UI path is ' +
+            'required. Agent arm omitted; publication_ready false.',
+        identityContract:
+            'A read-only REST fixture user (openadapt.oracle@example.invalid) ' +
+            'with a custom read-only Loan Application permission — distinct from ' +
+            'the UI/API writer, so it cannot substitute a different Customer.',
+        effectOracle:
+            'Read-only REST field readback plus direct MariaDB read-back and an ' +
+            'exact per-table row-count contract: “tabLoan Application: +1” and ' +
+            'every other table +0. A new subscriber table fails closed until ' +
+            'reviewed. Pixels and self-report never establish success.',
+        trialResults: {
+            headline: '12/12 model-free rows correct',
+            detail:
+                'Compiled and direct-API arms, baseline + ui_cosmetic_v1 drift, ' +
+                '3 trials per cell (compiled 6/6, direct-API 6/6). ' +
+                '0 silent incorrect successes, 0 over-halts, 0 model calls, $0.',
+            scope:
+                'Local model-free compiled-vs-API engineering subset ' +
+                '(2026-07-16); the paid agent arm and a 10-trial publication ' +
+                'matrix are not included.',
+        },
+        knownLimits: [
+            'Agent arm omitted; not a full three-arm comparison.',
+            'Frappe is API-rich and is NOT a legacy Windows/Citrix LOS; this is ' +
+                'not evidence for a proprietary system such as Encompass or Calyx.',
+            'Not customer-proven and not a broad reliability claim.',
+        ],
+        scope:
+            'Synthetic fixtures only; one pinned local macOS arm64 environment; ' +
+            '6 compiled + 6 direct-API trials; not customer-proven.',
+        reproduction:
+            '.venv/bin/python scripts/frappe_lending_demo.py run --profile ' +
+            'initial --model-free --bundle benchmark/frappe_lending/out/bundle ' +
+            '--out benchmark/frappe_lending/out/model-free-initial-YYYYMMDD',
+        methodologyHref: `${FLOW_REPO}/tree/main/benchmark/frappe_lending`,
+        license:
+            'Lending and ERPNext are GPL-3.0 and are run, not redistributed.',
+        ...HONESTY_DEFAULTS,
+    },
+    {
+        id: 'openimis',
+        industry: 'Insurance',
+        solutionHref: '/solutions/insurance',
+        application: 'openIMIS',
+        applicationRole:
+            'Open-source insurance/claims management (Health Facility Claim intake)',
+        version: '25.10',
+        versionDetail:
+            'openIMIS 25.10 — backend image sha256:a77228c7…892592, frontend ' +
+            'sha256:ed0e0b1d…63db4a, PostgreSQL demo-dataset ' +
+            'sha256:d4bc881e…adf29d; distribution commit cd6220d1…d0caa5.',
+        substrate: 'browser',
+        substrateLabel: 'Browser (Playwright)',
+        maturity: SUBSTRATE_MATURITY.browser,
+        // openIMIS is explicitly a reference/demo environment, not a benchmark.
+        evidenceKind: 'reference demonstration (not a trial matrix)',
+        task:
+            'Enter exactly one synthetic health-facility claim (insuree number, ' +
+            'claim number, diagnosis A000, explanation note, and service A1) and ' +
+            'save it into status “Entered”.',
+        recording:
+            'benchmark/openimis_claims — recorded claim OA000003, then three ' +
+            'compiled replays (OA231353, OA231429, OA231458). Evidence commit ' +
+            '3276ad2b537c558211a5a357fd7ac1e19f0a029e (openadapt-flow #141).',
+        recordingHref: `${FLOW_REPO}/tree/main/benchmark/openimis_claims`,
+        policy:
+            'Model-free compiled replays: 0 model calls. This directory is a ' +
+            'reference/demo environment — there is no timing matrix, no agent ' +
+            'arm, and no publication protocol.',
+        identityContract:
+            'The openIMIS demo actor credential (Admin) with a fixed health ' +
+            'facility (VIHOS001) and claim-administrator context as unmeasured ' +
+            'setup. Weaker than the OpenEMR/Frappe entries: verification is by ' +
+            'direct SQL rather than a separate read-only oracle client.',
+        effectOracle:
+            'Direct SQL read of the openIMIS claims database requiring exactly ' +
+            'one non-voided claim row per run, in status “Entered”, matching the ' +
+            'demonstrated insuree number and health facility. A duplicate or ' +
+            'missing row fails the run loudly; pixels never establish success.',
+        trialResults: {
+            headline: '3/3 compiled replays verified',
+            detail:
+                '1 recorded demonstration + 3 compiled replays, all 3 ' +
+                'SQL-verified. 0 duplicate claims, 0 wrong-policyholder writes, ' +
+                '0 model calls. Replay wall times 25.6s / 26.6s / 30.3s.',
+            scope:
+                'A local reference demonstration, NOT a benchmark: no agent arm, ' +
+                'no trial matrix, no publication protocol.',
+        },
+        knownLimits: [
+            'openIMIS is AGPL-3.0 — the reference environment stays ' +
+                'repository-only and is never shipped in a packaged artifact.',
+            'Reference/demo only: no agent arm, no timing matrix; not ' +
+                'adjudication automation.',
+            'Not a customer deployment, not Windows/RDP/Citrix, and not ' +
+                'customer-proven. OpenAdapt is not affiliated with the openIMIS ' +
+                'Initiative.',
+        ],
+        scope:
+            'Synthetic fixtures only (upstream demo dataset plus one bootstrapped ' +
+            'synthetic policyholder); one pinned local macOS arm64 environment; ' +
+            '3 verified replays; not customer-proven.',
+        reproduction:
+            '.venv/bin/python scripts/openimis_claims_demo.py replay --bundle ' +
+            'benchmark/openimis_claims/out/bundle --headed',
+        methodologyHref: `${FLOW_REPO}/tree/main/benchmark/openimis_claims`,
+        license:
+            'openIMIS is AGPL-3.0 and is run locally, never vendored or ' +
+            'redistributed inside an OpenAdapt package.',
+        ...HONESTY_DEFAULTS,
+    },
+]
+
+// Every field the catalog page relies on and the honesty test enforces.
+export const REQUIRED_ENTRY_FIELDS = [
+    'application',
+    'version',
+    'substrate',
+    'maturity',
+    'task',
+    'recording',
+    'policy',
+    'identityContract',
+    'effectOracle',
+    'trialResults',
+    'knownLimits',
+    'scope',
+    'reproduction',
+]

--- a/pages/workflows.js
+++ b/pages/workflows.js
@@ -1,0 +1,266 @@
+import Head from 'next/head'
+import Link from 'next/link'
+
+import Footer from '@components/Footer'
+import { CATALOG, SUBSTRATE_MATURITY } from 'data/workflowCatalog'
+
+const webPageSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    name: 'Workflow reference catalog',
+    url: 'https://openadapt.ai/workflows',
+    description:
+        'A reference catalog of the workflows OpenAdapt has recorded, compiled, ' +
+        'and replayed under an independent effect oracle. Every entry is a ' +
+        'synthetic, pinned local fixture; none is customer-proven.',
+    isPartOf: {
+        '@type': 'WebSite',
+        name: 'OpenAdapt.AI',
+        url: 'https://openadapt.ai',
+    },
+    inLanguage: 'en',
+}
+
+function Field({ label, children }) {
+    return (
+        <div className="border-t border-hairline pt-4">
+            <dt className="font-display text-xs font-semibold uppercase tracking-wide text-ink-3">
+                {label}
+            </dt>
+            <dd className="mt-2 text-sm leading-relaxed text-ink-2">
+                {children}
+            </dd>
+        </div>
+    )
+}
+
+function CatalogEntry({ entry }) {
+    return (
+        <article
+            id={entry.id}
+            className="rounded-2xl border-2 border-ink bg-panel p-6 md:p-8"
+        >
+            <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                    <p className="eyebrow">{entry.industry}</p>
+                    <h2 className="font-display mt-2 text-2xl font-semibold tracking-tight text-ink">
+                        {entry.application}{' '}
+                        <span className="font-mono text-base font-normal text-ink-3">
+                            {entry.version}
+                        </span>
+                    </h2>
+                    <p className="mt-1 text-sm text-ink-2">
+                        {entry.applicationRole}
+                    </p>
+                </div>
+                <div className="flex flex-col items-end gap-2">
+                    <span className="rounded-full border border-ink px-3 py-1 text-xs font-semibold text-ink">
+                        {entry.substrateLabel} · {entry.maturity}
+                    </span>
+                    {entry.evidenceKind && (
+                        <span
+                            className="rounded-full px-3 py-1 text-xs font-semibold text-ink-2"
+                            style={{
+                                border: '1px solid var(--inset-warn)',
+                            }}
+                        >
+                            {entry.evidenceKind}
+                        </span>
+                    )}
+                </div>
+            </div>
+
+            <div className="mt-5 rounded-xl border border-hairline bg-ground p-4">
+                <p className="font-display text-lg font-semibold text-ink">
+                    {entry.trialResults.headline}
+                </p>
+                <p className="mt-1 text-sm text-ink-2">
+                    {entry.trialResults.detail}
+                </p>
+                <p className="mt-2 text-xs italic text-ink-3">
+                    Scope: {entry.trialResults.scope}
+                </p>
+            </div>
+
+            <dl className="mt-6 grid gap-5 md:grid-cols-2">
+                <Field label="Task">{entry.task}</Field>
+                <Field label="Recording / bundle">
+                    {entry.recording}{' '}
+                    <a
+                        href={entry.recordingHref}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        View benchmark →
+                    </a>
+                </Field>
+                <Field label="Policy">{entry.policy}</Field>
+                <Field label="Identity contract">
+                    {entry.identityContract}
+                </Field>
+                <Field label="Effect oracle">{entry.effectOracle}</Field>
+                <Field label="Known limits">
+                    <ul className="list-disc space-y-1 pl-4">
+                        {entry.knownLimits.map((limit) => (
+                            <li key={limit}>{limit}</li>
+                        ))}
+                    </ul>
+                </Field>
+            </dl>
+
+            {entry.secondaryEvidence && (
+                <p className="mt-5 text-xs leading-relaxed text-ink-3">
+                    {entry.secondaryEvidence}
+                </p>
+            )}
+
+            <div className="mt-6 border-t border-hairline pt-4">
+                <p className="font-display text-xs font-semibold uppercase tracking-wide text-ink-3">
+                    Honest scope
+                </p>
+                <p className="mt-2 text-sm text-ink-2">{entry.scope}</p>
+                <p className="mt-1 text-xs text-ink-3">{entry.license}</p>
+            </div>
+
+            <div className="mt-6">
+                <p className="font-display text-xs font-semibold uppercase tracking-wide text-ink-3">
+                    Reproduce it
+                </p>
+                <pre className="mt-2 overflow-x-auto rounded-xl border border-hairline bg-ground p-4 text-xs leading-relaxed text-ink-2">
+                    <code>{entry.reproduction}</code>
+                </pre>
+                <p className="mt-3 text-sm">
+                    <Link href={entry.solutionHref}>
+                        See the {entry.industry.toLowerCase()} reference →
+                    </Link>
+                </p>
+            </div>
+        </article>
+    )
+}
+
+export default function WorkflowsPage() {
+    return (
+        <div className="min-h-screen bg-ground text-ink">
+            <Head>
+                <title>Workflow reference catalog | OpenAdapt</title>
+                <meta
+                    name="description"
+                    content="A reference catalog of the workflows OpenAdapt has recorded, compiled, and replayed under an independent effect oracle. Every entry is a synthetic, pinned local fixture; none is customer-proven."
+                />
+                <link rel="canonical" href="https://openadapt.ai/workflows" />
+                <meta
+                    property="og:title"
+                    content="Workflow reference catalog | OpenAdapt"
+                />
+                <meta
+                    property="og:description"
+                    content="Synthetic, pinned reference workflows with their identity contract, effect oracle, real trial results, and honest scope."
+                />
+                <meta
+                    property="og:url"
+                    content="https://openadapt.ai/workflows"
+                />
+                <script
+                    type="application/ld+json"
+                    dangerouslySetInnerHTML={{
+                        __html: JSON.stringify(webPageSchema),
+                    }}
+                />
+            </Head>
+
+            <div className="mx-auto max-w-4xl px-4 py-14">
+                <p className="eyebrow">Reference catalog</p>
+                <h1 className="font-display mt-3 text-3xl font-semibold tracking-tight text-ink md:text-4xl">
+                    The workflows we&#39;ve actually recorded, compiled, and
+                    verified.
+                </h1>
+                <p className="mt-5 max-w-3xl text-base text-ink-2 md:text-lg">
+                    This is a <strong className="text-ink">reference
+                    catalog, not a marketplace</strong>. Each entry is a
+                    synthetic, pinned local fixture we recorded once, compiled,
+                    and replayed under an independent effect oracle. We publish
+                    the exact application version, identity contract, oracle,
+                    real trial results, and the limits each result does not
+                    cover — so you can judge the evidence rather than reuse a
+                    workflow we have not proven for your environment.
+                </p>
+                <p className="mt-4 max-w-3xl text-base text-ink-2 md:text-lg">
+                    None of these is customer-proven, none is a complete
+                    published benchmark, and reusing a demonstration you did not
+                    record is exactly the premature step OpenAdapt is built to
+                    refuse. To qualify one of these — or your own — for a real
+                    deployment,{' '}
+                    <Link href="/#book">evaluate a workflow with us</Link>.
+                </p>
+
+                {/* Maturity legend — canonical substrate labels */}
+                <div className="mt-8 rounded-xl border border-hairline bg-panel p-5">
+                    <p className="font-display text-sm font-semibold text-ink">
+                        Substrate maturity labels
+                    </p>
+                    <ul className="mt-3 grid gap-2 text-sm text-ink-2 sm:grid-cols-2">
+                        <li>
+                            <strong className="text-ink">Browser</strong> —{' '}
+                            {SUBSTRATE_MATURITY.browser} (the reference path;
+                            every catalog entry below runs here)
+                        </li>
+                        <li>
+                            <strong className="text-ink">Windows UIA</strong> —{' '}
+                            {SUBSTRATE_MATURITY.windows}
+                        </li>
+                        <li>
+                            <strong className="text-ink">Native macOS</strong> —{' '}
+                            {SUBSTRATE_MATURITY.macos}
+                        </li>
+                        <li>
+                            <strong className="text-ink">RDP</strong> —{' '}
+                            {SUBSTRATE_MATURITY.rdp}
+                        </li>
+                        <li>
+                            <strong className="text-ink">Citrix</strong> —{' '}
+                            {SUBSTRATE_MATURITY.citrix}
+                        </li>
+                    </ul>
+                </div>
+            </div>
+
+            <div className="mx-auto max-w-4xl px-4 pb-16">
+                <div className="grid gap-8">
+                    {CATALOG.map((entry) => (
+                        <CatalogEntry key={entry.id} entry={entry} />
+                    ))}
+                </div>
+            </div>
+
+            <div className="mx-auto max-w-4xl px-4 pb-16">
+                <div className="rounded-2xl border-2 border-ink bg-panel p-6 text-center md:p-8">
+                    <h2 className="font-display text-xl font-semibold tracking-tight text-ink">
+                        Bring the workflow you want qualified next.
+                    </h2>
+                    <p className="mx-auto mt-3 max-w-2xl text-sm text-ink-2 md:text-base">
+                        These references show the method: record once, compile,
+                        and verify against an independent source of truth. The
+                        next entry can be yours — on your application, under your
+                        policy and identity contract.
+                    </p>
+                    <div className="mt-5 flex flex-wrap justify-center gap-3">
+                        <Link href="/#book" className="btn-ink">
+                            Evaluate a workflow
+                        </Link>
+                        <a
+                            href="https://docs.openadapt.ai"
+                            className="btn-ghost-ink"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            Read the docs
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <Footer />
+        </div>
+    )
+}

--- a/tests/workflowCatalog.test.js
+++ b/tests/workflowCatalog.test.js
@@ -1,0 +1,138 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+const vm = require('node:vm')
+
+const root = path.join(__dirname, '..')
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8')
+
+// data/workflowCatalog.js is an ESM source (Next transpiles it). Evaluate it in
+// a CommonJS sandbox so the honesty test asserts the REAL objects, not strings.
+function loadCatalogModule() {
+    const source = read('data/workflowCatalog.js')
+        .replace(/export const/g, 'const')
+        .replace(/export \{[^}]*\}/g, '')
+    const wrapped =
+        source +
+        '\n;module.exports = { CATALOG, SUBSTRATE_MATURITY, REQUIRED_ENTRY_FIELDS };'
+    const module = { exports: {} }
+    vm.runInNewContext(wrapped, { module, exports: module.exports })
+    return module.exports
+}
+
+const { CATALOG, SUBSTRATE_MATURITY, REQUIRED_ENTRY_FIELDS } =
+    loadCatalogModule()
+
+test('catalog covers exactly the three real benchmark references', () => {
+    assert.equal(
+        JSON.stringify(CATALOG.map((e) => e.id).sort()),
+        JSON.stringify(['frappe-lending', 'openemr', 'openimis'])
+    )
+})
+
+test('every catalog entry carries the required honesty fields', () => {
+    for (const entry of CATALOG) {
+        const where = `entry ${entry.id}`
+
+        // Explicit honesty envelope — never customer-proven or publication-grade.
+        assert.equal(entry.syntheticFixture, true, `${where} syntheticFixture`)
+        assert.equal(entry.customerProven, false, `${where} customerProven`)
+        assert.equal(
+            entry.publicationReady,
+            false,
+            `${where} publicationReady`
+        )
+
+        // All required descriptive fields are present and non-empty.
+        for (const field of REQUIRED_ENTRY_FIELDS) {
+            assert.ok(entry[field], `${where} missing required field: ${field}`)
+        }
+
+        // Honest scope prose must name its synthetic, non-customer nature.
+        assert.match(entry.scope, /synthetic/i, `${where} scope names synthetic`)
+        assert.match(
+            entry.scope,
+            /not customer-proven/i,
+            `${where} scope disclaims customer proof`
+        )
+
+        // Known limits are a real, non-empty list.
+        assert.ok(
+            Array.isArray(entry.knownLimits) && entry.knownLimits.length >= 1,
+            `${where} has known limits`
+        )
+
+        // Trial results always carry their own scope caveat.
+        assert.ok(entry.trialResults.headline, `${where} trial headline`)
+        assert.ok(entry.trialResults.detail, `${where} trial detail`)
+        assert.match(
+            entry.trialResults.scope,
+            /not (a )?(complete|publication|benchmark)|reference demonstration|engineering subset/i,
+            `${where} trial scope is bounded`
+        )
+
+        // Exactly one reproduction command (single line).
+        assert.doesNotMatch(
+            entry.reproduction,
+            /\n/,
+            `${where} reproduction is one command`
+        )
+    }
+})
+
+test('all catalog entries use the canonical browser=Beta maturity label', () => {
+    assert.equal(SUBSTRATE_MATURITY.browser, 'Beta')
+    for (const entry of CATALOG) {
+        assert.equal(entry.substrate, 'browser', `${entry.id} substrate`)
+        assert.equal(
+            entry.maturity,
+            SUBSTRATE_MATURITY.browser,
+            `${entry.id} maturity is the canonical browser label`
+        )
+    }
+})
+
+test('trial numbers match the committed evidence provenance, not invented ones', () => {
+    // Frappe Lending: the compiled arm is 6/6, the model-free matrix is 12/12.
+    const lending = JSON.parse(read('public/lending-demo/provenance.json'))
+    assert.equal(lending.evidence.compiled_correct, 6)
+    assert.equal(lending.evidence.publication_ready_comparative_matrix, false)
+    const frappe = CATALOG.find((e) => e.id === 'frappe-lending')
+    assert.match(frappe.trialResults.headline, /12\/12/)
+    assert.match(frappe.trialResults.detail, /6\/6/)
+
+    // openIMIS: exactly the 3 verified compiled replays, no matrix.
+    const insurance = JSON.parse(read('public/insurance-demo/provenance.json'))
+    assert.equal(insurance.evidence.compiled_replays_verified, 3)
+    assert.equal(insurance.evidence.publication_ready_comparative_matrix, false)
+    const openimis = CATALOG.find((e) => e.id === 'openimis')
+    assert.match(openimis.trialResults.headline, /3\/3/)
+    // openIMIS is a reference demonstration, not a benchmark — say so.
+    assert.match(openimis.trialResults.scope, /not a benchmark/i)
+
+    // OpenEMR: matched model-free 12/12; historical field showcase 20/20 vs 10/10.
+    const openemr = CATALOG.find((e) => e.id === 'openemr')
+    assert.match(openemr.trialResults.headline, /12\/12/)
+    assert.match(openemr.secondaryEvidence, /20\/20.*10\/10/)
+})
+
+test('the page frames itself as a reference catalog, not a marketplace', () => {
+    const page = read('pages/workflows.js')
+    assert.match(page, /reference\s*\n?\s*catalog, not a marketplace/i)
+    assert.match(page, /none is customer-proven|not customer-proven/i)
+    // Pulls from the shared data module and renders the shared footer.
+    assert.match(page, /from 'data\/workflowCatalog'/)
+    assert.match(page, /<Footer/)
+    assert.match(page, /rel="canonical" href="https:\/\/openadapt\.ai\/workflows"/)
+})
+
+test('workflows is linked from nav and footer but not the homepage body', () => {
+    assert.match(
+        read('components/NavHeader.js'),
+        /\{ label: 'Workflows', href: '\/workflows' \}/
+    )
+    assert.match(read('components/Footer.js'), /href="\/workflows"/)
+    // A parallel agent owns the homepage; keep /workflows out of its body.
+    assert.doesNotMatch(read('pages/index.js'), /\/workflows/)
+})


### PR DESCRIPTION
## What

Adds a **reference catalog** at `/workflows` for the three workflows OpenAdapt has actually recorded, compiled, and replayed under an independent effect oracle. This is an **organize-what-exists** page, not a new capability.

It is explicitly a **reference catalog, not a marketplace** — the qualification review warns against premature reuse, so every entry is a synthetic, pinned local fixture and none is customer-proven.

## Entries (real numbers, copied from evidence — never invented)

| Industry | App + pinned version | Substrate · maturity | Trial results (with scope) |
|---|---|---|---|
| Healthcare | **OpenEMR v8.0.0.3** | Browser · Beta | **12/12** model-free (compiled 6/6 + direct-API 6/6, baseline + drift, 3/cell); 0 silent-incorrect / over-halt / model-call. Historical field showcase 20/20 vs agent 10/10 noted as non-CI. |
| Lending | **Frappe Lending v16.2.0** | Browser · Beta | **12/12** model-free (compiled 6/6 + direct-API 6/6); same zero counters. |
| Insurance | **openIMIS 25.10** | Browser · Beta | **3/3** verified compiled replays (1 recorded demo + 3 replays; wall 25.6/26.6/30.3s). A reference demonstration, **not** a benchmark; AGPL-3.0, repository-only. |

Each card shows: application + pinned version/commits, substrate + canonical maturity badge, recording/bundle reference (with a link to the benchmark), policy, identity contract, effect oracle, trial results + scope, known limits, honest scope, license note, and one reproduction command.

## Honesty

- Every entry sets `syntheticFixture: true`, `customerProven: false`, `publicationReady: false`, and a bounded scope disclaiming customer proof.
- Numbers trace to the openadapt-flow benchmark READMEs and the committed provenance manifests (`public/lending-demo/provenance.json`, `public/insurance-demo/provenance.json`).
- Canonical substrate labels used (browser = Beta; Windows/macOS/RDP = scoped partner qualification; Citrix = design-partner-only), shown in a legend.
- `publicTruth` and all existing surfaces are preserved.

## Wiring

- Linked from **nav** (Product dropdown) and **footer** — deliberately **not** the homepage body, to avoid colliding with the parallel homepage change.

## Tests / gates
- `tests/workflowCatalog.test.js` evaluates the data module and asserts each entry carries the required honesty fields and that the published trial numbers match the committed provenance manifests.
- `node --test` — **79/79 pass** (73 existing + 6 new).
- `next build` — compiles `/workflows` as a static route.