### PR TITLE
feat(site): lead with the target-state product across hero and pricing

### DIFF
--- a/components/MastHead.js
+++ b/components/MastHead.js
@@ -53,14 +53,14 @@ export default function Home({ githubStats }) {
                             <p className="mt-0 mb-6 mx-auto max-w-2xl font-sans font-normal text-base md:text-lg text-ink-2">
                                 Demonstrate a bounded, repeated GUI workflow and
                                 compile it into a locally executable program whose
-                                healthy replay makes no model calls. Under interface
-                                drift OpenAdapt re-resolves from retained evidence,
-                                proposes a governed repair, or halts for an
-                                operator. Browser workflows run in Beta today;
-                                Windows, macOS, and remote desktops are
-                                design-partner only.{' '}
+                                healthy replay makes no model calls. OpenAdapt brings
+                                the same governed loop to the interfaces your work is
+                                trapped behind &mdash; browser, Windows, RDP, and
+                                Citrix/VDI &mdash; re-resolving from retained
+                                evidence, proposing a governed repair, or halting for
+                                an operator when verification fails.{' '}
                                 <Link href="#product-status">
-                                    See where it runs.
+                                    See where each capability stands.
                                 </Link>
                             </p>
                             <div id="register">

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -137,9 +137,9 @@ export default function Pricing({ hostedOffer = null }) {
                 <p className="mx-auto mt-3 max-w-2xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
                     Run the MIT-licensed engine yourself for free. Subscribe to
                     managed browser execution &mdash; a live offer in Beta, with
-                    assisted onboarding rather than one-click self-serve. For
-                    consequential desktop, Citrix, or regulated workflows, start
-                    a scoped paid pilot as a design partner.
+                    assisted onboarding as we qualify your first workflow. Bring
+                    OpenAdapt to desktop, Citrix, and regulated workflows through
+                    a scoped paid pilot.
                 </p>
 
                 <div className="mt-10 grid items-start gap-6 md:grid-cols-3">
@@ -268,9 +268,8 @@ export default function Pricing({ hostedOffer = null }) {
                             Priced after qualification
                         </p>
                         <p className="mt-3 text-sm leading-relaxed text-ink-2">
-                            The way to start on Windows, macOS, RDP, Citrix, or
-                            regulated data &mdash; substrates offered to design
-                            partners only. We qualify the substrate, artifact
+                            Bring the governed loop to Windows, macOS, RDP, Citrix,
+                            or regulated data. We qualify the substrate, artifact
                             policy, effect oracle, and operating model with you in
                             a customer-controlled boundary, then scope and price
                             the pilot before production use.


### PR DESCRIPTION
## Lead with the target-state product, keep the proof one click away

Per the founder's repeated directive, the primary marketing voice should present
the full target-state product with confidence: OpenAdapt is the governed
automation platform for the repeated GUI workflows that legacy Windows,
Citrix/VDI, RDP, and browser interfaces trap. Windows/macOS/Citrix/browser are
core product capabilities, not caveated footnotes.

This is a **positioning/voice change only** — no functional, data, or evidence
change. After the recent homepage cut (#223), status manifest (#222), trust
center (#220), and `/workflows` catalog (#221), the solutions/product/compare
pages were already capabilities-first. The two remaining places where a
defensive hedge was still the **lead** framing were the hero paragraph and the
pricing intro/pilot card. Those are reframed here.

### Before → after

**Hero (`components/MastHead.js`)**
- Before: "…Under interface drift OpenAdapt re-resolves… **Browser workflows run
  in Beta today; Windows, macOS, and remote desktops are design-partner only.**
  See where it runs."
- After: "…OpenAdapt **brings the same governed loop to the interfaces your work
  is trapped behind — browser, Windows, RDP, and Citrix/VDI —** re-resolving from
  retained evidence, proposing a governed repair, or halting for an operator when
  verification fails. **See where each capability stands.**"
- The "design-partner only" caveat is removed from the lead; substrate breadth is
  stated as a core capability. The honest per-surface status is one click away via
  the same link, now pointing readers to the evidence section explicitly ("See
  where each capability stands" → `#product-status`, which renders the
  `status.json`-driven readiness matrix unchanged).

**Pricing intro (`components/Pricing.js`)**
- Before: "…assisted onboarding **rather than one-click self-serve**. For
  consequential desktop, Citrix, or regulated workflows, start a scoped paid pilot
  **as a design partner**."
- After: "…assisted onboarding **as we qualify your first workflow**. **Bring
  OpenAdapt to desktop, Citrix, and regulated workflows** through a scoped paid
  pilot."
- Same truthful meaning (still assisted, still a scoped pilot, still Beta), stated
  as capability rather than apology.

**Pricing pilot card (`components/Pricing.js`)**
- Before: "The way to start on Windows, macOS, RDP, Citrix, or regulated data —
  **substrates offered to design partners only.** We qualify the substrate…"
- After: "**Bring the governed loop to** Windows, macOS, RDP, Citrix, or regulated
  data. We qualify the substrate…"
- The "offered to design partners only" lead hedge is removed. The pilot mechanism
  (qualification → scope → price) stays intact and honest, and the "Design
  partner" / "Scoped pilot" badges still describe the engagement model.

### Honesty floor — what was deliberately KEPT (not weakened)
- `public/status.json` and its per-surface labels ("Scoped acceptance — design
  partners only", "Research / design-partner qualification") — **unchanged**. This
  is the honest proof matrix rendered under `#product-status`.
- `components/ProductStatus.js` "Where each interface stands today / One honest
  readiness label per surface" section — **unchanged**; still linked from the hero.
- `/workflows` catalog, LIMITS link, `/security` trust center, `/compare`
  methodology, `/safety` bounded test cases — **unchanged and still linked**.
- `ReplayHero` "Illustrative — a stylized depiction… not a live capture" label
  (an honesty-floor item added in #223) — **unchanged**.
- "Beta" lifecycle label on the hosted card and the sanitized-upload / PHI
  boundary note in pricing — **unchanged**.
- No sentence asserts a specific false completed fact (no SOC 2, no "validated in
  production at N clinics", no false safety-validation). The new copy is
  target-state product/architecture description ("brings the governed loop to…"),
  which matches the founder's explicitly-allowed framing.

### publicTruth guards
- **No guard was touched or weakened.** All 82 node tests pass unchanged,
  including every `publicTruth.test.js` guard. In particular the anti-overclaim
  guard (`record once|runs forever|self-heal|milliseconds`) and the required
  `bounded workflow` / `governed repair` slogans still pass, and the
  false-completed-fact guards in `statusManifest.test.js` (which pin the honest
  `status.json` labels) are untouched. Because the recent capabilities-first cut
  already loosened the guards for target-state wording, this reframe fit inside
  them with no guard change required.

### Flag for founder review (closest to the honesty floor)
- The hero now names **Citrix/VDI** alongside browser/Windows/RDP as an interface
  the governed loop is brought to. `status.json` records that no validated ICA/HDX
  integration exists yet (research / design-partner qualification). The wording is
  a capability/architecture statement ("brings the same governed loop to…"), not a
  present-tense "runs in production on Citrix" claim, and the adjacent "See where
  each capability stands" link discloses Citrix's actual status. I judged this on
  the allowed side of the floor (matches the sanctioned "OpenAdapt automates Citrix
  workflows through governed pixel execution" example), but flagging it explicitly
  since Citrix is the least-proven named substrate.

### Gates
- `npm test` — 82/82 pass
- `npm run build` — succeeds (prebuild reruns the full test suite)
- Cypress e2e — 30/30 pass (5 specs) against `npm start`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM
