### PR TITLE
feat(site): share one vertical selection across homepage reference sections

### DIFF
--- a/components/HomeReferenceWorkflow.js
+++ b/components/HomeReferenceWorkflow.js
@@ -1,0 +1,238 @@
+import Clip from './Clip'
+import processStyles from './HowItWorks.module.css'
+import panelStyles from './LendingWorkflowDemo.module.css'
+import styles from './HomeReferenceWorkflow.module.css'
+import { HOME_REFERENCES } from '../data/referenceWorkflows'
+
+// Homepage process / "reference workflow" section. The selected vertical is
+// LIFTED to pages/index.js so this section and the "More reference workflows"
+// list share ONE selection: picking a vertical here updates the list, and
+// picking one in the list updates this section.
+//
+// The animated footage keeps the #213/#214 behavior: each stage clip is an
+// <img> pointed directly at the looping GIF (via <Clip>), and every stage is
+// keyed by the selected vertical so switching restarts the footage from its
+// first frame. Reduced-motion handling lives in the GIF assets and the shared
+// Clip styling, exactly as on the solution pages — no bespoke play/pause
+// control is reintroduced here.
+
+function CompilePanel({ compile }) {
+    return (
+        <figure className={panelStyles.evidenceFigure}>
+            <div className={panelStyles.panelHeader}>
+                <span>workflow.json</span>
+                <span className={panelStyles.status}>compiled</span>
+            </div>
+            <dl className={panelStyles.contract}>
+                <div>
+                    <dt>workflow</dt>
+                    <dd>{compile.workflow}</dd>
+                </div>
+                <div>
+                    <dt>parameters</dt>
+                    <dd>{compile.parameters}</dd>
+                </div>
+                <div>
+                    <dt>target</dt>
+                    <dd>{compile.target}</dd>
+                </div>
+                <div>
+                    <dt>effect</dt>
+                    <dd>{compile.effect}</dd>
+                </div>
+                <div>
+                    <dt>healthy run</dt>
+                    <dd>{compile.healthy}</dd>
+                </div>
+            </dl>
+            <figcaption className={panelStyles.caption}>
+                Compile — inspectable task contract derived from the recorded
+                synthetic workflow
+            </figcaption>
+        </figure>
+    )
+}
+
+function VerificationPanel({ verify }) {
+    return (
+        <figure className={panelStyles.evidenceFigure}>
+            <div className={panelStyles.panelHeader}>
+                <span>{verify.heading}</span>
+                <span
+                    className={
+                        verify.qualified
+                            ? panelStyles.status
+                            : styles.statusAttention
+                    }
+                >
+                    {verify.qualified ? 'verified' : 'qualification required'}
+                </span>
+            </div>
+            <ul className={panelStyles.checks}>
+                {verify.checks.map(([label, value]) => (
+                    <li key={label}>
+                        <span
+                            className={
+                                verify.qualified
+                                    ? panelStyles.checkmark
+                                    : styles.pendingMark
+                            }
+                            aria-hidden="true"
+                        >
+                            {verify.qualified ? '✓' : '•'}
+                        </span>
+                        <span>
+                            <strong>{label}</strong>
+                            <small>{value}</small>
+                        </span>
+                    </li>
+                ))}
+            </ul>
+            <div className={panelStyles.metrics}>
+                {verify.metrics.map((metric) => (
+                    <span key={metric}>{metric}</span>
+                ))}
+            </div>
+            <figcaption className={panelStyles.caption}>
+                {verify.caption}
+            </figcaption>
+        </figure>
+    )
+}
+
+export default function HomeReferenceWorkflow({ vertical, onSelectVertical }) {
+    const reference =
+        HOME_REFERENCES.find((item) => item.key === vertical) ||
+        HOME_REFERENCES[0]
+
+    const steps = [
+        {
+            number: '1.0',
+            name: 'Demonstrate',
+            description:
+                'Complete one bounded, synthetic instance while OpenAdapt captures the browser evidence and input events.',
+            visual: (
+                <Clip
+                    key={`${reference.key}-record`}
+                    clip={reference.record}
+                />
+            ),
+        },
+        {
+            number: '2.0',
+            name: 'Compile',
+            description:
+                'Turn the demonstration into a parameterized, inspectable workflow with a declared business effect.',
+            visual: (
+                <CompilePanel
+                    key={`${reference.key}-compile`}
+                    compile={reference.compile}
+                />
+            ),
+        },
+        {
+            number: '3.0',
+            name: 'Replay',
+            description:
+                'Execute the compiled steps locally without asking a model to reinterpret the task.',
+            visual: (
+                <Clip
+                    key={`${reference.key}-replay`}
+                    clip={reference.replay}
+                />
+            ),
+        },
+        {
+            number: '4.0',
+            name: reference.verify.qualified
+                ? 'Verify the write'
+                : 'Qualify the effect',
+            description: reference.verify.qualified
+                ? 'Check the saved record through a separately authenticated read-only session and a direct database delta audit.'
+                : 'Gate execution on a deployment-specific effect oracle and configured identity policy before any correctness claim.',
+            visual: (
+                <VerificationPanel
+                    key={`${reference.key}-verify`}
+                    verify={reference.verify}
+                />
+            ),
+        },
+    ]
+
+    return (
+        <section
+            data-testid="home-reference-workflow"
+            data-reference={reference.key}
+            className={processStyles.section}
+        >
+            <div className={processStyles.inner}>
+                <p className={processStyles.eyebrow}>{reference.eyebrow}</p>
+                <h2 className={processStyles.heading}>{reference.heading}</h2>
+                <p className={processStyles.subheading}>
+                    {reference.subheading}
+                </p>
+
+                <div className={processStyles.references}>
+                    <div className={processStyles.selectorBlock}>
+                        <p className={processStyles.referenceLabel}>
+                            Reference workflow
+                        </p>
+                        <div
+                            className={processStyles.tabs}
+                            role="group"
+                            aria-label="Reference workflow vertical"
+                        >
+                            {HOME_REFERENCES.map((item) => (
+                                <button
+                                    key={item.key}
+                                    type="button"
+                                    className={processStyles.tab}
+                                    aria-pressed={item.key === reference.key}
+                                    data-testid={`home-reference-tab-${item.key}`}
+                                    onClick={() => onSelectVertical(item.key)}
+                                >
+                                    <span>{item.label}</span>
+                                    <small>{item.application}</small>
+                                </button>
+                            ))}
+                        </div>
+                        <p className={styles.selectorNote}>
+                            Each reference is a bounded, synthetic fixture with
+                            its own honest evidence and caveats.
+                        </p>
+                    </div>
+                </div>
+
+                <ol className={processStyles.steps}>
+                    {steps.map((step) => (
+                        <li key={step.number} className={processStyles.step}>
+                            <div className={processStyles.copy}>
+                                <span className={processStyles.number}>
+                                    {step.number}
+                                </span>
+                                <div className={processStyles.body}>
+                                    <h3 className={processStyles.name}>
+                                        {step.name}
+                                    </h3>
+                                    <p className={processStyles.description}>
+                                        {step.description}
+                                    </p>
+                                </div>
+                            </div>
+                            <div className={processStyles.clip}>
+                                {step.visual}
+                            </div>
+                        </li>
+                    ))}
+                </ol>
+
+                <div className={panelStyles.disclosure}>
+                    <p>{reference.disclosure.text}</p>
+                    <a href={reference.disclosure.linkHref}>
+                        {reference.disclosure.linkLabel}
+                    </a>
+                </div>
+            </div>
+        </section>
+    )
+}

--- a/components/HomeReferenceWorkflow.module.css
+++ b/components/HomeReferenceWorkflow.module.css
@@ -1,0 +1,30 @@
+/*
+ * Homepage reference-workflow selector: honest status treatment.
+ *
+ * The verified verticals reuse the accent "verified" pill from
+ * LendingWorkflowDemo.module.css. The Healthcare reference is NOT verified, so
+ * it must not borrow the accent/verified look — this attention pill and the
+ * neutral pending marker keep the qualification-required state visually
+ * distinct from a passed audit.
+ */
+
+.statusAttention {
+    padding: 3px 8px;
+    border: 1px solid color-mix(in srgb, var(--ink-3) 45%, transparent);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--ink-3) 10%, transparent);
+    color: var(--ink-2);
+}
+
+.pendingMark {
+    color: var(--ink-3);
+    font-weight: 700;
+}
+
+.selectorNote {
+    margin: 12px 0 0;
+    color: var(--ink-3);
+    font-size: 12px;
+    line-height: 1.5;
+    text-align: center;
+}

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -415,20 +415,23 @@ describe('public product truth', () => {
     it('keeps buyer claims inside the shipped browser and tested safety scope', () => {
         // FAQ moved to /compare; the per-application HowItWorks selector and
         // the buyer-fit grid moved to the solution pages. The homepage now
-        // links each reference workflow directly and shows one real reference.
+        // shares ONE selected vertical between the reference list and the
+        // reference-workflow section (defaulting to the verified Lending
+        // reference); see cypress/e2e/homepage-vertical-sync.cy.js.
         cy.get('#references').within(() => {
             cy.contains('Healthcare workflow reference').should('be.visible')
             cy.contains('Lending operations reference').should('be.visible')
             cy.contains('Insurance claims reference').should('be.visible')
         })
-        cy.get('[data-testid="frappe-lending-workflow-demo"]')
+        cy.get('[data-testid="home-reference-workflow"]')
             .scrollIntoView()
             .should('be.visible')
+            .and('have.attr', 'data-reference', 'lending')
         cy.contains('6/6 compiled trials correct').should('be.visible')
 
         cy.viewport(375, 812)
         cy.visit('/')
-        cy.get('[data-testid="frappe-lending-workflow-demo"]')
+        cy.get('[data-testid="home-reference-workflow"]')
             .scrollIntoView()
             .should('be.visible')
         cy.document().then((document) => {

--- a/cypress/e2e/homepage-vertical-sync.cy.js
+++ b/cypress/e2e/homepage-vertical-sync.cy.js
@@ -1,0 +1,92 @@
+// The homepage reference selector is shared: the process/reference-workflow
+// section and the "More reference workflows" list read and write ONE lifted
+// vertical. Selecting a vertical in either section must update the other, and
+// the choice must be deep-linkable via ?ref=.
+
+describe('Homepage reference-vertical sync', () => {
+    it('keeps the process section and the reference list on one shared vertical', () => {
+        cy.viewport(1280, 1800)
+        cy.visit('/')
+
+        // Default: the homepage leads with the verified Lending reference, and
+        // the list reflects it.
+        cy.get('[data-testid="home-reference-workflow"]')
+            .should('have.attr', 'data-reference', 'lending')
+            .and('contain.text', 'verified Frappe write')
+        cy.get('[data-testid="reference-link-lending"]').should(
+            'have.attr',
+            'aria-pressed',
+            'true'
+        )
+
+        // List -> process: selecting Healthcare in the "More reference
+        // workflows" list switches the process section to Healthcare, and the
+        // section keeps the honest qualification-required label (never
+        // "verified").
+        cy.get('[data-testid="reference-link-healthcare"]')
+            .scrollIntoView()
+            .click()
+            .should('have.attr', 'aria-pressed', 'true')
+        cy.get('[data-testid="reference-link-lending"]').should(
+            'have.attr',
+            'aria-pressed',
+            'false'
+        )
+        cy.get('[data-testid="home-reference-workflow"]')
+            .should('have.attr', 'data-reference', 'healthcare')
+            .and('contain.text', 'qualification required')
+        cy.get('[data-testid="home-reference-tab-healthcare"]').should(
+            'have.attr',
+            'aria-pressed',
+            'true'
+        )
+
+        // Process -> list: selecting Insurance in the in-section tabs updates
+        // the list highlight and the URL, proving the selection is shared both
+        // ways.
+        cy.get('[data-testid="home-reference-tab-insurance"]')
+            .scrollIntoView()
+            .click()
+            .should('have.attr', 'aria-pressed', 'true')
+        cy.get('[data-testid="home-reference-workflow"]').should(
+            'have.attr',
+            'data-reference',
+            'insurance'
+        )
+        cy.get('[data-testid="reference-link-insurance"]').should(
+            'have.attr',
+            'aria-pressed',
+            'true'
+        )
+        cy.get('[data-testid="reference-link-healthcare"]').should(
+            'have.attr',
+            'aria-pressed',
+            'false'
+        )
+        cy.location('search').should('include', 'ref=insurance')
+
+        // The animated footage swaps to the selected reference's own GIF and
+        // keeps playing (an <img> pointed at the looping GIF).
+        cy.get('[data-testid="home-reference-workflow"]')
+            .find('img[src$=".gif"]')
+            .first()
+            .should('have.attr', 'src')
+            .and('include', 'openimis')
+    })
+
+    it('deep-links a vertical into the homepage via ?ref=', () => {
+        cy.viewport(1280, 1800)
+        cy.visit('/?ref=healthcare')
+
+        cy.get('[data-testid="home-reference-workflow"]').should(
+            'have.attr',
+            'data-reference',
+            'healthcare'
+        )
+        cy.get('[data-testid="reference-link-healthcare"]').should(
+            'have.attr',
+            'aria-pressed',
+            'true'
+        )
+    })
+})

--- a/data/referenceWorkflows.js
+++ b/data/referenceWorkflows.js
@@ -1,0 +1,204 @@
+// Shared honest source of truth for the homepage reference-workflow selector.
+//
+// The homepage was restructured (#223/#224): the interactive "OpenAdapt Cloud"
+// preview moved to /hosted/welcome and the full per-application HowItWorks
+// selector moved to the solution pages, leaving the homepage with a single
+// hard-coded Lending process demo plus a static list of reference links. This
+// module lets ONE lifted selection drive every reference-aware homepage
+// section, so choosing a vertical in the process section or in the reference
+// list updates the other.
+//
+// Evidence and labels mirror the bounded per-application content on the
+// solution pages (components/HowItWorks.js) and the Cloud preview
+// (components/DashboardShowcase.js). Lending and Insurance carry their bounded
+// verified trial counts; Healthcare stays "qualification required" because the
+// OpenEMR footage does not establish an independent effect oracle. Do not
+// promote Healthcare to a verified claim here.
+
+export const VERTICAL_KEYS = ['healthcare', 'lending', 'insurance']
+
+// The homepage leads with the strongest bounded evidence (the verified Frappe
+// Lending reference), matching the pre-sync single-vertical demo.
+export const DEFAULT_VERTICAL = 'lending'
+
+export const HOME_REFERENCES = [
+    {
+        key: 'healthcare',
+        label: 'Healthcare',
+        application: 'OpenEMR',
+        href: '/solutions/healthcare',
+        // Exact label kept in sync with the reference list rendered from
+        // pages/index.js (asserted by tests/insuranceReference.test.js).
+        linkLabel: 'Healthcare workflow reference',
+        eyebrow: 'Real reference footage',
+        heading: 'From demonstration to a qualification-gated OpenEMR write',
+        subheading:
+            'Real OpenEMR footage on a pinned local instance. The effect oracle is deployment-specific and not established by this media.',
+        record: {
+            gif: '/how-it-works/record_openemr.gif',
+            width: 880,
+            height: 550,
+            alt: 'Captured OpenEMR frames showing a synthetic patient workflow demonstration in a live, pinned OpenEMR instance.',
+            caption:
+                'Demonstrate — captured OpenEMR frames · synthetic local instance',
+        },
+        replay: {
+            gif: '/how-it-works/run_openemr.gif',
+            width: 880,
+            height: 550,
+            alt: 'OpenAdapt replaying the compiled OpenEMR workflow locally with no per-run model calls.',
+            caption:
+                'Replay — compiled OpenEMR run · local and model-free',
+        },
+        compile: {
+            workflow: 'openemr-browser-reference',
+            parameters: 'workflow-defined inputs',
+            target: 'Bounded OpenEMR browser task',
+            effect: 'Deployment-specific oracle required',
+            healthy: 'Deterministic · zero model calls',
+        },
+        verify: {
+            qualified: false,
+            status: 'Qualification required',
+            heading: 'qualification contract',
+            checks: [
+                ['Recorded media', 'record and compiled-replay footage'],
+                ['Effect oracle', 'not established by this media'],
+                ['Identity policy', 'must be configured for the workflow'],
+                ['Acceptance', 'halt until declared checks pass'],
+            ],
+            metrics: ['No application-specific audit result claimed'],
+            caption:
+                'Qualification contract for the OpenEMR reference. The footage does not establish an independent effect audit or production EMR reliability.',
+        },
+        disclosure: {
+            text:
+                'OpenEMR footage shows a real demonstration and compiled replay on a pinned local instance with synthetic data. This reference has no independent effect oracle yet — a deployment-specific verifier must be configured before any correctness claim.',
+            linkHref: '/solutions/healthcare',
+            linkLabel: 'View the healthcare reference',
+        },
+    },
+    {
+        key: 'lending',
+        label: 'Lending',
+        application: 'Frappe Lending',
+        href: '/solutions/lending',
+        linkLabel: 'Lending operations reference',
+        eyebrow: 'Real reference workflow',
+        heading: 'From demonstration to verified Frappe write',
+        subheading:
+            'Synthetic local data, real Frappe Lending interactions, and an oracle outside the replay path.',
+        record: {
+            gif: '/lending-demo/record-frappe.gif',
+            width: 880,
+            height: 550,
+            alt: 'Captured Frappe Lending frames showing a synthetic loan application demonstration being completed and saved.',
+            caption:
+                'Demonstrate — captured Frappe Lending frames · synthetic local fixture',
+        },
+        replay: {
+            gif: '/lending-demo/replay-frappe.gif',
+            width: 880,
+            height: 550,
+            alt: 'OpenAdapt deterministically replaying the compiled synthetic loan application workflow in Frappe Lending.',
+            caption:
+                'Replay — real compiled run · local, model-free, independently checked',
+        },
+        compile: {
+            workflow: 'create-loan-application',
+            parameters: 'email · phone · product · amount · term',
+            target: 'Loan Application form',
+            effect: 'exactly one matching record',
+            healthy: 'deterministic · zero model calls',
+        },
+        verify: {
+            qualified: true,
+            status: 'Verified',
+            heading: 'independent effect evidence',
+            checks: [
+                ['REST readback', 'exact fields matched'],
+                ['SQL delta', '+1 Loan Application'],
+                ['Collateral audit', 'non-target digest unchanged'],
+                ['Execution', '6/6 compiled trials correct'],
+            ],
+            metrics: [
+                '0 silent incorrect successes',
+                '0 over-halts',
+                '0 model calls',
+            ],
+            caption:
+                'Verify — three baseline and three cosmetic-drift compiled trials; scoped to the pinned local reference environment.',
+        },
+        disclosure: {
+            text:
+                'Frappe Lending v16.2.0, Frappe v16.27.0, and ERPNext v16.27.0 were pinned in a local fixture with fictional values. The six compiled trials cover one task on one environment under baseline and cosmetic-drift conditions. OpenAdapt is unaffiliated with Frappe Technologies Pvt. Ltd.; Frappe is its registered trademark.',
+            linkHref: '/lending-demo/provenance.json',
+            linkLabel: 'Inspect evidence manifest',
+        },
+    },
+    {
+        key: 'insurance',
+        label: 'Insurance',
+        application: 'openIMIS',
+        href: '/solutions/insurance',
+        linkLabel: 'Insurance claims reference',
+        eyebrow: 'Real reference workflow',
+        heading: 'From demonstration to verified openIMIS claim',
+        subheading:
+            'Synthetic claim data, real openIMIS interactions, and a claims-database oracle outside the replay path.',
+        record: {
+            gif: '/insurance-demo/record-openimis.gif',
+            width: 880,
+            height: 550,
+            alt: 'Captured openIMIS frames showing a synthetic health-facility claim being entered and saved.',
+            caption:
+                'Demonstrate — captured openIMIS frames · synthetic local fixture',
+        },
+        replay: {
+            gif: '/insurance-demo/replay-openimis.gif',
+            width: 880,
+            height: 550,
+            alt: 'OpenAdapt deterministically replaying the compiled claims-intake workflow in openIMIS with a fresh claim number.',
+            caption:
+                'Replay — real compiled run · local, model-free, independently checked',
+        },
+        compile: {
+            workflow: 'openimis-claim-intake',
+            parameters: 'insuree no. · claim no. · explanation',
+            target: 'Health Facility Claim form',
+            effect: 'exactly one claim row in status Entered',
+            healthy: 'deterministic · zero model calls',
+        },
+        verify: {
+            qualified: true,
+            status: 'Verified',
+            heading: 'independent effect evidence',
+            checks: [
+                ['SQL claim readback', 'exactly one new claim row'],
+                ['Claim status', 'Entered, ready for review'],
+                ['Record context', 'insuree and facility matched'],
+                ['Execution', 'three compiled replays verified'],
+            ],
+            metrics: [
+                '0 duplicate claims',
+                '0 wrong-policyholder writes',
+                '0 model calls',
+            ],
+            caption:
+                'Verify — three compiled replays with fresh claim numbers; scoped to the pinned local reference environment.',
+        },
+        disclosure: {
+            text:
+                'openIMIS was pinned in a local fixture with fictional claim data. The three compiled replays cover one claim-intake task, each checked against the claims database. OpenAdapt is unaffiliated with the openIMIS Initiative.',
+            linkHref: '/insurance-demo/provenance.json',
+            linkLabel: 'Inspect evidence manifest',
+        },
+    },
+]
+
+export function getHomeReference(key) {
+    return (
+        HOME_REFERENCES.find((reference) => reference.key === key) ||
+        HOME_REFERENCES.find((reference) => reference.key === DEFAULT_VERTICAL)
+    )
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,18 +1,21 @@
+import { useEffect, useState } from 'react'
 import Head from 'next/head'
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 
 import ContactBookingSection from '@components/ContactBookingSection'
 import Developers from '@components/Developers'
 import DriftOutcomes from '@components/DriftOutcomes'
 import EmailForm from '@components/EmailForm'
 import Footer from '@components/Footer'
+import HomeReferenceWorkflow from '@components/HomeReferenceWorkflow'
 import HowItWorksCondensed from '@components/HowItWorksCondensed'
-import LendingWorkflowDemo from '@components/LendingWorkflowDemo'
 import MastHead from '@components/MastHead'
 import Pricing from '@components/Pricing'
 import ProductStatus from '@components/ProductStatus'
 import Qualification from '@components/Qualification'
 import Reveal from '@components/Reveal'
+import { DEFAULT_VERTICAL, VERTICAL_KEYS } from '../data/referenceWorkflows'
 
 const organizationSchema = {
     '@context': 'https://schema.org',
@@ -101,9 +104,21 @@ const websiteSchema = {
 }
 
 const referenceLinks = [
-    { label: 'Healthcare workflow reference', href: '/solutions/healthcare' },
-    { label: 'Lending operations reference', href: '/solutions/lending' },
-    { label: 'Insurance claims reference', href: '/solutions/insurance' },
+    {
+        key: 'healthcare',
+        label: 'Healthcare workflow reference',
+        href: '/solutions/healthcare',
+    },
+    {
+        key: 'lending',
+        label: 'Lending operations reference',
+        href: '/solutions/lending',
+    },
+    {
+        key: 'insurance',
+        label: 'Insurance claims reference',
+        href: '/solutions/insurance',
+    },
 ]
 
 export async function getStaticProps() {
@@ -128,6 +143,34 @@ export async function getStaticProps() {
 }
 
 export default function Home({ githubStats, buildWarnings, hostedOffer }) {
+    const router = useRouter()
+    // ONE lifted selection shared by every reference-aware homepage section:
+    // the process/reference-workflow demo and the "More reference workflows"
+    // list read and write this single vertical, so choosing a vertical in one
+    // updates the other. The ?ref= query param makes the choice shareable and
+    // lets other surfaces (the Cloud preview, the solution pages) deep-link a
+    // vertical into the homepage.
+    const [vertical, setVertical] = useState(DEFAULT_VERTICAL)
+
+    useEffect(() => {
+        const requested = router.query.ref
+        if (typeof requested === 'string' && VERTICAL_KEYS.includes(requested)) {
+            setVertical(requested)
+        }
+    }, [router.query.ref])
+
+    const selectVertical = (key) => {
+        if (!VERTICAL_KEYS.includes(key)) return
+        setVertical(key)
+        // Reflect the choice in the URL without a scroll jump or full
+        // navigation so the selection stays shareable and in sync.
+        router.replace(
+            { pathname: router.pathname, query: { ...router.query, ref: key } },
+            undefined,
+            { shallow: true, scroll: false }
+        )
+    }
+
     return (
         <div>
             <Head>
@@ -159,7 +202,10 @@ export default function Home({ githubStats, buildWarnings, hostedOffer }) {
                 <HowItWorksCondensed />
             </Reveal>
             <Reveal>
-                <LendingWorkflowDemo />
+                <HomeReferenceWorkflow
+                    vertical={vertical}
+                    onSelectVertical={selectVertical}
+                />
             </Reveal>
             <section
                 id="references"
@@ -169,18 +215,45 @@ export default function Home({ githubStats, buildWarnings, hostedOffer }) {
                     <p className="eyebrow">More reference workflows</p>
                     <p className="mx-auto mt-2 max-w-2xl text-sm leading-relaxed text-ink-2">
                         Each reference is a bounded, synthetic fixture with its
-                        own honest evidence and caveats.
+                        own honest evidence and caveats. Select one to preview
+                        it above.
                     </p>
-                    <div className="mt-5 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm">
-                        {referenceLinks.map((reference) => (
-                            <Link
-                                key={reference.href}
-                                href={reference.href}
-                                className="font-medium text-accent hover:underline"
-                            >
-                                {reference.label}
-                            </Link>
-                        ))}
+                    <div
+                        className="mt-5 flex flex-wrap items-center justify-center gap-3 text-sm"
+                        role="group"
+                        aria-label="Reference workflow vertical"
+                    >
+                        {referenceLinks.map((reference) => {
+                            const active = reference.key === vertical
+                            return (
+                                <span
+                                    key={reference.href}
+                                    className="inline-flex items-center gap-3"
+                                >
+                                    <button
+                                        type="button"
+                                        aria-pressed={active}
+                                        data-testid={`reference-link-${reference.key}`}
+                                        onClick={() =>
+                                            selectVertical(reference.key)
+                                        }
+                                        className={
+                                            active
+                                                ? 'rounded-full border border-accent bg-ground px-4 py-1.5 font-medium text-ink shadow-[inset_0_0_0_1px_var(--accent)]'
+                                                : 'rounded-full border border-hairline bg-panel px-4 py-1.5 font-medium text-ink-2 hover:border-ink-3'
+                                        }
+                                    >
+                                        {reference.label}
+                                    </button>
+                                    <Link
+                                        href={reference.href}
+                                        className="text-accent hover:underline"
+                                    >
+                                        Open
+                                    </Link>
+                                </span>
+                            )
+                        })}
                     </div>
                 </div>
             </section>

--- a/tests/homeVerticalSync.test.js
+++ b/tests/homeVerticalSync.test.js
@@ -1,0 +1,124 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+const root = path.join(__dirname, '..')
+const read = (relativePath) =>
+    fs.readFileSync(path.join(root, relativePath), 'utf8')
+
+// The homepage reference selector is SHARED: the process/reference-workflow
+// section and the "More reference workflows" list read and write ONE lifted
+// vertical, so selecting a vertical in one updates the other. These tests lock
+// that single-source-of-truth wiring at the source level; the end-to-end
+// click-through sync is asserted in cypress/e2e/homepage-vertical-sync.cy.js.
+
+test('homepage lifts one shared vertical selection to the page and syncs the URL', () => {
+    const home = read('pages/index.js')
+
+    // Exactly one piece of vertical state lives on the shared parent.
+    assert.match(home, /const \[vertical, setVertical\] = useState\(DEFAULT_VERTICAL\)/)
+    assert.match(home, /const selectVertical = \(key\) =>/)
+    assert.match(home, /VERTICAL_KEYS\.includes/)
+
+    // The choice is reflected into ?ref= (shareable + deep-linkable) without a
+    // scroll jump, and read back on mount so the two sections stay in sync.
+    assert.match(home, /router\.query\.ref/)
+    assert.match(home, /router\.replace\(/)
+    assert.match(home, /shallow: true, scroll: false/)
+})
+
+test('both homepage reference sections read and write the same selection', () => {
+    const home = read('pages/index.js')
+
+    // The process/reference-workflow section is driven by the lifted state.
+    assert.match(
+        home,
+        /<HomeReferenceWorkflow\s+vertical=\{vertical\}\s+onSelectVertical=\{selectVertical\}/
+    )
+
+    // The reference list buttons write the SAME selection and reflect it.
+    assert.match(home, /onClick=\{[^}]*selectVertical\(reference\.key\)/s)
+    assert.match(home, /aria-pressed=\{active\}/)
+    assert.match(home, /const active = reference\.key === vertical/)
+
+    // The homepage no longer hard-codes a single-vertical demo.
+    assert.doesNotMatch(home, /LendingWorkflowDemo/)
+
+    // Required reference links remain present on the homepage.
+    assert.match(home, /Insurance claims reference/)
+    assert.match(home, /\/solutions\/insurance/)
+})
+
+test('the process section derives its vertical from the prop, not its own state', () => {
+    const component = read('components/HomeReferenceWorkflow.js')
+
+    assert.match(
+        component,
+        /export default function HomeReferenceWorkflow\(\{ vertical, onSelectVertical \}\)/
+    )
+    // No independent copy of the selection inside the section.
+    assert.doesNotMatch(component, /useState/)
+    // The section resolves the active reference from the shared vertical.
+    assert.match(component, /HOME_REFERENCES\.find\(\(item\) => item\.key === vertical\)/)
+    // The in-section tabs write the shared selection.
+    assert.match(component, /onClick=\{\(\) => onSelectVertical\(item\.key\)\}/)
+    assert.match(component, /aria-pressed=\{item\.key === reference\.key\}/)
+})
+
+test('reference footage restarts on select and keeps the animated GIF behavior', () => {
+    const component = read('components/HomeReferenceWorkflow.js')
+
+    // Uses the shared <Clip> (animated GIF via <img>, #213/#214 behavior).
+    assert.match(component, /import Clip from '\.\/Clip'/)
+    // Each stage is keyed by the selected vertical, so switching remounts the
+    // clips/panels and the GIF restarts from its first frame.
+    assert.match(component, /key=\{`\$\{reference\.key\}-record`\}/)
+    assert.match(component, /key=\{`\$\{reference\.key\}-replay`\}/)
+    // No bespoke reduced-motion swap or play/pause control is reintroduced
+    // here; the GIF assets and shared Clip styling own that behavior.
+    assert.doesNotMatch(component, /<picture>|reducedMotion|Pause animation|Play animation/)
+})
+
+test('shared reference data stays honest per vertical', () => {
+    const data = read('data/referenceWorkflows.js')
+
+    assert.match(data, /VERTICAL_KEYS = \['healthcare', 'lending', 'insurance'\]/)
+    assert.match(data, /DEFAULT_VERTICAL = 'lending'/)
+    for (const key of ['healthcare', 'lending', 'insurance']) {
+        assert.match(data, new RegExp(`key: '${key}'`))
+    }
+
+    // Healthcare must stay qualification-required — never promoted to verified.
+    // Scope the check to the healthcare block so lending's verified 6/6 does
+    // not leak into the assertion.
+    const healthcareBlock = data.slice(
+        data.indexOf("key: 'healthcare'"),
+        data.indexOf("key: 'lending'")
+    )
+    assert.match(healthcareBlock, /qualified: false/)
+    assert.doesNotMatch(healthcareBlock, /qualified: true/)
+    assert.doesNotMatch(healthcareBlock, /6 ?\/ ?6|verified/i)
+    assert.match(healthcareBlock, /Deployment-specific oracle required/)
+    assert.match(healthcareBlock, /No application-specific audit result claimed/)
+
+    // Lending and Insurance carry their bounded verified evidence.
+    assert.match(data, /key: 'lending'[\s\S]*?qualified: true/)
+    assert.match(data, /0 silent incorrect successes/)
+    assert.match(data, /key: 'insurance'[\s\S]*?qualified: true/)
+    assert.match(data, /0 duplicate claims/)
+
+    // Each vertical uses its OWN application footage (no cross-reuse).
+    const gifMatches = [...data.matchAll(/gif: '([^']+\.gif)'/g)].map(
+        (match) => match[1]
+    )
+    assert.equal(gifMatches.length, 6)
+    assert.equal(new Set(gifMatches).size, 6, 'each clip must use unique footage')
+    for (const gif of gifMatches) {
+        assert.equal(
+            fs.existsSync(path.join(root, 'public', gif)),
+            true,
+            `${gif} should exist`
+        )
+    }
+})


### PR DESCRIPTION
Fixes #26 — the shipped v0.6.1 macOS arm64 DMG (and, it turns out, **every shipped installer on every platform since the scaffold**) panics at launch:

```
thread 'main' panicked at src/main.rs:77:10:
error while building openadapt-desktop: PluginInitialization("updater",
"Error deserializing 'plugins.updater' within your Tauri configuration:
invalid type: null, expected struct Config")
```

## Root cause (exact mechanism)

- `main.rs:38` has registered `tauri_plugin_updater::Builder::new().build()` unconditionally since the initial scaffold (`629fa4e`).
- The release guard test `test_updater_feed_is_disabled_until_signing_key_lifecycle_exists` deliberately **forbids** any `plugins.updater` key in `tauri.conf.json` until a signing-key lifecycle exists — so no shipped config ever had one. The config was never "nulled" in the bundler: the null is synthesized at runtime.
- Tauri 2.11.5 initializes each plugin with `config.0.get(plugin.name()).cloned().unwrap_or_default()` (`tauri/src/plugin.rs:1007`) — an **absent** key becomes `serde_json::Value::Null`.
- `tauri-plugin-updater` 2.10.1 is `TauriPlugin<R, Config>` with a **required** `Config { pubkey: String, endpoints, .. }`; deserializing `null` fails, Tauri wraps it as `PluginInitialization("updater", ...)`, and the `.expect` at `main.rs:77` aborts. Same failure on macOS/Windows/Linux, packaged and `tauri dev` alike (dev "worked" only as frontend-only Vite).

## Fix

Generate the context first and register the updater plugin **only when a non-null `plugins.updater` config is embedded**. This keeps the guard's intent (no updater feed until signing exists), lets the frontend's existing `checkUpdate()` catch degrade to "Update check unavailable", and auto-enables the updater the day a valid config lands — no Rust change needed then. The guard test now also pins the conditional registration.

## Launch-smoke CI gate (so this class of bug cannot ship again)

`scripts/smoke_test_native_installer.py` gains `--launch-seconds N`: after install + signature/architecture checks it launches the installed app, requires the process to survive N seconds (startup panics exit in ~1s; one retry absorbs slow runners), then kills the whole process tree (`taskkill /T` / POSIX process-group) before uninstalling. Wired with `--launch-seconds 20` into **every** smoke invocation in both `build.yml` (per-PR) and `native-release.yml` (release gate): macOS DMG (both arches), Windows MSI + NSIS, Linux DEB + AppImage (under `dbus-run-session -- xvfb-run`, `WEBKIT_DISABLE_COMPOSITING_MODE=1`, `APPIMAGE_EXTRACT_AND_RUN=1`). A new test asserts every smoke invocation passes `--launch-seconds` so the gate can't silently regress.

## Verification (macOS arm64 host, real bits)

- Shipped `OpenAdapt-Desktop-Experimental-v0.6.1-macos-arm64-adhoc.dmg`: reproduced the exact panic (exit 101); the new launch smoke **fails** it with the panic surfaced in the error.
- Rebuilt DMG from this branch (`tauri build --bundles dmg --target aarch64-apple-darwin`, ad-hoc signed, engine sidecar bundled): passes `install → adhoc signature → arch → 20s launch → uninstall`; launched the packaged app for real — it runs to the Connect/Sign-in screen and was verified alive at 2m48s uptime with stable UI (screenshots captured for the /download work, stored internally).
- Suites: 317 Python tests + ruff green; `cargo test` (5) green; `cargo fmt --check` + `cargo check` green; `tsc && vite build` green; both workflow YAMLs parse.
- Windows/Linux: fixed by the same conditional registration (single shared `tauri.conf.json` + `main.rs`); statically checked only — not launched locally. The CI matrix on this PR exercises the launch smoke on all three platforms.

## Release note for the launch owner

Every published installer (desktop-v0.1.x–v0.6.1) carries the launch panic, so after merge a new `desktop-v*` tag (e.g. v0.6.2 via the freshness lane or directly) is needed for users to get working binaries; the /download page should point at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM
