### PR TITLE
refactor(home): focus the homepage and reframe packaging to Beta/pilot

### DIFF
--- a/components/Developers.js
+++ b/components/Developers.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import styles from './Developers.module.css';
 import InstallSection from '@components/InstallSection';
-import PyPIDownloadChart from './PyPIDownloadChart';
 import { BLOG_LINK, DEVELOPER_LINKS } from 'data/developerLinks';
 
 // Canonical hrefs live in data/developerLinks.js (shared with the nav
@@ -58,8 +57,7 @@ export default function Developers({ buildWarnings = [], githubStats = null }) {
                     {/* uv-first Installation Section */}
                     <InstallSection />
 
-                    {/* PyPI Download Statistics */}
-                    <PyPIDownloadChart githubStats={githubStats} />
+                    {/* Package adoption stats live on the Download page. */}
 
                     <div className="mt-8 mb-2 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-center">
                         {ecosystemLinks.map((link) => (

--- a/components/HowItWorksCondensed.js
+++ b/components/HowItWorksCondensed.js
@@ -1,0 +1,64 @@
+// Condensed three-step model for the homepage. The full five-stage walkthrough
+// with per-application footage lives on the solution pages (it uses
+// <HowItWorks showUseCases />); this compresses record + compile + replay +
+// resolve + verify into the three ideas a first-time reader needs.
+
+const steps = [
+    {
+        number: '1',
+        name: 'Record & compile',
+        description:
+            'Demonstrate one bounded, repeated instance. OpenAdapt compiles the trace into a reviewable, parameterized program — not a prompt a model reinterprets each run.',
+    },
+    {
+        number: '2',
+        name: 'Replay deterministically',
+        description:
+            'Healthy runs execute the compiled steps locally with zero model calls, so repeat runs are fast and cost nothing per run.',
+    },
+    {
+        number: '3',
+        name: 'Resolve, repair, or halt',
+        description:
+            'Under interface drift, deterministic evidence re-finds the target, an optional model proposes a governed repair, or configured verification halts and preserves a run report.',
+    },
+]
+
+export default function HowItWorksCondensed() {
+    return (
+        <section
+            id="how-it-works"
+            className="border-b border-hairline bg-ground px-5 py-14 md:py-16"
+        >
+            <div className="mx-auto max-w-5xl">
+                <p className="eyebrow text-center">How it works</p>
+                <h2 className="mx-auto mt-2 max-w-2xl text-center font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl">
+                    A demonstration becomes a reviewable program
+                </h2>
+                <p className="mx-auto mt-3 max-w-2xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
+                    Three steps, one governed loop. Healthy replay is
+                    deterministic; model spend is reserved for compilation or
+                    repair.
+                </p>
+                <ol className="mt-9 grid gap-4 md:grid-cols-3">
+                    {steps.map((step) => (
+                        <li
+                            key={step.number}
+                            className="flex h-full flex-col rounded-2xl border border-hairline bg-panel p-6"
+                        >
+                            <span className="font-mono text-xs font-medium text-accent">
+                                {step.number}
+                            </span>
+                            <h3 className="mt-3 font-display text-lg font-semibold tracking-tight text-ink">
+                                {step.name}
+                            </h3>
+                            <p className="mt-2 text-sm leading-relaxed text-ink-2">
+                                {step.description}
+                            </p>
+                        </li>
+                    ))}
+                </ol>
+            </div>
+        </section>
+    )
+}

--- a/components/MastHead.js
+++ b/components/MastHead.js
@@ -47,32 +47,23 @@ export default function Home({ githubStats }) {
                                 )}
                             </div>
                             <h1 className="font-display text-2xl md:text-3xl mt-0 mb-4 font-semibold tracking-tight text-ink">
-                                Compile repeated GUI work into governed,
-                                deterministic workflows.
+                                Compile repeated GUI work. Verify the result.
+                                Halt when you can&rsquo;t.
                             </h1>
-                            <p className="mt-0 mb-6 mx-auto max-w-3xl font-sans font-normal text-base md:text-lg text-ink-2">
-                                Demonstrate a bounded, repeated GUI workflow.
-                                Compile it into a locally executable workflow
-                                whose healthy replay makes no model calls. When the
-                                interface changes, OpenAdapt re-resolves from
-                                retained evidence, proposes a governed repair, or
-                                halts for an operator.
+                            <p className="mt-0 mb-6 mx-auto max-w-2xl font-sans font-normal text-base md:text-lg text-ink-2">
+                                Demonstrate a bounded, repeated GUI workflow and
+                                compile it into a locally executable program whose
+                                healthy replay makes no model calls. Under interface
+                                drift OpenAdapt re-resolves from retained evidence,
+                                proposes a governed repair, or halts for an
+                                operator. Browser workflows are proven today;
+                                Windows and macOS are experimental.{' '}
+                                <Link href="#product-status">
+                                    See where it runs.
+                                </Link>
                             </p>
-                            <p className="mt-0 mb-6 mx-auto max-w-3xl font-sans font-normal text-base md:text-lg text-ink-3">
-                                Use the same compiled workflow model across browser,
-                                Windows, macOS, Linux, RDP, Citrix, and VDI targets,
-                                running locally, through OpenAdapt Cloud, or inside
-                                a customer-controlled boundary. Browser workflows
-                                are proven today; Windows and macOS are
-                                experimental, and remote-display targets (RDP,
-                                Citrix, VDI) are research-stage.{' '}
-                                <Link href="#product-status">See how deployment works.</Link>
-                            </p>
-                            <div className="flex flex-col align-center justify-center px-4 min-w-0 max-w-full overflow-hidden">
-                                <ReplayHero />
-                            </div>
                             <div id="register">
-                                <div className="flex items-center justify-center gap-3 mt-6 mb-4">
+                                <div className="flex flex-wrap items-center justify-center gap-3 mt-0 mb-8">
                                     <Link
                                         className="btn-ink"
                                         href="#book"
@@ -96,6 +87,9 @@ export default function Home({ githubStats }) {
                                         Try locally
                                     </Link>
                                 </div>
+                            </div>
+                            <div className="flex flex-col align-center justify-center px-4 min-w-0 max-w-full overflow-hidden">
+                                <ReplayHero />
                             </div>
                         </div>
                     </div>

--- a/components/MastHead.js
+++ b/components/MastHead.js
@@ -56,8 +56,9 @@ export default function Home({ githubStats }) {
                                 healthy replay makes no model calls. Under interface
                                 drift OpenAdapt re-resolves from retained evidence,
                                 proposes a governed repair, or halts for an
-                                operator. Browser workflows are proven today;
-                                Windows and macOS are experimental.{' '}
+                                operator. Browser workflows run in Beta today;
+                                Windows, macOS, and remote desktops are
+                                design-partner only.{' '}
                                 <Link href="#product-status">
                                     See where it runs.
                                 </Link>

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -122,14 +122,15 @@ export default function Pricing({ hostedOffer = null }) {
             className="border-t-2 border-ink bg-ground px-5 py-16 md:py-20"
         >
             <div className="mx-auto max-w-5xl">
-                <p className="eyebrow text-center">Launch options</p>
+                <p className="eyebrow text-center">Early access</p>
                 <h2 className="mx-auto mt-2 max-w-2xl text-center font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl">
-                    Run it yourself or launch with us
+                    Start as a design partner
                 </h2>
                 <p className="mx-auto mt-3 max-w-xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
-                    Run the MIT-licensed engine yourself, use managed browser
-                    execution, or qualify a customer-controlled deployment.
-                    Hosted prices are confirmed by Stripe before payment.
+                    OpenAdapt is in early access. We lead with a scoped, paid
+                    pilot: we qualify one workflow with you, then price the
+                    engagement. You can also run the MIT-licensed engine yourself
+                    for free, or join early access for managed browser execution.
                 </p>
 
                 <div className="mt-10 grid items-start gap-6 md:grid-cols-3">
@@ -169,9 +170,9 @@ export default function Pricing({ hostedOffer = null }) {
                     {/* Card 2 — Hosted browser execution */}
                     <div className="relative flex h-full flex-col rounded-2xl border border-hairline bg-panel p-6 md:p-7">
                         <span className="absolute -top-3 left-6 rounded-full border border-hairline bg-ground px-3 py-1 font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-ink-2">
-                            Managed browser
+                            Early access
                         </span>
-                        <p className="eyebrow">Hosted</p>
+                        <p className="eyebrow">Hosted browser</p>
                         <div className="mt-2 flex items-baseline gap-2">
                             <span className="font-display text-2xl font-semibold tracking-tight text-ink">
                                 {hostedOfferAvailable
@@ -198,9 +199,9 @@ export default function Pricing({ hostedOffer = null }) {
                             </p>
                         )}
                         <p className="mt-3 text-sm leading-relaxed text-ink-2">
-                            Bring an approved browser workflow to a managed
-                            control plane for repeat execution, reporting, and
-                            governed updates.
+                            Early-access managed execution for an approved browser
+                            workflow: a control plane for repeat execution,
+                            reporting, and governed updates.
                         </p>
                         <FeatureList
                             items={[
@@ -241,19 +242,23 @@ export default function Pricing({ hostedOffer = null }) {
                         className="relative flex h-full flex-col rounded-2xl border-2 border-ink bg-panel p-6 shadow-[0_8px_32px_rgba(35,40,31,0.10)] md:p-7"
                     >
                         <span className="absolute -top-3 left-6 rounded-full bg-ink px-3 py-1 font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-ground">
-                            Regulated deployment
+                            Design partner
                         </span>
-                        <p className="eyebrow">Enterprise</p>
+                        <p className="eyebrow">Scoped pilot</p>
                         <div className="mt-2 flex items-baseline gap-2">
                             <span className="font-display text-2xl font-semibold tracking-tight text-ink">
-                                Contact sales
+                                Scoped paid pilot
                             </span>
                         </div>
+                        <p className="mt-1 text-sm text-ink-3">
+                            Priced after qualification
+                        </p>
                         <p className="mt-3 text-sm leading-relaxed text-ink-2">
-                            For consequential workflows that require a
-                            customer-controlled data boundary. We qualify the
-                            substrate, artifact policy, effect oracle, and
-                            operating model before production use.
+                            The primary way to start. For consequential workflows
+                            that require a customer-controlled data boundary, we
+                            qualify the substrate, artifact policy, effect oracle,
+                            and operating model with you, then scope and price the
+                            pilot before production use.
                         </p>
                         <FeatureList
                             items={[

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -1,13 +1,21 @@
 import { useState } from 'react'
 import Link from 'next/link'
 
+import status from '../public/status.json'
+
 const { monthlyRunCapLabel } = require('../lib/hostedOfferContract')
 
 /*
  * Three delivery paths. The hosted amount is retrieved from Stripe at build
  * time rather than duplicated in site code; Checkout confirms the same
- * configured product and price before payment.
+ * configured product and price before payment. The hosted maturity label is
+ * read from the canonical status manifest (public/status.json) so it can never
+ * drift from the single source of truth.
  */
+
+const hostedStatusLabel =
+    status.substrates.find((substrate) => substrate.name === 'Hosted Cloud')
+        ?.public_label || 'Beta'
 
 function Check() {
     return (
@@ -122,15 +130,16 @@ export default function Pricing({ hostedOffer = null }) {
             className="border-t-2 border-ink bg-ground px-5 py-16 md:py-20"
         >
             <div className="mx-auto max-w-5xl">
-                <p className="eyebrow text-center">Early access</p>
+                <p className="eyebrow text-center">Ways to start</p>
                 <h2 className="mx-auto mt-2 max-w-2xl text-center font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl">
-                    Start as a design partner
+                    Run it yourself, subscribe, or start a pilot
                 </h2>
-                <p className="mx-auto mt-3 max-w-xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
-                    OpenAdapt is in early access. We lead with a scoped, paid
-                    pilot: we qualify one workflow with you, then price the
-                    engagement. You can also run the MIT-licensed engine yourself
-                    for free, or join early access for managed browser execution.
+                <p className="mx-auto mt-3 max-w-2xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
+                    Run the MIT-licensed engine yourself for free. Subscribe to
+                    managed browser execution &mdash; a live offer in Beta, with
+                    assisted onboarding rather than one-click self-serve. For
+                    consequential desktop, Citrix, or regulated workflows, start
+                    a scoped paid pilot as a design partner.
                 </p>
 
                 <div className="mt-10 grid items-start gap-6 md:grid-cols-3">
@@ -169,8 +178,11 @@ export default function Pricing({ hostedOffer = null }) {
 
                     {/* Card 2 — Hosted browser execution */}
                     <div className="relative flex h-full flex-col rounded-2xl border border-hairline bg-panel p-6 md:p-7">
-                        <span className="absolute -top-3 left-6 rounded-full border border-hairline bg-ground px-3 py-1 font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-ink-2">
-                            Early access
+                        <span
+                            className="absolute -top-3 left-6 rounded-full border border-hairline bg-ground px-3 py-1 font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-ink-2"
+                            data-testid="hosted-status-label"
+                        >
+                            {hostedStatusLabel}
                         </span>
                         <p className="eyebrow">Hosted browser</p>
                         <div className="mt-2 flex items-baseline gap-2">
@@ -199,9 +211,11 @@ export default function Pricing({ hostedOffer = null }) {
                             </p>
                         )}
                         <p className="mt-3 text-sm leading-relaxed text-ink-2">
-                            Early-access managed execution for an approved browser
+                            A live, managed subscription for an approved browser
                             workflow: a control plane for repeat execution,
-                            reporting, and governed updates.
+                            reporting, and governed updates. Onboarding is
+                            assisted &mdash; we qualify the first workflow with
+                            you rather than one-click self-serve.
                         </p>
                         <FeatureList
                             items={[
@@ -254,11 +268,12 @@ export default function Pricing({ hostedOffer = null }) {
                             Priced after qualification
                         </p>
                         <p className="mt-3 text-sm leading-relaxed text-ink-2">
-                            The primary way to start. For consequential workflows
-                            that require a customer-controlled data boundary, we
-                            qualify the substrate, artifact policy, effect oracle,
-                            and operating model with you, then scope and price the
-                            pilot before production use.
+                            The way to start on Windows, macOS, RDP, Citrix, or
+                            regulated data &mdash; substrates offered to design
+                            partners only. We qualify the substrate, artifact
+                            policy, effect oracle, and operating model with you in
+                            a customer-controlled boundary, then scope and price
+                            the pilot before production use.
                         </p>
                         <FeatureList
                             items={[

--- a/components/Qualification.js
+++ b/components/Qualification.js
@@ -1,0 +1,87 @@
+import Link from 'next/link'
+
+// Buyer qualification lifted from the /compare "start with the right category"
+// guidance: APIs first, RPA for breadth, agents for novel work, and OpenAdapt
+// for the repeated, consequential UI-only last mile that can be checked
+// against an independent source of truth.
+
+const fits = [
+    'The work repeats and the business intent stays stable.',
+    'A wrong action matters, so a run must be verified or halted.',
+    'There is no practical API for the last mile — it is UI-only.',
+    'An independent oracle (REST, SQL, export) can confirm the effect.',
+]
+
+const doesNot = [
+    'A stable API already exists — call it directly instead.',
+    'You need broad connector coverage and orchestration — use mature RPA.',
+    'The task is novel or exploratory — a computer-use agent can re-plan each run.',
+    'No independent check can confirm the outcome — the result cannot be trusted.',
+]
+
+export default function Qualification() {
+    return (
+        <section
+            id="qualification"
+            className="border-b border-hairline bg-panel px-5 py-14 md:py-16"
+        >
+            <div className="mx-auto max-w-5xl">
+                <p className="eyebrow text-center">Is this the right tool?</p>
+                <h2 className="mx-auto mt-2 max-w-2xl text-center font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl">
+                    Use APIs first. Use OpenAdapt for the UI-only last mile.
+                </h2>
+                <p className="mx-auto mt-3 max-w-2xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
+                    OpenAdapt is deliberately narrow. It is built for repeated,
+                    consequential GUI work that has no practical integration and
+                    can be checked against an independent source of truth.
+                </p>
+                <div className="mt-8 grid gap-4 md:grid-cols-2">
+                    <article className="rounded-2xl border border-hairline bg-ground p-6">
+                        <h3 className="font-display text-lg font-semibold tracking-tight text-ink">
+                            When OpenAdapt fits
+                        </h3>
+                        <ul className="mt-4 flex flex-col gap-3 text-sm leading-relaxed text-ink-2">
+                            {fits.map((item) => (
+                                <li key={item} className="flex gap-2.5">
+                                    <span
+                                        aria-hidden="true"
+                                        className="mt-[2px] flex-shrink-0 font-mono text-accent"
+                                    >
+                                        ✓
+                                    </span>
+                                    <span>{item}</span>
+                                </li>
+                            ))}
+                        </ul>
+                    </article>
+                    <article className="rounded-2xl border border-hairline bg-ground p-6">
+                        <h3 className="font-display text-lg font-semibold tracking-tight text-ink">
+                            When it isn&rsquo;t the right tool
+                        </h3>
+                        <ul className="mt-4 flex flex-col gap-3 text-sm leading-relaxed text-ink-2">
+                            {doesNot.map((item) => (
+                                <li key={item} className="flex gap-2.5">
+                                    <span
+                                        aria-hidden="true"
+                                        className="mt-[2px] flex-shrink-0 font-mono text-ink-3"
+                                    >
+                                        ·
+                                    </span>
+                                    <span>{item}</span>
+                                </li>
+                            ))}
+                        </ul>
+                    </article>
+                </div>
+                <p className="mx-auto mt-6 max-w-2xl text-center text-sm text-ink-3">
+                    See the full breakdown against RPA, computer-use agents, and
+                    browser recorders on the{' '}
+                    <Link href="/compare" className="text-accent underline">
+                        comparison page
+                    </Link>
+                    .
+                </p>
+            </div>
+        </section>
+    )
+}

--- a/components/ReplayHero.js
+++ b/components/ReplayHero.js
@@ -1,12 +1,15 @@
 import { useEffect, useRef, useState } from 'react'
+import Link from 'next/link'
 
 import styles from './ReplayHero.module.css'
 
 /**
- * ReplayHero — the hero visual is the product: a compiled workflow replaying
- * as a live run report. Steps resolve through the deterministic ladder, one
- * hits UI drift and re-resolves deterministically, and the run closes with
- * zero model calls.
+ * ReplayHero — a stylized, illustrative depiction of a compiled workflow
+ * replaying as a run report. Steps resolve through the deterministic ladder,
+ * one hits UI drift and re-resolves deterministically, and the run closes
+ * with zero model calls. The numbers shown are an illustration of the
+ * intended behavior, not captured benchmark data — a visible caption says so,
+ * and measured results live on the Compare page.
  * Pure DOM + CSS (no video, no canvas); plays while visible and restarts
  * from the top whenever it scrolls back into view, so every viewing starts
  * at step 1.0; static final frame under prefers-reduced-motion.
@@ -78,19 +81,20 @@ export default function ReplayHero() {
     }, [])
 
     return (
+        <figure className={styles.figure}>
         <div
             ref={frameRef}
             className={styles.frame}
-            aria-label="Example of a compiled workflow replaying and re-resolving UI drift"
+            aria-label="Illustrative example of a compiled workflow replaying and re-resolving UI drift"
         >
             <div className={styles.titlebar}>
                 <span className={styles.dot} />
                 <span className={styles.dot} />
                 <span className={styles.dot} />
-                <span className={styles.title}>referral-intake · compiled replay</span>
+                <span className={styles.title}>referral-intake · illustrative replay</span>
                 <span className={styles.badge}>
                     <span className={styles.badgeDot} aria-hidden="true" />
-                    local
+                    illustrative
                 </span>
             </div>
             <div className={styles.body} key={cycle}>
@@ -150,5 +154,11 @@ export default function ReplayHero() {
                 </div>
             </div>
         </div>
+            <figcaption className={styles.illustrative}>
+                Illustrative — a stylized depiction of a compiled replay, not
+                captured benchmark data. See{' '}
+                <Link href="/compare">measured results</Link>.
+            </figcaption>
+        </figure>
     )
 }

--- a/components/ReplayHero.module.css
+++ b/components/ReplayHero.module.css
@@ -1,3 +1,25 @@
+.figure {
+    margin: 0 auto;
+    width: 100%;
+    max-width: 640px;
+    min-width: 0;
+}
+
+.illustrative {
+    margin: 0.6rem auto 0;
+    max-width: 640px;
+    text-align: center;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    line-height: 1.5;
+    letter-spacing: 0.01em;
+    color: var(--ink-3);
+}
+
+.illustrative a {
+    color: var(--accent);
+}
+
 .frame {
     width: 100%;
     max-width: 640px;

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -43,14 +43,16 @@ describe('public product truth', () => {
         cy.visit('/')
     })
 
-    it('leads with the governed compiler and routes each audience', () => {
+    it('leads with the governed compiler and qualifies the buyer', () => {
         cy.get('h1').should(
             'contain.text',
-            'Compile repeated GUI work into governed, deterministic workflows.'
+            'Compile repeated GUI work. Verify the result. Halt when you can’t.'
         )
-        cy.contains('Developer').should('be.visible')
-        cy.contains('Automation & operations').should('be.visible')
-        cy.contains('Regulated enterprise').should('be.visible')
+        cy.contains(
+            'Use APIs first. Use OpenAdapt for the UI-only last mile.'
+        ).should('be.visible')
+        cy.contains('When OpenAdapt fits').should('be.visible')
+        cy.contains('When it isn’t the right tool').should('be.visible')
         cy.get('a[href$="#open-source"]').should('exist')
         cy.get('a[href$="#product-status"]').should('exist')
         cy.get('a[href="/security"]').should('exist')
@@ -210,8 +212,9 @@ describe('public product truth', () => {
             cy.contains('Product maturity').should('not.exist')
         })
         cy.get('#pricing').within(() => {
-            cy.contains('Run it yourself or launch with us').should('be.visible')
-            cy.contains('Managed browser').should('be.visible')
+            cy.contains('Start as a design partner').should('be.visible')
+            cy.contains('Scoped paid pilot').should('be.visible')
+            cy.contains('Early access').should('be.visible')
             cy.contains('Offer unavailable').should('not.exist')
             cy.contains('Hosted checkout unavailable').should('not.exist')
             cy.contains('approved sanitized copy').should('be.visible')
@@ -357,20 +360,8 @@ describe('public product truth', () => {
     })
 
     it('keeps benchmark proof concise and bounded', () => {
-        cy.get('[data-testid="benchmark-proof"]').within(() => {
-            cy.contains(
-                'Repeated work should not pay an agent to rethink the same task.'
-            ).should('be.visible')
-            cy.contains('In a bounded browser benchmark').should('be.visible')
-            cy.contains('not a production reliability claim').should('be.visible')
-            cy.contains(
-                'Review scope, samples, pricing basis, caveats, and raw results'
-            ).should('have.attr', 'href').and('include', 'benchmark/BENCHMARK.md')
-            cy.contains('N=').should('not.exist')
-            cy.contains('resets daily').should('not.exist')
-            cy.contains('introductory').should('not.exist')
-        })
-
+        // The homepage benchmark teaser was relocated to /compare, which holds
+        // the canonical measured evidence.
         cy.visit('/compare')
         cy.get('h1').should(
             'contain.text',
@@ -420,268 +411,24 @@ describe('public product truth', () => {
     })
 
     it('keeps buyer claims inside the shipped browser and tested safety scope', () => {
-        cy.get('#faq').within(() => {
-            cy.contains('Does hosted validation certify my workflow?').should(
-                'not.exist'
-            )
-            cy.contains('approved sanitized copy').should('be.visible')
-        })
-
-        cy.get('#industries').within(() => {
-            cy.contains("Who it's for").should('be.visible')
-            cy.contains('Automation teams & BPO operators').should('be.visible')
-            cy.contains('RCM & vertical-software vendors').should('be.visible')
-            cy.contains('Regulated enterprise operations').should('be.visible')
+        // FAQ moved to /compare; the per-application HowItWorks selector and
+        // the buyer-fit grid moved to the solution pages. The homepage now
+        // links each reference workflow directly and shows one real reference.
+        cy.get('#references').within(() => {
             cy.contains('Healthcare workflow reference').should('be.visible')
             cy.contains('Lending operations reference').should('be.visible')
             cy.contains('Insurance claims reference').should('be.visible')
-            cy.contains('Mortgage & lending ops').should('not.exist')
-            cy.contains("There's An AI For That").should('not.exist')
         })
-
-        cy.get('#how-it-works').within(() => {
-            cy.contains('button', 'Healthcare')
-                .should('have.attr', 'aria-pressed', 'true')
-            cy.contains('button', 'Browser')
-                .should('have.attr', 'aria-pressed', 'true')
-            cy.get('figure[data-execution-environment="browser"]')
-                .should('have.length', 5)
-                .each(($figure) => {
-                    cy.wrap($figure).should(
-                        'have.attr',
-                        'data-environment-source-kind',
-                        'application-footage'
-                    )
-                })
-            cy.get('img[alt*="OpenEMR"]').should('have.length', 5)
-            cy.get('[data-testid^="reference-"]')
-                .should('have.length', 3)
-                .each(($panel) => {
-                    cy.wrap($panel).should(
-                        'have.attr',
-                        'data-reference',
-                        'healthcare'
-                    )
-                })
-            cy.get('[data-testid="reference-compile-panel"]')
-                .should('contain.text', 'OpenEMR browser reference')
-                .and('contain.text', 'deployment-specific oracle required')
-                .and(
-                    'have.attr',
-                    'data-stage-source',
-                    '/how-it-works/record_openemr.gif'
-                )
-                .find('img')
-                .should('have.attr', 'src', '/how-it-works/record_openemr.gif')
-            cy.get('[data-testid="reference-resolve-panel"]')
-                .should('contain.text', 'OpenEMR browser reference')
-                .and(
-                    'have.attr',
-                    'data-stage-source',
-                    '/how-it-works/run_openemr.gif'
-                )
-                .find('img')
-                .should('have.attr', 'src', '/how-it-works/run_openemr.gif')
-            cy.get('[data-testid="reference-resolve-panel"]')
-                .find('[data-testid="resolve-target-track"]')
-                .should('have.attr', 'data-resolve-track', 'openemrTargets')
-                .and('have.attr', 'data-resolve-duration', '6.58s')
-            cy.get('[data-testid="reference-verify-panel"]')
-                .should('contain.text', 'qualification required')
-                .and('contain.text', 'No application-specific audit result claimed')
-                .and(
-                    'have.attr',
-                    'data-stage-source',
-                    '/how-it-works/run_openemr.gif'
-                )
-                .find('img')
-                .should('have.attr', 'src', '/how-it-works/run_openemr.gif')
-
-            cy.contains('button', 'Lending').click()
-            cy.contains('button', 'Lending')
-                .should('have.attr', 'aria-pressed', 'true')
-            cy.get('img[src="/lending-demo/record-frappe.gif"]').should(
-                'be.visible'
-            )
-            cy.get('img[src="/lending-demo/replay-frappe.gif"]').should(
-                'be.visible'
-            )
-            cy.get('[data-testid^="reference-"]')
-                .each(($panel) => {
-                    cy.wrap($panel).should(
-                        'have.attr',
-                        'data-reference',
-                        'lending'
-                    )
-                })
-            cy.get('[data-testid="reference-compile-panel"]')
-                .should('contain.text', 'Frappe Lending reference')
-                .and('contain.text', 'create-loan-application')
-                .and(
-                    'have.attr',
-                    'data-stage-source',
-                    '/lending-demo/record-frappe.gif'
-                )
-                .find('img')
-                .should('have.attr', 'src', '/lending-demo/record-frappe.gif')
-            cy.get('[data-testid="reference-resolve-panel"]')
-                .should('contain.text', 'Frappe Loan Application evidence')
-                .and(
-                    'have.attr',
-                    'data-stage-source',
-                    '/lending-demo/replay-frappe.gif'
-                )
-                .find('img')
-                .should('have.attr', 'src', '/lending-demo/replay-frappe.gif')
-            cy.get('[data-testid="reference-resolve-panel"]')
-                .find('[data-testid="resolve-target-track"]')
-                .should('have.attr', 'data-resolve-track', 'frappeTargets')
-                .and('have.attr', 'data-resolve-duration', '10.18s')
-            cy.get('[data-testid="reference-verify-panel"]')
-                .should('contain.text', '6 / 6 verified')
-                .and('contain.text', '0 silent incorrect successes')
-                .and(
-                    'have.attr',
-                    'data-stage-source',
-                    '/lending-demo/replay-frappe.gif'
-                )
-                .find('img')
-                .should('have.attr', 'src', '/lending-demo/replay-frappe.gif')
-
-            cy.contains('button', 'Insurance').click()
-            cy.contains('button', 'Insurance')
-                .should('have.attr', 'aria-pressed', 'true')
-            cy.get('img[src="/insurance-demo/record-openimis.gif"]').should(
-                'be.visible'
-            )
-            cy.get('img[src="/insurance-demo/replay-openimis.gif"]').should(
-                'be.visible'
-            )
-            cy.get('[data-testid^="reference-"]')
-                .each(($panel) => {
-                    cy.wrap($panel).should(
-                        'have.attr',
-                        'data-reference',
-                        'insurance'
-                    )
-                })
-            cy.get('[data-testid="reference-compile-panel"]')
-                .should('contain.text', 'openIMIS claims reference')
-                .and('contain.text', 'openimis-claim-intake')
-                .and(
-                    'have.attr',
-                    'data-stage-source',
-                    '/insurance-demo/record-openimis.gif'
-                )
-                .find('img')
-                .should(
-                    'have.attr',
-                    'src',
-                    '/insurance-demo/record-openimis.gif'
-                )
-            cy.get('[data-testid="reference-resolve-panel"]')
-                .should('contain.text', 'openIMIS claim-form evidence')
-                .and(
-                    'have.attr',
-                    'data-stage-source',
-                    '/insurance-demo/replay-openimis.gif'
-                )
-                .find('img')
-                .should(
-                    'have.attr',
-                    'src',
-                    '/insurance-demo/replay-openimis.gif'
-                )
-            cy.get('[data-testid="reference-resolve-panel"]')
-                .find('[data-testid="resolve-target-track"]')
-                .should('have.attr', 'data-resolve-track', 'openimisTargets')
-                .and('have.attr', 'data-resolve-duration', '19.79s')
-            cy.get('[data-testid="reference-verify-panel"]')
-                .should('contain.text', '3 / 3 verified')
-                .and('contain.text', '0 duplicate claims')
-                .and(
-                    'have.attr',
-                    'data-stage-source',
-                    '/insurance-demo/replay-openimis.gif'
-                )
-                .find('img')
-                .should(
-                    'have.attr',
-                    'src',
-                    '/insurance-demo/replay-openimis.gif'
-                )
-            cy.contains('View the bounded use case')
-                .should('have.attr', 'href')
-                .and('equal', '/solutions/insurance')
-
-            cy.contains('button', 'RDP').click()
-            cy.contains('button', 'RDP')
-                .should('have.attr', 'aria-pressed', 'true')
-            cy.contains('button', 'Insurance')
-                .should('have.attr', 'aria-pressed', 'true')
-            cy.get('figure[data-execution-environment="rdp"]')
-                .should('have.length', 5)
-                .each(($figure) => {
-                    cy.wrap($figure).should(
-                        'have.attr',
-                        'data-environment-source-kind',
-                        'transport-visualization'
-                    )
-                })
-            cy.contains('governed RDP transport path').should('be.visible')
-            cy.get('img[src="/insurance-demo/record-openimis.gif"]').should(
-                'be.visible'
-            )
-
-            cy.contains('button', 'Citrix').click()
-            cy.contains('button', 'Citrix')
-                .should('have.attr', 'aria-pressed', 'true')
-            cy.get('figure[data-execution-environment="citrix"]')
-                .should('have.length', 5)
-                .and(
-                    'have.attr',
-                    'data-environment-source-kind',
-                    'transport-visualization'
-                )
-            cy.contains('governed ICA/HDX transport path').should(
-                'be.visible'
-            )
-
-            cy.contains('button', 'Linux').click()
-            cy.contains(
-                'Native Linux execution uses AT-SPI structural evidence'
-            ).should('be.visible')
-            cy.get('figure[data-execution-environment="linux"]')
-                .should('have.length', 5)
-                .and(
-                    'have.attr',
-                    'data-environment-source-kind',
-                    'environment-visualization'
-                )
-
-            for (const environment of ['Windows', 'macOS', 'Browser']) {
-                cy.contains('button', environment).click()
-                cy.contains('button', environment).should(
-                    'have.attr',
-                    'aria-pressed',
-                    'true'
-                )
-            }
-        })
+        cy.get('[data-testid="frappe-lending-workflow-demo"]')
+            .scrollIntoView()
+            .should('be.visible')
+        cy.contains('6/6 compiled trials correct').should('be.visible')
 
         cy.viewport(375, 812)
         cy.visit('/')
-        cy.get('#how-it-works').within(() => {
-            cy.contains('button', 'Insurance').click()
-            cy.contains('button', 'Citrix').click()
-            cy.get('img[src="/insurance-demo/record-openimis.gif"]').should(
-                'be.visible'
-            )
-            cy.get('figure[data-execution-environment="citrix"]').should(
-                'have.length',
-                5
-            )
-        })
+        cy.get('[data-testid="frappe-lending-workflow-demo"]')
+            .scrollIntoView()
+            .should('be.visible')
         cy.document().then((document) => {
             expect(document.documentElement.scrollWidth).to.be.at.most(375)
         })

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -212,9 +212,11 @@ describe('public product truth', () => {
             cy.contains('Product maturity').should('not.exist')
         })
         cy.get('#pricing').within(() => {
-            cy.contains('Start as a design partner').should('be.visible')
+            cy.contains('Run it yourself, subscribe, or start a pilot').should(
+                'be.visible'
+            )
             cy.contains('Scoped paid pilot').should('be.visible')
-            cy.contains('Early access').should('be.visible')
+            cy.contains('Beta / public offer').should('be.visible')
             cy.contains('Offer unavailable').should('not.exist')
             cy.contains('Hosted checkout unavailable').should('not.exist')
             cy.contains('approved sanitized copy').should('be.visible')

--- a/cypress/e2e/dashboard-showcase.cy.js
+++ b/cypress/e2e/dashboard-showcase.cy.js
@@ -58,7 +58,7 @@ describe('Cloud product preview', () => {
     it('supports the guided tour and interactive reference states', () => {
         cy.viewport(1280, 1700)
         cy.then(() => emulateReducedMotion('no-preference'))
-        cy.visit('/', { onBeforeLoad: preferMotion })
+        cy.visit('/hosted/welcome', { onBeforeLoad: preferMotion })
 
         cy.get('#cloud-product').scrollIntoView().should('be.visible')
         cy.get('[data-testid="dashboard-product-preview"]').within(() => {
@@ -143,7 +143,7 @@ describe('Cloud product preview', () => {
     it('keeps the interactive preview static for reduced motion on mobile', () => {
         cy.viewport(390, 844)
         cy.then(() => emulateReducedMotion('reduce'))
-        cy.visit('/', { onBeforeLoad: preferReducedMotion })
+        cy.visit('/hosted/welcome', { onBeforeLoad: preferReducedMotion })
 
         cy.get('#cloud-product').scrollIntoView().should('be.visible')
         cy.get('[data-testid="dashboard-product-preview"]').within(() => {

--- a/pages/compare.js
+++ b/pages/compare.js
@@ -3,7 +3,21 @@ import Link from 'next/link'
 
 import Footer from '@components/Footer'
 import BenchmarkCharts from '@components/BenchmarkCharts'
+import Faq, { faqItems } from '@components/Faq'
 import benchmark from '../data/benchmark.json'
+
+const faqSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faqItems.map((item) => ({
+        '@type': 'Question',
+        name: item.question,
+        acceptedAnswer: {
+            '@type': 'Answer',
+            text: item.answer,
+        },
+    })),
+}
 
 const description =
     'See when OpenAdapt, traditional RPA, computer-use agents, or browser recorders fit repeated GUI work. Compare authoring, run economics, change handling, verification, and deployment.'
@@ -115,6 +129,12 @@ export default function ComparePage() {
                     type="application/ld+json"
                     dangerouslySetInnerHTML={{
                         __html: JSON.stringify(webPageSchema),
+                    }}
+                />
+                <script
+                    type="application/ld+json"
+                    dangerouslySetInnerHTML={{
+                        __html: JSON.stringify(faqSchema),
                     }}
                 />
             </Head>
@@ -371,6 +391,10 @@ export default function ComparePage() {
                         </Link>
                     </p>
                 </section>
+
+                <div className="mt-14">
+                    <Faq />
+                </div>
 
                 <section className="mt-14 rounded-2xl border-2 border-ink bg-panel p-6 text-center md:p-8">
                     <h2 className="font-display text-2xl font-semibold tracking-tight text-ink">

--- a/pages/download.js
+++ b/pages/download.js
@@ -4,6 +4,7 @@ import Link from 'next/link'
 
 import DesktopPreview from '@components/DesktopPreview'
 import Footer from '@components/Footer'
+import PyPIDownloadChart from '@components/PyPIDownloadChart'
 import { track } from 'utils/analytics'
 import {
     assetForPlatform,
@@ -480,6 +481,10 @@ export default function DownloadPage({ release, fetchFailed }) {
                         </a>
                     </div>
                 </div>
+            </div>
+
+            <div className="mx-auto w-full max-w-5xl px-4 pb-12">
+                <PyPIDownloadChart />
             </div>
 
             <Footer />

--- a/pages/hosted/welcome.js
+++ b/pages/hosted/welcome.js
@@ -1,6 +1,7 @@
 import Head from 'next/head'
 import Link from 'next/link'
 
+import DashboardShowcase from '@components/DashboardShowcase'
 import Footer from '@components/Footer'
 
 /*
@@ -123,6 +124,7 @@ export default function HostedWelcome() {
                     </Link>
                 </div>
             </div>
+            <DashboardShowcase />
             <Footer />
         </div>
     )

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,23 +1,18 @@
-import { useRef, useState } from 'react'
 import Head from 'next/head'
+import Link from 'next/link'
 
 import ContactBookingSection from '@components/ContactBookingSection'
-import DashboardShowcase from '@components/DashboardShowcase'
 import Developers from '@components/Developers'
 import DriftOutcomes from '@components/DriftOutcomes'
 import EmailForm from '@components/EmailForm'
-import Faq, { faqItems } from '@components/Faq'
 import Footer from '@components/Footer'
-import HowItWorks from '@components/HowItWorks'
-import IndustriesGrid from '@components/IndustriesGrid'
+import HowItWorksCondensed from '@components/HowItWorksCondensed'
+import LendingWorkflowDemo from '@components/LendingWorkflowDemo'
 import MastHead from '@components/MastHead'
 import Pricing from '@components/Pricing'
 import ProductStatus from '@components/ProductStatus'
-import ProofBand from '@components/ProofBand'
-import AudiencePaths from '@components/AudiencePaths'
+import Qualification from '@components/Qualification'
 import Reveal from '@components/Reveal'
-import SafetyBand from '@components/SafetyBand'
-// import SocialSection from '@components/SocialSection' // Temporarily disabled - feeds not working
 
 const organizationSchema = {
     '@context': 'https://schema.org',
@@ -105,18 +100,11 @@ const websiteSchema = {
     inLanguage: 'en',
 }
 
-const faqSchema = {
-    '@context': 'https://schema.org',
-    '@type': 'FAQPage',
-    mainEntity: faqItems.map((item) => ({
-        '@type': 'Question',
-        name: item.question,
-        acceptedAnswer: {
-            '@type': 'Answer',
-            text: item.answer,
-        },
-    })),
-}
+const referenceLinks = [
+    { label: 'Healthcare workflow reference', href: '/solutions/healthcare' },
+    { label: 'Lending operations reference', href: '/solutions/lending' },
+    { label: 'Insurance claims reference', href: '/solutions/insurance' },
+]
 
 export async function getStaticProps() {
     // Seed the initial HTML with the shared cached/verified repository stats.
@@ -140,13 +128,6 @@ export async function getStaticProps() {
 }
 
 export default function Home({ githubStats, buildWarnings, hostedOffer }) {
-    const [feedbackData, setFeedbackData] = useState({
-        email: '',
-        message: '',
-    })
-
-    const sectionRef = useRef(null)
-
     return (
         <div>
             <Head>
@@ -169,23 +150,40 @@ export default function Home({ githubStats, buildWarnings, hostedOffer }) {
                         __html: JSON.stringify(websiteSchema),
                     }}
                 />
-                <script
-                    type="application/ld+json"
-                    dangerouslySetInnerHTML={{
-                        __html: JSON.stringify(faqSchema),
-                    }}
-                />
             </Head>
             <MastHead githubStats={githubStats} />
             <Reveal>
-                <AudiencePaths />
+                <Qualification />
             </Reveal>
             <Reveal>
-                <DashboardShowcase />
+                <HowItWorksCondensed />
             </Reveal>
             <Reveal>
-                <HowItWorks showUseCases />
+                <LendingWorkflowDemo />
             </Reveal>
+            <section
+                id="references"
+                className="border-b border-hairline bg-panel px-5 py-10"
+            >
+                <div className="mx-auto max-w-5xl text-center">
+                    <p className="eyebrow">More reference workflows</p>
+                    <p className="mx-auto mt-2 max-w-2xl text-sm leading-relaxed text-ink-2">
+                        Each reference is a bounded, synthetic fixture with its
+                        own honest evidence and caveats.
+                    </p>
+                    <div className="mt-5 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm">
+                        {referenceLinks.map((reference) => (
+                            <Link
+                                key={reference.href}
+                                href={reference.href}
+                                className="font-medium text-accent hover:underline"
+                            >
+                                {reference.label}
+                            </Link>
+                        ))}
+                    </div>
+                </div>
+            </section>
             <Reveal>
                 <DriftOutcomes />
             </Reveal>
@@ -193,33 +191,16 @@ export default function Home({ githubStats, buildWarnings, hostedOffer }) {
                 <ProductStatus />
             </Reveal>
             <Reveal>
-                <ProofBand />
-            </Reveal>
-            <Reveal>
-                <SafetyBand />
-            </Reveal>
-            <Reveal>
-                <IndustriesGrid
-                    feedbackData={feedbackData}
-                    setFeedbackData={setFeedbackData}
-                    sectionRef={sectionRef}
-                />
-            </Reveal>
-            <Reveal>
                 <Pricing hostedOffer={hostedOffer} />
+            </Reveal>
+            <Reveal>
+                <ContactBookingSection />
             </Reveal>
             <Reveal>
                 <Developers
                     buildWarnings={buildWarnings}
                     githubStats={githubStats}
                 />
-            </Reveal>
-            {/* <SocialSection /> */} {/* Temporarily disabled - feeds not working */}
-            <Reveal>
-                <Faq />
-            </Reveal>
-            <Reveal>
-                <ContactBookingSection prefill={feedbackData} />
             </Reveal>
             <Reveal>
                 <EmailForm />

--- a/tests/dashboardShowcase.test.js
+++ b/tests/dashboardShowcase.test.js
@@ -7,12 +7,15 @@ const root = path.join(__dirname, '..')
 const read = (relativePath) =>
     fs.readFileSync(path.join(root, relativePath), 'utf8')
 
-test('homepage shows a code-native interactive Cloud preview', () => {
-    const home = read('pages/index.js')
+test('hosted onboarding shows a code-native interactive Cloud preview', () => {
+    // The Cloud product preview was relocated off the (deliberately shorter)
+    // marketing homepage to the hosted onboarding page, where the Cloud
+    // product is the relevant context.
+    const hosted = read('pages/hosted/welcome.js')
     const component = read('components/DashboardShowcase.js')
 
-    assert.match(home, /import DashboardShowcase/)
-    assert.match(home, /<DashboardShowcase \/>/)
+    assert.match(hosted, /import DashboardShowcase/)
+    assert.match(hosted, /<DashboardShowcase \/>/)
     assert.match(component, /OpenAdapt/)
     assert.match(component, /Cloud/)
     assert.match(component, /Choose a reference workflow/)

--- a/tests/insuranceReference.test.js
+++ b/tests/insuranceReference.test.js
@@ -53,7 +53,10 @@ test('insurance reference is linked from the buyer-fit grid and llms.txt', () =>
     assert.match(industries, /\/solutions\/insurance/)
     assert.match(footer, /\/solutions\/insurance/)
     assert.match(nav, /\/solutions\/insurance/)
-    assert.match(home, /<HowItWorks showUseCases \/>/)
+    // The homepage links every reference workflow directly (the full
+    // per-application HowItWorks selector now lives on the solution pages).
+    assert.match(home, /\/solutions\/insurance/)
+    assert.match(home, /Insurance claims reference/)
     for (const useCase of ['Healthcare', 'Lending', 'Insurance']) {
         assert.match(howItWorks, new RegExp(`label: '${useCase}'`))
     }


### PR DESCRIPTION
## What & why

Addresses review findings **#4 (homepage too long)** and **#5 (premature packaging)**. Consistency / clarity / honesty only — no new product features. Stripe wiring untouched. `tests/publicTruth.test.js` is unchanged.

Branch is rebased on current `main` (picks up the status manifest #222, `/security` #220, `/workflows` #221 — no file overlap, clean rebase).

## #4 — Homepage focus

Cut the 15-section homepage to a focused funnel and **relocated** (not deleted) the heavier sections.

**New order:** Hero → Qualification → How it works (3 steps) → one real reference workflow (Frappe Lending) → more-references links → repair & limits → where it runs → offer → booking → local quickstart → updates.

**Relocated, content preserved:**
- Cloud product preview (`DashboardShowcase`) → `/hosted/welcome`
- FAQ + FAQPage schema → `/compare`
- PyPI package-adoption chart → `/download`
- Full 5-stage per-application `HowItWorks` selector → stays on the solution pages
- Benchmark teaser (`ProofBand`) → canonical evidence already on `/compare`
- Buyer-fit grid / three-audience paths → folded into the new Qualification + Pricing cards (component files retained)

**Same-environment before → after (Electron, 1280px):**

| Metric | Before (`main`) | After | Δ |
| --- | --- | --- | --- |
| Document height | 16,376px | 11,063px | **−5,313px (−32%)** |
| `<h2>` | 15 | 8 | −7 |
| `<button>` | 29 | 8 | −21 |
| `<a>` | 85 | 64 | −21 |
| `<section>` | 10 | 8 | −2 |

Hero CTA (`Evaluate a workflow` / `Try locally`) now renders **above** the hero animation, i.e. above the fold. Design system, motion tokens, reduced-motion, and no-layout-shift behavior preserved.

## Animation-honesty fix

The stylized `ReplayHero` terminal (shows `VERIFIED · 0 MODEL CALLS`, `cost per run: $0.00`, `total 2.4s`) previously read as benchmark evidence. It now carries a **visible caption** — *"Illustrative — a stylized depiction of a compiled replay, not captured benchmark data. See measured results."* (links to `/compare`) — plus an `illustrative` title-bar badge and updated aria-label. Real captured footage still appears in the Frappe reference workflow below the hero.

## #5 — Packaging reframe (reconciled with the status manifest)

The `$500/mo, 10,000 runs` presentation implied frictionless self-serve. Reframed to lead with the assisted / pilot motion **without** downgrading the live offer:

- Section: **"Run it yourself, subscribe, or start a pilot."**
- **Hosted browser card** stays a live, purchasable offer. Its maturity label is now read verbatim from `public/status.json` → renders **"Beta / public offer"** (cannot drift from the manifest). Copy states onboarding is **assisted**, not one-click self-serve. The $500/mo Stripe price and checkout path are unchanged.
- **Design-partner card** now clearly leads the scoped-paid-pilot motion for the design-partner-only substrates (Windows, macOS, RDP, Citrix, regulated), priced after qualification.
- Hero copy aligned to canonical terms: Browser in Beta; Windows/macOS/remote desktops are design-partner only.

> Reconciliation note: an earlier draft of this branch relabeled Hosted as "Early Access"; per the canonical status manifest + AGENTS.md (a live offer must not be waitlist-positioned), it is now **"Beta / public offer"**, read from `public/status.json`.

## 🚩 Founder decisions

1. **Pilot price range.** The review suggested $15–50k. I did **not** hardcode any figure — the pilot is presented as *"scoped paid pilot, priced after qualification."* Decide whether to publish a range.
2. **Keep the $500/mo self-serve hosted card?** Kept as a live **"Beta / public offer"** with assisted-onboarding framing (per manifest + AGENTS.md). If you'd rather narrow it (e.g. concierge-only), that's a one-line copy call.

## publicTruth impact

`tests/publicTruth.test.js` — **unchanged**, still green. Two non-publicTruth coherence tests were updated to match the new (equally honest) structure, with rationale in-file:
- `insuranceReference.test.js`: homepage now links the insurance reference **directly** (the full selector moved to solution pages) instead of asserting `<HowItWorks showUseCases />`.
- `dashboardShowcase.test.js`: asserts the Cloud preview renders on `pages/hosted/welcome.js` (its new home).

Cypress specs (`basic`, `dashboard-showcase`) updated to the new DOM.

## Gates

- `node --test tests/*.test.js` → **82/82 pass**
- `next build` → **exit 0**
- `cypress run` (Electron, headless, all 5 specs) → **30/30 pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM
