### PR TITLE
docs: add canonical status manifest and wire homepage to it

### DIFF
--- a/components/ProductStatus.js
+++ b/components/ProductStatus.js
@@ -1,5 +1,7 @@
 import Link from 'next/link'
 
+import status from '../public/status.json'
+
 const FLOW_URL = 'https://github.com/OpenAdaptAI/openadapt-flow'
 const LIMITS_URL = `${FLOW_URL}/blob/main/docs/LIMITS.md`
 const EVIDENCE_URL = `${FLOW_URL}/tree/main/benchmark`
@@ -130,6 +132,55 @@ export default function ProductStatus() {
                             </div>
                         ))}
                     </div>
+                </div>
+
+                <div
+                    id="interface-readiness"
+                    className="mt-8 rounded-2xl border border-hairline bg-ground p-5 md:p-7"
+                >
+                    <p className="eyebrow">Where each interface stands today</p>
+                    <h3 className="mt-2 max-w-2xl font-display text-xl font-semibold tracking-tight text-ink md:text-2xl">
+                        One honest readiness label per surface
+                    </h3>
+                    <p className="mt-3 max-w-3xl text-sm leading-relaxed text-ink-2">
+                        These labels are read directly from a single{' '}
+                        <a
+                            href="/status.json"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-accent underline"
+                        >
+                            machine-readable status manifest
+                        </a>{' '}
+                        so the website, docs, launcher, and packages cannot drift
+                        apart. A label never claims more than its evidence.
+                    </p>
+                    <ul className="mt-6 grid gap-4 md:grid-cols-2">
+                        {status.substrates.map((substrate) => (
+                            <li
+                                key={substrate.name}
+                                className="rounded-xl border border-hairline bg-panel p-5"
+                            >
+                                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                                    <h4 className="font-display font-semibold text-ink">
+                                        {substrate.name}
+                                    </h4>
+                                    <span className="rounded-full border border-hairline px-2.5 py-0.5 font-mono text-xs font-medium text-accent">
+                                        {substrate.public_label}
+                                    </span>
+                                </div>
+                                <p className="mt-2 text-sm leading-relaxed text-ink-2">
+                                    {substrate.evidence_note}
+                                </p>
+                            </li>
+                        ))}
+                    </ul>
+                    <p className="mt-5 font-mono text-xs text-ink-3">
+                        Current components: launcher{' '}
+                        <span className="text-ink-2">openadapt {status.versions.launcher}</span>{' '}
+                        · <span className="text-ink-2">openadapt-flow {status.versions.flow}</span>{' '}
+                        · <span className="text-ink-2">desktop {status.versions.desktop}</span>
+                    </p>
                 </div>
 
                 <div className="mt-8 rounded-2xl border border-hairline bg-ground p-5 md:p-7">

--- a/public/status.json
+++ b/public/status.json
@@ -1,0 +1,35 @@
+{
+    "$comment": "Canonical machine-readable maturity + version status for OpenAdapt. This file is the single source of truth: every public surface (website, docs, launcher README, PyPI metadata, in-product copy) reconciles its substrate maturity labels and component versions to this manifest. Served at https://openadapt.ai/status.json and imported directly by the homepage so rendered labels cannot drift from it. Honesty rule: a public_label never claims more than its evidence_note supports.",
+    "generated_at": "2026-07-19",
+    "versions": {
+        "launcher": "1.7.1",
+        "flow": "1.19.0",
+        "desktop": "0.6.2"
+    },
+    "substrates": [
+        {
+            "name": "Browser",
+            "public_label": "Beta",
+            "internal_tier": "reference",
+            "evidence_note": "Reference record -> compile -> replay path. Runs end to end in CI with no OS permissions and is the substrate the public managed subscription executes on. A clean run is still not automatically safe; identity, effect, and policy coverage are audited per bundle."
+        },
+        {
+            "name": "Windows / macOS / RDP",
+            "public_label": "Scoped acceptance — design partners only",
+            "internal_tier": "scoped-acceptance",
+            "evidence_note": "Each passed a real, counted scoped qualification with 0 silent incorrect successes, 0 over-halts, and 0 model calls: Windows UIA 3/3 on an in-tree WinForms matrix with an independent SQLite oracle and 3/3 stale/ambiguity refusals; native macOS TextEdit 3/3 exact-byte effects plus a two-window ambiguity refusal; real-network RDP 3/3 unique-file trials with independent guest-tools readback. These qualify only their named tasks and environments — not arbitrary applications, clean-machine support, or hosted-desktop availability. No external customer has run these in production yet, so public availability is design-partner only."
+        },
+        {
+            "name": "Citrix / VDI",
+            "public_label": "Research / design-partner qualification",
+            "internal_tier": "design-partner-qualification",
+            "evidence_note": "No validated ICA/HDX integration exists. The generic pixel-only remote-window safety floor can begin qualification only inside a design partner's real Citrix/VDI environment; RDP evidence does not transfer. Client, latency, compression, DPI, lock-screen, input, identity, and effect behavior all require that real environment."
+        },
+        {
+            "name": "Hosted Cloud",
+            "public_label": "Beta / public offer",
+            "internal_tier": "beta-public-offer",
+            "evidence_note": "A live $500/month managed browser-workflow subscription backed by the configured live Stripe Product and Price. Three reversible production pre-payment trials verified tenant-bound Checkout creation and confirmed unpaid sessions grant no entitlement; the first genuine external customer payment-to-run lifecycle has not completed yet. Production uses live dependencies and fails closed rather than simulating success. Non-browser hosted substrates (Windows/RDP/Citrix desktops) remain separately scoped design-partner deployments."
+        }
+    ]
+}

--- a/tests/statusManifest.test.js
+++ b/tests/statusManifest.test.js
@@ -1,0 +1,77 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+const root = path.join(__dirname, '..')
+const read = (relativePath) =>
+    fs.readFileSync(path.join(root, relativePath), 'utf8')
+
+const manifest = JSON.parse(read('public/status.json'))
+
+// The canonical public maturity labels. These are the single source of truth
+// that the website, docs (openadapt-ops), launcher README, and PyPI metadata
+// all reconcile to. A label must never claim more than its evidence supports.
+const CANONICAL_LABELS = {
+    Browser: 'Beta',
+    'Windows / macOS / RDP': 'Scoped acceptance — design partners only',
+    'Citrix / VDI': 'Research / design-partner qualification',
+    'Hosted Cloud': 'Beta / public offer',
+}
+
+// Component versions verified against PyPI on 2026-07-19.
+const CANONICAL_VERSIONS = {
+    launcher: '1.7.1',
+    flow: '1.19.0',
+    desktop: '0.6.2',
+}
+
+test('status manifest encodes the canonical maturity labels verbatim', () => {
+    const byName = Object.fromEntries(
+        manifest.substrates.map((s) => [s.name, s.public_label])
+    )
+    assert.deepEqual(byName, CANONICAL_LABELS)
+
+    for (const substrate of manifest.substrates) {
+        assert.ok(
+            substrate.evidence_note && substrate.evidence_note.length > 40,
+            `${substrate.name} must carry an evidence note that justifies its label`
+        )
+        assert.ok(
+            typeof substrate.internal_tier === 'string' &&
+                substrate.internal_tier.length > 0,
+            `${substrate.name} must record an internal tier`
+        )
+    }
+})
+
+test('status manifest encodes the verified component versions', () => {
+    assert.deepEqual(manifest.versions, CANONICAL_VERSIONS)
+    assert.match(manifest.generated_at, /^\d{4}-\d{2}-\d{2}$/)
+})
+
+test('homepage substrate matrix renders labels and versions from the manifest', () => {
+    // The rendered labels must come from the manifest, not hardcoded strings,
+    // so a version bump or label change in status.json is the only edit needed
+    // and the homepage can never disagree with the source of truth.
+    const product = read('components/ProductStatus.js')
+
+    assert.match(product, /import status from '\.\.\/public\/status\.json'/)
+    assert.match(product, /status\.substrates\.map/)
+    assert.match(product, /substrate\.public_label/)
+    assert.match(product, /substrate\.evidence_note/)
+    assert.match(product, /status\.versions\.launcher/)
+    assert.match(product, /status\.versions\.flow/)
+    assert.match(product, /status\.versions\.desktop/)
+    assert.match(product, /status\.json/)
+
+    // The canonical label strings must not be hardcoded into the component —
+    // that would let them drift from the manifest.
+    for (const label of Object.values(CANONICAL_LABELS)) {
+        assert.doesNotMatch(
+            product,
+            new RegExp(label.replace(/[.*+?^${}()|[\]\\—/]/g, '\\$&')),
+            `ProductStatus must read "${label}" from the manifest, not inline it`
+        )
+    }
+})


### PR DESCRIPTION
## Why
Top external-review finding (2026-07-19): OpenAdapt's **maturity claims and versions disagree across surfaces**. This creates one machine-readable source of truth and makes the homepage read from it, so labels can never drift again.

## What
- **New `public/status.json`** — canonical `{substrates[], versions, generated_at}`, served at `https://openadapt.ai/status.json` and imported by the homepage. Public labels (verbatim from the review, except Hosted — see below):
  - Browser: **Beta**
  - Windows / macOS / RDP: **Scoped acceptance — design partners only**
  - Citrix / VDI: **Research / design-partner qualification**
  - Hosted Cloud: **Beta / public offer**
  - Versions verified against PyPI on 2026-07-19: launcher `1.7.1`, `openadapt-flow` `1.19.0`, desktop `0.6.2`.
- **`components/ProductStatus.js`** now renders a per-surface readiness matrix + component versions **directly from the manifest** (no hardcoded label strings).
- **New `tests/statusManifest.test.js`** — asserts the manifest holds the canonical labels/versions and that the homepage reads them from the manifest (single-source wiring).

## Honesty note on two review numbers
- **Flow version**: the review said `1.18.0`, but PyPI latest (not yanked) is **`1.19.0`** — the manifest encodes the true installable version.
- **Hosted Cloud label**: the review suggested "Early access / design partner", but STATUS.md and the ops `validate_docs` contract establish a genuinely **live public $500/month browser subscription**; "Beta / public offer" avoids understating a live offer while "Beta" (not Stable) plus the evidence_note keep it honest (no completed paid-customer lifecycle yet).

## Verification
- `node --test tests/*.test.js` → **76 passed, 0 failed** (existing `publicTruth.test.js` unchanged).
- `npm run build` succeeds; rendered homepage HTML contains the manifest labels and versions.