### PR TITLE
feat(site): revamp top nav and footer information architecture

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,15 +1,56 @@
 import React, { useEffect, useState } from 'react'
-import Image from 'next/image'
-import { useRouter } from 'next/router'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faArrowPointer } from '@fortawesome/free-solid-svg-icons'
+import {
+    faGithub,
+    faXTwitter,
+    faLinkedinIn,
+    faDiscord,
+} from '@fortawesome/free-brands-svg-icons'
+import { useRouter } from 'next/router'
 
 import {
     OPENADAPT_REPOSITORY_URL,
     OPENADAPT_STATS_SNAPSHOT,
 } from 'data/repositoryStats'
+import { BLOG_LINK, DEVELOPER_LINKS } from 'data/developerLinks'
 import { track, EVENTS } from 'utils/analytics'
 import styles from './Footer.module.css'
+
+// The hosted control plane. Mirrors NEXT_PUBLIC_CLOUD_APP_URL (.env.example)
+// and the top-nav "Sign in" destination so the two surfaces never drift.
+const CLOUD_APP_URL = 'https://app.openadapt.ai'
+
+// Official GitHub octicons (MIT-licensed, 16px) so the star/fork widget is a
+// faithful lookalike of GitHub's own star/fork buttons, rendered entirely in
+// our own markup. We deliberately avoid the third-party embed widget, which
+// makes every visitor's browser call api.github.com.
+function StarOcticon() {
+    return (
+        <svg
+            viewBox="0 0 16 16"
+            width="16"
+            height="16"
+            aria-hidden="true"
+            focusable="false"
+        >
+            <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
+        </svg>
+    )
+}
+
+function ForkOcticon() {
+    return (
+        <svg
+            viewBox="0 0 16 16"
+            width="16"
+            height="16"
+            aria-hidden="true"
+            focusable="false"
+        >
+            <path d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z" />
+        </svg>
+    )
+}
 
 function validStats(value) {
     return (
@@ -31,6 +72,57 @@ function snapshotLabel(stats) {
     return 'GitHub snapshot · refreshed when available'
 }
 
+// Attach the right funnel event to an external footer destination.
+function externalEvent(href) {
+    if (!href) return null
+    if (href.includes('github.com')) return EVENTS.GITHUB_CLICK
+    if (href.includes('docs.openadapt.ai')) return EVENTS.DOCS_CLICK
+    if (href.includes('discord.gg')) return EVENTS.DISCORD_CLICK
+    return null
+}
+
+function FooterLink({ href, children, external }) {
+    const isExternal = external ?? /^https?:\/\//.test(href)
+    const event = isExternal ? externalEvent(href) : null
+    return (
+        <a
+            href={href}
+            className={styles.columnLink}
+            {...(isExternal
+                ? { target: '_blank', rel: 'noopener noreferrer' }
+                : {})}
+            onClick={
+                event ? () => track(event, { location: 'footer' }) : undefined
+            }
+        >
+            {children}
+        </a>
+    )
+}
+
+// Developer ecosystem destinations come from the single canonical source
+// (data/developerLinks) so the footer can never drift from the top nav.
+const byLabel = (label) => DEVELOPER_LINKS.find((item) => item.label === label)
+
+// Build-time guard: fail loudly if the canonical list is renamed out from
+// under the footer instead of silently dropping a column entry.
+const DEVELOPER_COLUMN = [
+    'Compiler/runtime source',
+    'Docs',
+    'Technical paper source',
+    'Report an issue',
+].map((label) => {
+    const link = byLabel(label)
+    if (!link) throw new Error(`Missing canonical developer link: ${label}`)
+    return link
+})
+
+const CONNECT_COLUMN = [
+    BLOG_LINK,
+    byLabel('Discord'),
+    { label: 'GitHub', href: OPENADAPT_REPOSITORY_URL },
+]
+
 export default function Footer({ repositoryStats = OPENADAPT_STATS_SNAPSHOT }) {
     const router = useRouter()
     const currentYear = new Date().getFullYear()
@@ -38,9 +130,7 @@ export default function Footer({ repositoryStats = OPENADAPT_STATS_SNAPSHOT }) {
     const bookHref = isHome ? '#book' : '/book'
     const contactHref = isHome ? '#book' : '/contact'
     const [stats, setStats] = useState(
-        validStats(repositoryStats)
-            ? repositoryStats
-            : OPENADAPT_STATS_SNAPSHOT
+        validStats(repositoryStats) ? repositoryStats : OPENADAPT_STATS_SNAPSHOT
     )
 
     useEffect(() => {
@@ -68,70 +158,21 @@ export default function Footer({ repositoryStats = OPENADAPT_STATS_SNAPSHOT }) {
 
     return (
         <div className={styles.footerContainer}>
-            <footer className="grid grid-flow-row auto-rows-max gap-3 max-w-4xl mx-auto">
-                <div className="m-auto pb-4">
-                    <div className="flex items-center justify-center z-10 opacity-70">
-                        <Image
-                            className=""
-                            priority
-                            src="/images/favicon.svg"
-                            height={24}
-                            width={24}
-                            alt="OpenAdapt"
-                        />
-                        <FontAwesomeIcon
-                            icon={faArrowPointer}
-                            className="ml-1 text-ink-3 text-sm"
-                        />
-                    </div>
-                </div>
-                <div className={styles.repositoryProof}>
-                    <iframe
-                        src="https://github.com/sponsors/OpenAdaptAI/button"
-                        title="Sponsor OpenAdaptAI"
-                        height="32"
-                        width="114"
-                        style={{ border: '0', borderRadius: '6px' }}
-                    ></iframe>
-                    <div
-                        className={styles.repositoryStats}
-                        data-testid="footer-repository-stats"
-                    >
-                        <a
-                            href={OPENADAPT_REPOSITORY_URL}
-                            className={styles.repositoryStat}
-                            aria-label={`${stats.stars.toLocaleString('en-US')} stars on OpenAdapt`}
-                        >
-                            <span aria-hidden="true">★</span>
-                            <strong data-testid="footer-star-count">
-                                {stats.stars.toLocaleString('en-US')}
-                            </strong>
-                            <small>stars on OpenAdapt</small>
+            <footer className={styles.footer}>
+                <div className={styles.top}>
+                    <div className={styles.brand}>
+                        <a href="/" className={styles.wordmark}>
+                            <span className="font-extralight">Open</span>
+                            <span className="font-semibold">Adapt</span>
                         </a>
-                        <a
-                            href={`${OPENADAPT_REPOSITORY_URL}/fork`}
-                            className={styles.repositoryStat}
-                            aria-label={`${stats.forks.toLocaleString('en-US')} forks of OpenAdapt`}
-                        >
-                            <span aria-hidden="true">⑂</span>
-                            <strong data-testid="footer-fork-count">
-                                {stats.forks.toLocaleString('en-US')}
-                            </strong>
-                            <small>forks</small>
-                        </a>
-                    </div>
-                    <p
-                        className={styles.repositorySource}
-                        data-testid="footer-repository-source"
-                    >
-                        {snapshotLabel(stats)}
-                    </p>
-                </div>
-                <div className={styles.footerContent}>
-                    <div className={`${styles.footerLinks} pt-4`}>
+                        <p className={styles.tagline}>
+                            OpenAdapt compiles demonstrated GUI workflows into
+                            deterministic, locally executable programs — and
+                            halts when it can’t verify the result.
+                        </p>
                         <a
                             href={bookHref}
-                            className={styles.link}
+                            className={styles.brandCta}
                             onClick={() =>
                                 track(EVENTS.BOOK_PILOT_CLICK, {
                                     location: 'footer',
@@ -140,129 +181,263 @@ export default function Footer({ repositoryStats = OPENADAPT_STATS_SNAPSHOT }) {
                         >
                             Evaluate a workflow
                         </a>
-                        <a href={contactHref} className={styles.link}>
-                            Contact
-                        </a>
-                        <a
-                            href="mailto:hello@openadapt.ai"
-                            className={styles.link}
+                        <div
+                            className={styles.repositoryProof}
+                            data-testid="footer-repository-stats"
                         >
-                            Email
-                        </a>
+                            <a
+                                href={OPENADAPT_REPOSITORY_URL}
+                                className={styles.ghButton}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                aria-label={`${stats.stars.toLocaleString(
+                                    'en-US'
+                                )} stars on OpenAdapt`}
+                                onClick={() =>
+                                    track(EVENTS.GITHUB_CLICK, {
+                                        location: 'footer_star',
+                                    })
+                                }
+                            >
+                                <StarOcticon />
+                                <span>Star</span>
+                                <span className={styles.ghCount}>
+                                    <strong data-testid="footer-star-count">
+                                        {stats.stars.toLocaleString('en-US')}
+                                    </strong>
+                                </span>
+                            </a>
+                            <a
+                                href={`${OPENADAPT_REPOSITORY_URL}/fork`}
+                                className={styles.ghButton}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                aria-label={`${stats.forks.toLocaleString(
+                                    'en-US'
+                                )} forks of OpenAdapt`}
+                                onClick={() =>
+                                    track(EVENTS.GITHUB_CLICK, {
+                                        location: 'footer_fork',
+                                    })
+                                }
+                            >
+                                <ForkOcticon />
+                                <span>Fork</span>
+                                <span className={styles.ghCount}>
+                                    <strong data-testid="footer-fork-count">
+                                        {stats.forks.toLocaleString('en-US')}
+                                    </strong>
+                                </span>
+                            </a>
+                        </div>
+                        <p
+                            className={styles.repositorySource}
+                            data-testid="footer-repository-source"
+                        >
+                            {snapshotLabel(stats)}
+                        </p>
                     </div>
-                    <div className={styles.footerLinks}>
-                        <a href="/solutions/healthcare" className={styles.link}>
-                            Healthcare
-                        </a>
-                        <a href="/solutions/lending" className={styles.link}>
-                            Lending
-                        </a>
-                        <a href="/solutions/insurance" className={styles.link}>
-                            Insurance
-                        </a>
-                        <a href="/workflows" className={styles.link}>
-                            Workflows
-                        </a>
-                        <a href="/compare" className={styles.link}>
-                            Compare
-                        </a>
-                        <a href="/#product-status" className={styles.link}>
-                            How it runs
-                        </a>
-                        <a href="/download" className={styles.link}>
-                            Download
-                        </a>
-                        <a href="/about" className={styles.link}>
-                            About
-                        </a>
+
+                    <nav className={styles.columns} aria-label="Footer">
+                        <div className={styles.column}>
+                            <h2 className={styles.columnTitle}>Product</h2>
+                            <ul className={styles.columnList}>
+                                <li>
+                                    <FooterLink href="/#product-status">
+                                        How it runs
+                                    </FooterLink>
+                                </li>
+                                <li>
+                                    <FooterLink href="/workflows">
+                                        Workflows
+                                    </FooterLink>
+                                </li>
+                                <li>
+                                    <FooterLink href="/templates">
+                                        Templates
+                                    </FooterLink>
+                                </li>
+                                <li>
+                                    <FooterLink href="/compare">
+                                        Compare
+                                    </FooterLink>
+                                </li>
+                                <li>
+                                    <FooterLink href="/safety">
+                                        Safety
+                                    </FooterLink>
+                                </li>
+                                <li>
+                                    <FooterLink href="/download">
+                                        Download
+                                    </FooterLink>
+                                </li>
+                                <li>
+                                    <FooterLink href="/#pricing">
+                                        Pricing
+                                    </FooterLink>
+                                </li>
+                            </ul>
+                        </div>
+
+                        <div className={styles.column}>
+                            <h2 className={styles.columnTitle}>Solutions</h2>
+                            <ul className={styles.columnList}>
+                                <li>
+                                    <FooterLink href="/solutions/healthcare">
+                                        Healthcare
+                                    </FooterLink>
+                                </li>
+                                <li>
+                                    <FooterLink href="/solutions/lending">
+                                        Lending
+                                    </FooterLink>
+                                </li>
+                                <li>
+                                    <FooterLink href="/solutions/insurance">
+                                        Insurance
+                                    </FooterLink>
+                                </li>
+                            </ul>
+                        </div>
+
+                        <div className={styles.column}>
+                            <h2 className={styles.columnTitle}>Developers</h2>
+                            <ul className={styles.columnList}>
+                                {DEVELOPER_COLUMN.map((item) => (
+                                    <li key={item.label}>
+                                        <FooterLink href={item.href}>
+                                            {item.label}
+                                        </FooterLink>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+
+                        <div className={styles.column}>
+                            <h2 className={styles.columnTitle}>Connect</h2>
+                            <ul className={styles.columnList}>
+                                {CONNECT_COLUMN.map((item) => (
+                                    <li key={item.label}>
+                                        <FooterLink href={item.href}>
+                                            {item.label}
+                                        </FooterLink>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+
+                        <div className={styles.column}>
+                            <h2 className={styles.columnTitle}>Company</h2>
+                            <ul className={styles.columnList}>
+                                <li>
+                                    <FooterLink href="/about">About</FooterLink>
+                                </li>
+                                <li>
+                                    <FooterLink href={CLOUD_APP_URL}>
+                                        Hosted dashboard
+                                    </FooterLink>
+                                </li>
+                                <li>
+                                    <FooterLink href={contactHref}>
+                                        Contact
+                                    </FooterLink>
+                                </li>
+                                <li>
+                                    <a
+                                        href="mailto:hello@openadapt.ai"
+                                        className={styles.columnLink}
+                                    >
+                                        Email
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+
+                        <div className={styles.column}>
+                            <h2 className={styles.columnTitle}>
+                                Trust &amp; legal
+                            </h2>
+                            <ul className={styles.columnList}>
+                                <li>
+                                    <FooterLink href="/security">
+                                        Trust center
+                                    </FooterLink>
+                                </li>
+                                <li>
+                                    <FooterLink href="/privacy-policy">
+                                        Privacy Notice
+                                    </FooterLink>
+                                </li>
+                                <li>
+                                    <FooterLink href="/terms-of-service">
+                                        Terms of Service
+                                    </FooterLink>
+                                </li>
+                            </ul>
+                        </div>
+                    </nav>
+                </div>
+
+                <div className={styles.bottom}>
+                    <div className={styles.legal}>
+                        <p className={styles.copyright}>
+                            © 2023–{currentYear} OpenAdapt.AI and MLDSAI Inc.
+                            All rights reserved.
+                        </p>
+                        <p className={styles.license}>
+                            Our software is open source and licensed under the
+                            MIT License.
+                        </p>
                     </div>
-                    <div className={styles.footerLinks}>
-                        <a href="/security" className={styles.link}>
-                            Security
-                        </a>{' '}
-                        <a href="/privacy-policy" className={styles.link}>
-                            Privacy Notice
-                        </a>{' '}
-                        <a href="/terms-of-service" className={styles.link}>
-                            Terms of Service
-                        </a>
-                    </div>
-                    <div className={styles.footerLinks}>
+                    <div className={styles.social} aria-label="Social links">
                         <a
-                            href="https://docs.openadapt.ai"
-                            className={styles.link}
-                            onClick={() =>
-                                track(EVENTS.DOCS_CLICK, { location: 'footer' })
-                            }
-                        >
-                            Docs
-                        </a>
-                        <a
-                            href="https://blog.openadapt.ai"
-                            className={styles.link}
-                        >
-                            Blog
-                        </a>
-                        <a
-                            href="https://app.openadapt.ai"
-                            className={styles.link}
-                        >
-                            Hosted dashboard
-                        </a>
-                        <a
-                            href="https://github.com/OpenAdaptAI/OpenAdapt"
-                            className={styles.link}
+                            href={OPENADAPT_REPOSITORY_URL}
+                            className={styles.socialLink}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            aria-label="OpenAdapt on GitHub"
                             onClick={() =>
                                 track(EVENTS.GITHUB_CLICK, {
-                                    location: 'footer',
+                                    location: 'footer_social',
                                 })
                             }
                         >
-                            OpenAdapt project
-                        </a>
-                        <a
-                            href="https://github.com/OpenAdaptAI/openadapt-flow"
-                            className={styles.link}
-                            onClick={() =>
-                                track(EVENTS.GITHUB_CLICK, {
-                                    location: 'footer_engine',
-                                })
-                            }
-                        >
-                            Compiler/runtime source
-                        </a>
-                        <a
-                            href="https://discord.gg/yF527cQbDG"
-                            className={styles.link}
-                            onClick={() =>
-                                track(EVENTS.DISCORD_CLICK, {
-                                    location: 'footer',
-                                })
-                            }
-                        >
-                            Discord
+                            <FontAwesomeIcon icon={faGithub} />
                         </a>
                         <a
                             href="https://x.com/OpenAdaptAI"
-                            className={styles.link}
+                            className={styles.socialLink}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            aria-label="OpenAdapt on X"
                         >
-                            X
+                            <FontAwesomeIcon icon={faXTwitter} />
                         </a>
                         <a
                             href="https://www.linkedin.com/company/95677624"
-                            className={styles.link}
+                            className={styles.socialLink}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            aria-label="OpenAdapt on LinkedIn"
                         >
-                            LinkedIn
+                            <FontAwesomeIcon icon={faLinkedinIn} />
+                        </a>
+                        <a
+                            href="https://discord.gg/yF527cQbDG"
+                            className={styles.socialLink}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            aria-label="OpenAdapt on Discord"
+                            onClick={() =>
+                                track(EVENTS.DISCORD_CLICK, {
+                                    location: 'footer_social',
+                                })
+                            }
+                        >
+                            <FontAwesomeIcon icon={faDiscord} />
                         </a>
                     </div>
-                    <p className="mt-6 text-ink-3 text-xs">
-                        © 2023–{currentYear} OpenAdapt.AI and MLDSAI Inc. All
-                        rights reserved.
-                    </p>
-                    <p className="text-ink-3 text-xs">
-                        Our software is open source and licensed under the MIT
-                        License.
-                    </p>
                 </div>
             </footer>
         </div>

--- a/components/Footer.module.css
+++ b/components/Footer.module.css
@@ -2,126 +2,288 @@
     background: var(--ground);
     border-top: 1px solid var(--hairline);
     color: var(--ink-2);
-    padding: 2rem;
+    padding: 3rem 1.5rem 2rem;
 }
 
-.footerContent {
-    text-align: center;
+.footer {
+    max-width: 72rem;
+    margin: 0 auto;
+}
+
+/* ── Upper region: brand block + link columns ───────────────────────────── */
+.top {
+    display: grid;
+    grid-template-columns: minmax(220px, 260px) minmax(0, 1fr);
+    gap: 2.5rem;
+    padding-bottom: 2.5rem;
+    border-bottom: 1px solid var(--hairline);
+}
+
+.brand {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.9rem;
+    min-width: 0;
+}
+
+.wordmark {
+    font-family: var(--font-display);
+    font-size: 20px;
+    letter-spacing: -0.01em;
+    color: var(--ink);
+    text-decoration: none;
+}
+
+.wordmark:hover {
+    color: var(--ink);
+    text-decoration: none;
+}
+
+.tagline {
+    margin: 0;
+    max-width: 34ch;
+    font-size: 13px;
     line-height: 1.6;
-    margin-bottom: 2rem;
+    color: var(--ink-3);
 }
 
+.brandCta {
+    display: inline-block;
+    padding: 7px 16px;
+    border-radius: 9999px;
+    background: var(--ink);
+    color: var(--ground);
+    border: 1.5px solid var(--ink);
+    font-size: 13px;
+    font-weight: 500;
+    text-decoration: none;
+    white-space: nowrap;
+    transition: background-color var(--dur-2, 180ms) var(--ease-out, ease);
+}
+
+.brandCta:hover {
+    background: #3a4133;
+    border-color: #3a4133;
+    color: var(--ground);
+    text-decoration: none;
+}
+
+/* ── Link columns ───────────────────────────────────────────────────────── */
+.columns {
+    display: grid;
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    gap: 1.75rem 1rem;
+}
+
+.column {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.columnTitle {
+    margin: 0 0 0.85rem;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+}
+
+.columnList {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+.columnLink {
+    font-size: 13.5px;
+    line-height: 1.3;
+    color: var(--ink-2);
+    text-decoration: none;
+    transition: color var(--dur-2, 180ms) var(--ease-out, ease);
+}
+
+.columnLink:hover,
+.columnLink:focus-visible {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+/* ── GitHub-official star / fork lookalike ──────────────────────────────── */
 .repositoryProof {
     display: flex;
     align-items: center;
-    justify-content: center;
-    gap: 10px;
-    margin-bottom: 1rem;
+    gap: 8px;
     flex-wrap: wrap;
+    margin-top: 0.2rem;
 }
 
-.repositoryStats {
+.ghButton {
     display: inline-flex;
-    overflow: hidden;
-    border: 1px solid var(--hairline);
-    border-radius: 7px;
-    background: var(--paper);
-}
-
-.repositoryStat {
-    display: grid;
-    grid-template-columns: auto auto;
-    grid-template-rows: auto auto;
     align-items: center;
-    gap: 0 6px;
-    min-width: 128px;
-    padding: 7px 10px;
-    color: var(--ink);
+    gap: 4px;
+    height: 28px;
+    padding: 0 8px 0 10px;
+    font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial,
+        sans-serif;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1;
+    color: #24292f;
     text-decoration: none;
+    background-color: #ebf0f4;
+    background-image: linear-gradient(180deg, #f6f8fa, #ebeef2);
+    border: 1px solid rgba(31, 35, 40, 0.15);
+    border-radius: 6px;
+    white-space: nowrap;
+    transition: background-image var(--dur-2, 180ms) var(--ease-out, ease);
 }
 
-.repositoryStat + .repositoryStat {
-    border-left: 1px solid var(--hairline);
+.ghButton:hover {
+    color: #24292f;
+    text-decoration: none;
+    background-image: linear-gradient(180deg, #f3f4f6, #e1e6ea);
+    border-color: rgba(31, 35, 40, 0.2);
 }
 
-.repositoryStat:hover,
-.repositoryStat:focus-visible {
+.ghButton svg {
+    fill: #57606a;
+    flex: 0 0 auto;
+}
+
+/* The count bubble sits to the right of the label with the classic
+   GitHub triangle pointing back toward the button. */
+.ghCount {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    margin-left: 8px;
+    padding: 0 8px;
+    height: 22px;
     background: var(--panel);
+    border: 1px solid rgba(31, 35, 40, 0.15);
+    border-radius: 6px;
 }
 
-.repositoryStat > span {
-    grid-row: 1 / 3;
-    color: var(--accent);
-    font-size: 13px;
+.ghCount::before,
+.ghCount::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    right: 100%;
+    width: 0;
+    height: 0;
+    margin-top: -5px;
+    border: 5px solid transparent;
+    border-right-color: rgba(31, 35, 40, 0.15);
 }
 
-.repositoryStat strong {
+.ghCount::after {
+    margin-right: -1px;
+    border-right-color: var(--panel);
+}
+
+.ghCount strong {
     font-family: var(--font-mono);
     font-size: 12px;
     font-weight: 700;
-    line-height: 1.2;
-}
-
-.repositoryStat small {
-    color: var(--ink-3);
-    font-family: var(--font-mono);
-    font-size: 8px;
-    line-height: 1.3;
+    line-height: 1;
+    color: #24292f;
 }
 
 .repositorySource {
-    flex: 0 0 100%;
-    margin: -4px 0 0;
+    width: 100%;
+    margin: 0.1rem 0 0;
     color: var(--ink-3);
     font-family: var(--font-mono);
-    font-size: 8px;
+    font-size: 10px;
     letter-spacing: 0.03em;
-    text-align: center;
 }
 
-.footerLinks {
-    list-style: none;
-    padding: 0;
+/* ── Lower bar: legal + social ──────────────────────────────────────────── */
+.bottom {
     display: flex;
-    justify-content: center;
+    align-items: center;
+    justify-content: space-between;
     gap: 1rem;
+    flex-wrap: wrap;
+    padding-top: 1.5rem;
 }
 
-@media (max-width: 520px) {
-    .footerContainer {
-        padding: 2rem 1rem;
-    }
-
-    .repositoryProof {
-        align-items: stretch;
-        flex-direction: column;
-    }
-
-    .repositoryProof iframe {
-        align-self: center;
-    }
-
-    .repositoryStats {
-        align-self: center;
-    }
-
-    .repositoryStat {
-        min-width: 120px;
-    }
-
-    .footerLinks {
-        gap: 0.7rem;
-        flex-wrap: wrap;
-    }
+.legal {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
 }
 
-.link {
-    color: var(--accent);
+.copyright,
+.license {
+    margin: 0;
+    font-size: 11.5px;
+    line-height: 1.5;
+    color: var(--ink-3);
+}
+
+.social {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.socialLink {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    color: var(--ink-2);
+    font-size: 16px;
     text-decoration: none;
-    transition: color 0.3s;
+    transition:
+        color var(--dur-2, 180ms) var(--ease-out, ease),
+        background-color var(--dur-2, 180ms) var(--ease-out, ease);
 }
 
-.link:hover,
-.link:focus {
-    color: var(--ink);
+.socialLink:hover,
+.socialLink:focus-visible {
+    color: var(--accent);
+    background: var(--panel);
+    text-decoration: none;
+}
+
+/* ── Responsive ─────────────────────────────────────────────────────────── */
+@media (max-width: 900px) {
+    .top {
+        grid-template-columns: 1fr;
+        gap: 2.5rem;
+    }
+
+    .columns {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 560px) {
+    .footerContainer {
+        padding: 2.5rem 1.25rem 2rem;
+    }
+
+    .columns {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 1.75rem 1rem;
+    }
+
+    .bottom {
+        flex-direction: column-reverse;
+        align-items: flex-start;
+        gap: 1.25rem;
+    }
 }

--- a/components/NavHeader.js
+++ b/components/NavHeader.js
@@ -17,6 +17,10 @@ const externalEvent = (href) => {
 
 const isExternal = (href) => /^https?:\/\//.test(href)
 
+// The hosted control plane. Kept in sync with NEXT_PUBLIC_CLOUD_APP_URL
+// (.env.example) and the footer "Hosted dashboard" destination.
+const CLOUD_APP_URL = 'https://app.openadapt.ai'
+
 const SOLUTIONS_LINKS = [
     { label: 'Healthcare', href: '/solutions/healthcare' },
     { label: 'Lending', href: '/solutions/lending' },
@@ -32,6 +36,11 @@ const PRODUCT_LINKS = [
     { label: 'Download', href: '/download' },
 ]
 
+// The Developers dropdown consumes the canonical ecosystem list and adds
+// the blog, so the engineering-facing content lives under one menu instead
+// of scattering Blog across the top bar.
+const DEVELOPER_MENU_LINKS = [...DEVELOPER_LINKS, BLOG_LINK]
+
 const NAV_LINKS = [
     {
         label: 'Solutions',
@@ -45,11 +54,10 @@ const NAV_LINKS = [
         menuId: 'nav-product-menu',
         align: 'left',
     },
-    { label: 'Launch', href: '/#pricing' },
-    { label: BLOG_LINK.label, href: BLOG_LINK.href, external: true },
+    { label: 'Pricing', href: '/#pricing' },
     {
         label: 'Developers',
-        dropdown: DEVELOPER_LINKS,
+        dropdown: DEVELOPER_MENU_LINKS,
         menuId: 'nav-developers-menu',
         align: 'right',
     },
@@ -137,8 +145,7 @@ function NavDropdown({ label, links, menuId, align }) {
         if (!open || !pendingFocus.current || !panelRef.current) return
         const items = panelRef.current.querySelectorAll('a')
         if (items.length > 0) {
-            const index =
-                pendingFocus.current === 'last' ? items.length - 1 : 0
+            const index = pendingFocus.current === 'last' ? items.length - 1 : 0
             items[index].focus()
         }
         pendingFocus.current = null
@@ -324,6 +331,28 @@ export default function NavHeader() {
                         )
                     })}
                 </nav>
+                <div className={styles.actions}>
+                    <a
+                        href={CLOUD_APP_URL}
+                        className={styles.signIn}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Sign in
+                    </a>
+                    <Link
+                        href="/#book"
+                        className={styles.cta}
+                        onClick={() =>
+                            track(EVENTS.HERO_CTA_CLICK, {
+                                location: 'nav',
+                                cta: 'evaluate_workflow',
+                            })
+                        }
+                    >
+                        Evaluate a workflow
+                    </Link>
+                </div>
                 <button
                     type="button"
                     className={styles.menuButton}
@@ -334,18 +363,6 @@ export default function NavHeader() {
                 >
                     {menuOpen ? 'CLOSE' : 'MENU'}
                 </button>
-                <Link
-                    href="/#book"
-                    className={styles.cta}
-                    onClick={() =>
-                        track(EVENTS.HERO_CTA_CLICK, {
-                            location: 'nav',
-                            cta: 'evaluate_workflow',
-                        })
-                    }
-                >
-                    Evaluate a workflow
-                </Link>
             </div>
             {menuOpen && (
                 <nav
@@ -396,6 +413,14 @@ export default function NavHeader() {
                             </Link>
                         )
                     })}
+                    <a
+                        href={CLOUD_APP_URL}
+                        className={styles.mobileLink}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Sign in
+                    </a>
                 </nav>
             )}
         </header>

--- a/components/NavHeader.module.css
+++ b/components/NavHeader.module.css
@@ -157,6 +157,35 @@
     text-decoration: none;
 }
 
+.actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.signIn {
+    display: inline-flex;
+    align-items: center;
+    padding: 6px 14px;
+    border-radius: 9999px;
+    background: transparent;
+    color: var(--ink);
+    border: 1.5px solid var(--hairline);
+    font-size: 13px;
+    font-weight: 500;
+    text-decoration: none;
+    white-space: nowrap;
+    transition:
+        border-color var(--dur-2, 180ms) var(--ease-out, ease),
+        color var(--dur-2, 180ms) var(--ease-out, ease);
+}
+
+.signIn:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+    text-decoration: none;
+}
+
 .cta {
     display: inline-block;
     padding: 7px 16px;
@@ -206,13 +235,18 @@
         display: none;
     }
 
-    .menuButton {
-        display: inline-block;
+    .actions {
         margin-left: auto;
     }
 
-    .cta {
-        margin-left: 0;
+    /* On mobile the CTA and hamburger carry the header; "Sign in" lives
+       inside the expandable panel instead of crowding the top bar. */
+    .signIn {
+        display: none;
+    }
+
+    .menuButton {
+        display: inline-block;
     }
 
     .mobilePanel {

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -1,5 +1,4 @@
-const BOOKING_URL =
-    'https://cal.com/richard-abrich/30min?overlayCalendar=true'
+const BOOKING_URL = 'https://cal.com/richard-abrich/30min?overlayCalendar=true'
 
 function isProductionDeployment() {
     const baseUrl = Cypress.config('baseUrl')
@@ -63,8 +62,11 @@ describe('public product truth', () => {
                 .should('be.visible')
         })
         cy.get('h1').click()
-        cy.get('[data-testid="github-proof"]')
-            .should('have.attr', 'href', 'https://github.com/OpenAdaptAI/OpenAdapt')
+        cy.get('[data-testid="github-proof"]').should(
+            'have.attr',
+            'href',
+            'https://github.com/OpenAdaptAI/OpenAdapt'
+        )
         cy.get('[data-testid="github-proof"]')
             .should('contain.text', 'stars on OpenAdapt')
             .and('contain.text', 'forks')
@@ -87,47 +89,75 @@ describe('public product truth', () => {
         cy.get('#nav-product-menu a').first().should('be.focused')
         cy.focused().type('{downarrow}')
         cy.get('#nav-product-menu a').eq(1).should('be.focused')
-        cy.contains('nav[aria-label="Primary"] a', 'Launch').focus()
+        cy.contains('nav[aria-label="Primary"] a', 'Pricing').focus()
         cy.get('#nav-product-menu').should('not.exist')
 
         cy.get('nav[aria-label="Primary"]').within(() => {
-            cy.contains('a', 'Launch')
+            cy.contains('a', 'Pricing')
                 .should('be.visible')
                 .and('have.attr', 'href', '/#pricing')
-            cy.contains('a', 'Blog')
-                .should('be.visible')
-                .and('have.attr', 'href', 'https://blog.openadapt.ai')
             cy.contains('a', 'Open source')
                 .should('be.visible')
-                .and('have.attr', 'href', 'https://github.com/OpenAdaptAI/OpenAdapt')
+                .and(
+                    'have.attr',
+                    'href',
+                    'https://github.com/OpenAdaptAI/OpenAdapt'
+                )
             cy.contains('a', 'About').should('not.exist')
+            // Blog consolidated into the Developers dropdown, so it is not a
+            // top-level link while every dropdown is closed.
+            cy.contains('a', 'Blog').should('not.exist')
 
             cy.contains('button', 'Solutions')
                 .should('be.visible')
                 .and('have.attr', 'aria-expanded', 'false')
             cy.contains('button', 'Solutions').click()
             cy.get('#nav-solutions-menu').within(() => {
-                cy.contains('a', 'Healthcare')
-                    .should('have.attr', 'href', '/solutions/healthcare')
-                cy.contains('a', 'Lending')
-                    .should('have.attr', 'href', '/solutions/lending')
-                cy.contains('a', 'Insurance')
-                    .should('have.attr', 'href', '/solutions/insurance')
+                cy.contains('a', 'Healthcare').should(
+                    'have.attr',
+                    'href',
+                    '/solutions/healthcare'
+                )
+                cy.contains('a', 'Lending').should(
+                    'have.attr',
+                    'href',
+                    '/solutions/lending'
+                )
+                cy.contains('a', 'Insurance').should(
+                    'have.attr',
+                    'href',
+                    '/solutions/insurance'
+                )
             })
 
             cy.contains('button', 'Product').click()
             cy.get('#nav-solutions-menu').should('not.exist')
             cy.get('#nav-product-menu').within(() => {
-                cy.contains('a', 'How it runs')
-                    .should('have.attr', 'href', '/#product-status')
-                cy.contains('a', 'Safety')
-                    .should('have.attr', 'href', '/safety')
-                cy.contains('a', 'Compare')
-                    .should('have.attr', 'href', '/compare')
-                cy.contains('a', 'Templates')
-                    .should('have.attr', 'href', '/templates')
-                cy.contains('a', 'Download')
-                    .should('have.attr', 'href', '/download')
+                cy.contains('a', 'How it runs').should(
+                    'have.attr',
+                    'href',
+                    '/#product-status'
+                )
+                cy.contains('a', 'Safety').should(
+                    'have.attr',
+                    'href',
+                    '/safety'
+                )
+                cy.contains('a', 'Compare').should(
+                    'have.attr',
+                    'href',
+                    '/compare'
+                )
+                cy.contains('a', 'Templates').should(
+                    'have.attr',
+                    'href',
+                    '/templates'
+                )
+                cy.contains('a', 'Download').should(
+                    'have.attr',
+                    'href',
+                    '/download'
+                )
             })
 
             cy.contains('button', 'Developers')
@@ -168,9 +198,24 @@ describe('public product truth', () => {
                         'href',
                         'https://github.com/OpenAdaptAI/openadapt-flow/issues/new/choose'
                     )
-                // Blog is top-level, not duplicated inside the dropdown.
-                cy.contains('a', 'Blog').should('not.exist')
+                // Blog is consolidated into the Developers dropdown.
+                cy.contains('a', 'Blog')
+                    .should('be.visible')
+                    .and('have.attr', 'href', 'https://blog.openadapt.ai')
             })
+        })
+
+        // A primary evaluation CTA and a secondary "Sign in" affordance
+        // (the hosted control plane) sit in the header action cluster.
+        cy.get('header').within(() => {
+            cy.contains('a', 'Evaluate a workflow').should(
+                'have.attr',
+                'href',
+                '/#book'
+            )
+            cy.contains('a', 'Sign in')
+                .should('be.visible')
+                .and('have.attr', 'href', 'https://app.openadapt.ai')
         })
 
         // Escape closes and returns focus to the trigger.
@@ -183,23 +228,31 @@ describe('public product truth', () => {
         )
         cy.contains('button', 'Developers').should('be.focused')
 
-        // Reopen, then a click outside the dropdown closes it.
+        // Reopen, then a click outside the dropdown closes it. The
+        // right-aligned Developers panel overlays the hero heading, so
+        // dismiss from a point on the left that the panel never covers.
         cy.contains('button', 'Developers').click()
         cy.get('#nav-developers-menu').should('be.visible')
-        cy.get('h1').click()
+        cy.get('body').click(20, 500)
         cy.get('#nav-developers-menu').should('not.exist')
     })
 
     it('explains the governed workflow and execution choices', () => {
-        cy.contains('What “repair” means, and where it stops').should('be.visible')
+        cy.contains('What “repair” means, and where it stops').should(
+            'be.visible'
+        )
         cy.contains('Unsupported drift').should('be.visible')
         cy.get('#product-status').within(() => {
-            cy.contains('One governed workflow, end to end').should('be.visible')
+            cy.contains('One governed workflow, end to end').should(
+                'be.visible'
+            )
             cy.contains('Capture the workflow').should('be.visible')
             cy.contains('Run through the governed gate').should('be.visible')
             cy.contains('Managed browser execution').should('be.visible')
             cy.contains('Customer-controlled deployment').should('be.visible')
-            cy.contains('Built for the interfaces your work depends on').should('be.visible')
+            cy.contains('Built for the interfaces your work depends on').should(
+                'be.visible'
+            )
             cy.contains('Web applications').should('be.visible')
             cy.contains('Windows applications').should('be.visible')
             cy.contains('RDP, Citrix & VDI').should('be.visible')
@@ -303,7 +356,7 @@ describe('public product truth', () => {
             cy.contains('a', 'Download')
                 .should('have.attr', 'href')
                 .and('equal', '/download')
-            cy.contains('a', 'Launch').should('have.attr', 'href', '/#pricing')
+            cy.contains('a', 'Pricing').should('have.attr', 'href', '/#pricing')
             cy.contains('a', 'Blog')
                 .should('have.attr', 'href')
                 .and('equal', 'https://blog.openadapt.ai')
@@ -311,10 +364,7 @@ describe('public product truth', () => {
             cy.contains('Developers').scrollIntoView().should('be.visible')
             cy.contains('a', 'Compiler/runtime source')
                 .should('have.attr', 'href')
-                .and(
-                    'equal',
-                    'https://github.com/OpenAdaptAI/openadapt-flow'
-                )
+                .and('equal', 'https://github.com/OpenAdaptAI/openadapt-flow')
             cy.contains('a', 'Docs')
                 .should('have.attr', 'href')
                 .and('equal', 'https://docs.openadapt.ai')
@@ -337,6 +387,10 @@ describe('public product truth', () => {
                 .scrollIntoView()
                 .should('have.attr', 'href')
                 .and('equal', 'https://github.com/OpenAdaptAI/OpenAdapt')
+            cy.contains('a', 'Sign in')
+                .scrollIntoView()
+                .should('have.attr', 'href')
+                .and('equal', 'https://app.openadapt.ai')
         })
         cy.get('#nav-mobile-menu').then(($menu) => {
             expect($menu[0].scrollHeight).to.be.greaterThan(
@@ -380,20 +434,20 @@ describe('public product truth', () => {
         })
         cy.get('#benchmark-evidence').within(() => {
             cy.contains('On MockMed').should('be.visible')
-            cy.contains('Faster repeat runs without per-run model spend.').should(
-                'be.visible'
-            )
+            cy.contains(
+                'Faster repeat runs without per-run model spend.'
+            ).should('be.visible')
             cy.contains('100 compiled replays').should('not.exist')
             cy.contains('$3/$15').should('not.exist')
             cy.contains('introductory').should('not.exist')
             cy.contains('resets daily').should('not.exist')
             cy.contains('N=10').should('not.exist')
-            cy.contains(
-                'Method, raw results, and rerun instructions'
-            ).should('have.attr', 'href').and('include', 'benchmark/BENCHMARK.md')
-            cy.contains(
-                'OpenEMR cross-check'
-            ).should('have.attr', 'href').and('include', 'openemr/BENCHMARK.md')
+            cy.contains('Method, raw results, and rerun instructions')
+                .should('have.attr', 'href')
+                .and('include', 'benchmark/BENCHMARK.md')
+            cy.contains('OpenEMR cross-check')
+                .should('have.attr', 'href')
+                .and('include', 'openemr/BENCHMARK.md')
         })
         cy.contains("We'd rather tell you").should('not.exist')
         cy.contains('Versus traditional RPA platforms').should('not.exist')
@@ -406,9 +460,7 @@ describe('public product truth', () => {
         cy.get('#side-by-side [role="region"]')
             .should('be.visible')
             .and('have.attr', 'tabindex', '0')
-        cy.contains('Evaluate a workflow')
-            .scrollIntoView()
-            .should('be.visible')
+        cy.contains('Evaluate a workflow').scrollIntoView().should('be.visible')
         cy.contains('Try locally').should('be.visible')
     })
 
@@ -440,7 +492,9 @@ describe('public product truth', () => {
 
         cy.visit('/solutions/healthcare')
         cy.get('h1').should('contain.text', 'structured healthcare workflows')
-        cy.contains('document processing, eligibility, routing').should('be.visible')
+        cy.contains('document processing, eligibility, routing').should(
+            'be.visible'
+        )
         cy.contains('public safety gallery').should('be.visible')
         cy.contains('OpenAdapt does the retyping').should('not.exist')
         cy.contains('Certified workflows halt before').should('not.exist')
@@ -453,7 +507,9 @@ describe('public product truth', () => {
         cy.contains('supported APIs and exports').should('be.visible')
         cy.contains('customer-controlled deployment').should('be.visible')
         cy.contains('experimental').should('not.exist')
-        cy.get('[data-testid="frappe-lending-workflow-demo"]').should('be.visible')
+        cy.get('[data-testid="frappe-lending-workflow-demo"]').should(
+            'be.visible'
+        )
         cy.get('img[alt*="Frappe Lending frames"]')
             .scrollIntoView()
             .should('be.visible')
@@ -500,9 +556,9 @@ describe('public product truth', () => {
 
         cy.visit('/safety')
         cy.get('h1').should('contain.text', 'needs verified identity')
-        cy.contains('do not establish end-to-end or production EMR reliability').should(
-            'be.visible'
-        )
+        cy.contains(
+            'do not establish end-to-end or production EMR reliability'
+        ).should('be.visible')
     })
 
     it('starts the configured hosted checkout path', () => {
@@ -553,9 +609,7 @@ describe('public product truth', () => {
                 )
             } else {
                 expect(response.status).to.equal(503)
-                expect(response.body.error).to.equal(
-                    'checkout_not_configured'
-                )
+                expect(response.body.error).to.equal('checkout_not_configured')
             }
         })
     })
@@ -591,7 +645,9 @@ describe('public product truth', () => {
                 'STRIPE_EXPECTED_MODE',
                 'NEXT_PUBLIC_SITE_URL',
                 'NEXT_PUBLIC_CLOUD_APP_URL',
-            ].forEach((name) => expect(source).to.include(`process.env.${name}`))
+            ].forEach((name) =>
+                expect(source).to.include(`process.env.${name}`)
+            )
             expect(source.indexOf('stripe.prices.retrieve')).to.be.lessThan(
                 source.indexOf('stripe.checkout.sessions.create')
             )
@@ -607,7 +663,9 @@ describe('public product truth', () => {
         cy.contains('Subscription, Renewal, and Usage').should('be.visible')
         cy.contains('renews automatically').should('be.visible')
         cy.contains('Cancellation and Refunds').should('be.visible')
-        cy.contains('charges already paid are non-refundable').should('be.visible')
+        cy.contains('charges already paid are non-refundable').should(
+            'be.visible'
+        )
         cy.contains('Artifact and Runtime Data Boundaries').should('be.visible')
         cy.contains('Managed browser recording is a different path').should(
             'be.visible'
@@ -618,9 +676,9 @@ describe('public product truth', () => {
         cy.contains('A BAA applies only when expressly included').should(
             'be.visible'
         )
-        cy.contains('no uptime, response-time, support, retention, recovery').should(
-            'be.visible'
-        )
+        cy.contains(
+            'no uptime, response-time, support, retention, recovery'
+        ).should('be.visible')
     })
 })
 
@@ -638,19 +696,25 @@ describe('security boundary', () => {
         cy.contains('OpenAdapt does not yet hold a SOC 2 report').should(
             'be.visible'
         )
-        cy.contains('Scrubbing creates a reviewable derivative').should('be.visible')
+        cy.contains('Scrubbing creates a reviewable derivative').should(
+            'be.visible'
+        )
         cy.contains('approve that exact hash').should('be.visible')
         cy.contains('Risk-based hybrid').should('be.visible')
         cy.contains('Hosted runtime gate').should('be.visible')
         cy.contains('operator self-attestation').should('be.visible')
         cy.contains('its policy and risk-class allowlists').should('be.visible')
         cy.contains('deployed compiler-version allowlist').should('be.visible')
-        cy.contains('Does Cloud independently witness local sanitation review?').should('be.visible')
-        cy.contains('Can managed execution reach private-network targets?').should('be.visible')
+        cy.contains(
+            'Does Cloud independently witness local sanitation review?'
+        ).should('be.visible')
+        cy.contains(
+            'Can managed execution reach private-network targets?'
+        ).should('be.visible')
         cy.contains('What does break reporting send?').should('be.visible')
-        cy.contains('It does not upload the recording or compiled bundle').should(
-            'be.visible'
-        )
+        cy.contains(
+            'It does not upload the recording or compiled bundle'
+        ).should('be.visible')
     })
 
     it('states the same boundary in privacy and hosted onboarding', () => {
@@ -663,7 +727,9 @@ describe('security boundary', () => {
             'be.visible'
         )
         cy.contains('approved by exact archive hash').should('be.visible')
-        cy.contains('Managed browser recording is separate').should('be.visible')
+        cy.contains('Managed browser recording is separate').should(
+            'be.visible'
+        )
         cy.contains('Current Service Providers').should('be.visible')
         cy.contains('Healthy deterministic replay makes no model calls').should(
             'be.visible'
@@ -672,7 +738,9 @@ describe('security boundary', () => {
 
         cy.visit('/hosted/welcome')
         cy.contains('Continue hosted onboarding').should('be.visible')
-        cy.contains('Sign in with the email used at checkout').should('be.visible')
+        cy.contains('Sign in with the email used at checkout').should(
+            'be.visible'
+        )
         cy.contains('review the captured demonstration').should('be.visible')
         cy.contains('Run under supervision').should('be.visible')
         cy.contains('Monitor usage, outcomes').should('be.visible')

--- a/cypress/e2e/public-surface-coherence.cy.js
+++ b/cypress/e2e/public-surface-coherence.cy.js
@@ -10,8 +10,10 @@ describe('public surface coherence', () => {
                 'href',
                 'https://github.com/OpenAdaptAI/OpenAdapt'
             )
-        cy.get('[data-testid="github-proof"]')
-            .should('contain.text', 'stars on OpenAdapt')
+        cy.get('[data-testid="github-proof"]').should(
+            'contain.text',
+            'stars on OpenAdapt'
+        )
         cy.get('a.btn-ink')
             .contains('Evaluate a workflow')
             .should('have.attr', 'href', '/#book')
@@ -65,14 +67,23 @@ describe('public surface coherence', () => {
                 .scrollIntoView()
                 .should('be.visible')
                 .within(() => {
+                    // GitHub-official-style star/fork buttons: icon + label +
+                    // a count bubble. The descriptive count lives in the
+                    // accessible name of each button.
+                    cy.contains('Star').should('be.visible')
                     cy.get('[data-testid="footer-star-count"]')
                         .invoke('text')
                         .should('match', /^\d{1,3}(,\d{3})*$/)
-                    cy.contains('stars on OpenAdapt').should('be.visible')
+                    cy.get('a[aria-label*="stars on OpenAdapt"]').should(
+                        'exist'
+                    )
+                    cy.contains('Fork').should('be.visible')
                     cy.get('[data-testid="footer-fork-count"]')
                         .invoke('text')
                         .should('match', /^\d{1,3}(,\d{3})*$/)
-                    cy.contains('forks').should('be.visible')
+                    cy.get('a[aria-label*="forks of OpenAdapt"]').should(
+                        'exist'
+                    )
                     cy.get(
                         'a[href="https://github.com/OpenAdaptAI/OpenAdapt"]'
                     ).should('exist')

--- a/tests/footerStructure.test.js
+++ b/tests/footerStructure.test.js
@@ -1,0 +1,127 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+const root = path.join(__dirname, '..')
+const read = (relativePath) =>
+    fs.readFileSync(path.join(root, relativePath), 'utf8')
+
+const footer = read('components/Footer.js')
+
+test('footer is organized into the canonical column sections', () => {
+    for (const title of [
+        'Product',
+        'Solutions',
+        'Developers',
+        'Connect',
+        'Company',
+        'Trust &amp; legal',
+    ]) {
+        // The heading may be printed on one line or wrapped by Prettier.
+        const heading = new RegExp(
+            `columnTitle[^>]*>\\s*${title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*</h2>`
+        )
+        assert.match(footer, heading, `footer has a "${title}" section header`)
+    }
+})
+
+test('product and solutions destinations are all reachable from the footer', () => {
+    for (const href of [
+        '/#product-status',
+        '/workflows',
+        '/templates',
+        '/compare',
+        '/safety',
+        '/download',
+        '/#pricing',
+        '/solutions/healthcare',
+        '/solutions/lending',
+        '/solutions/insurance',
+    ]) {
+        assert.ok(footer.includes(`href="${href}"`), `footer links ${href}`)
+    }
+})
+
+test('developer and connect links come from the single canonical source', () => {
+    assert.match(
+        footer,
+        /import \{ BLOG_LINK, DEVELOPER_LINKS \} from 'data\/developerLinks'/
+    )
+    // The six developer/community destinations relocated from the homepage
+    // body live in the Developers and Connect columns.
+    assert.match(footer, /'Compiler\/runtime source'/)
+    assert.match(footer, /'Docs'/)
+    assert.match(footer, /'Technical paper source'/)
+    assert.match(footer, /'Report an issue'/)
+    assert.match(footer, /const CONNECT_COLUMN = \[/)
+    assert.match(footer, /BLOG_LINK/)
+    assert.match(footer, /byLabel\('Discord'\)/)
+    assert.match(footer, /label: 'GitHub', href: OPENADAPT_REPOSITORY_URL/)
+})
+
+test('company, trust, and legal sections are complete', () => {
+    for (const href of [
+        '/about',
+        '/security',
+        '/privacy-policy',
+        '/terms-of-service',
+    ]) {
+        assert.ok(footer.includes(`href="${href}"`), `footer links ${href}`)
+    }
+    // Hosted dashboard reachable from the footer's Company column.
+    assert.match(footer, /const CLOUD_APP_URL = 'https:\/\/app\.openadapt\.ai'/)
+    assert.match(footer, /href=\{CLOUD_APP_URL\}[\s\S]*?Hosted dashboard/)
+    assert.match(footer, /href="mailto:hello@openadapt\.ai"/)
+    // Honest labels preserved.
+    assert.match(footer, /Trust center/)
+    assert.match(footer, /Privacy Notice/)
+    assert.match(footer, /Terms of Service/)
+})
+
+test('footer carries the standard brand, legal, and social baseline', () => {
+    assert.match(
+        footer,
+        /© 2023–\{currentYear\} OpenAdapt\.AI and MLDSAI Inc\./
+    )
+    assert.match(footer, /licensed under the\s+MIT License/)
+    assert.match(footer, /OpenAdapt compiles demonstrated GUI workflows/)
+    for (const icon of [
+        'faGithub',
+        'faXTwitter',
+        'faLinkedinIn',
+        'faDiscord',
+    ]) {
+        assert.ok(footer.includes(icon), `social row renders ${icon}`)
+    }
+    assert.match(footer, /x\.com\/OpenAdaptAI/)
+    assert.match(footer, /linkedin\.com\/company\/95677624/)
+    assert.match(footer, /discord\.gg\/yF527cQbDG/)
+})
+
+test('star/fork widget is a faithful GitHub-button lookalike, not the api-calling widget', () => {
+    // Preserves the machine-readable contract used across the site.
+    for (const testid of [
+        'footer-repository-stats',
+        'footer-star-count',
+        'footer-fork-count',
+        'footer-repository-source',
+    ]) {
+        assert.ok(footer.includes(testid), `keeps ${testid}`)
+    }
+    // GitHub-official button anatomy: octicon + "Star"/"Fork" label + count.
+    assert.match(footer, /function StarOcticon\(\)/)
+    assert.match(footer, /function ForkOcticon\(\)/)
+    assert.match(footer, /<StarOcticon \/>/)
+    assert.match(footer, /<ForkOcticon \/>/)
+    assert.match(footer, /<span>Star<\/span>/)
+    assert.match(footer, /<span>Fork<\/span>/)
+    assert.match(footer, /stars on OpenAdapt/)
+    assert.match(footer, /forks of OpenAdapt/)
+    // Never the third-party widget that makes visitor browsers hit
+    // api.github.com (also guarded in publicTruth.test.js).
+    assert.doesNotMatch(
+        footer,
+        /data-show-count|github-button|buttons\.github\.io/
+    )
+})

--- a/tests/navContract.test.js
+++ b/tests/navContract.test.js
@@ -72,10 +72,17 @@ test('top navigation consolidates solutions, product and developer destinations'
     }
     assert.match(nav, /dropdown: PRODUCT_LINKS/)
 
-    assert.match(nav, /\{ label: 'Launch', href: '\/#pricing' \}/)
-    assert.match(nav, /label: BLOG_LINK\.label, href: BLOG_LINK\.href/)
+    // "Launch" was renamed to the clearer, conventional "Pricing".
+    assert.match(nav, /\{ label: 'Pricing', href: '\/#pricing' \}/)
+    assert.doesNotMatch(nav, /label: 'Launch'/)
 
-    assert.match(nav, /label: 'Developers',\s+dropdown: DEVELOPER_LINKS/)
+    // Blog is consolidated into the Developers dropdown rather than sitting
+    // as its own top-level item, still sourced from the canonical BLOG_LINK.
+    assert.match(
+        nav,
+        /const DEVELOPER_MENU_LINKS = \[\.\.\.DEVELOPER_LINKS, BLOG_LINK\]/
+    )
+    assert.match(nav, /label: 'Developers',\s+dropdown: DEVELOPER_MENU_LINKS/)
     assert.match(
         nav,
         /label: 'Open source',\s+href: 'https:\/\/github\.com\/OpenAdaptAI\/OpenAdapt'/
@@ -84,6 +91,12 @@ test('top navigation consolidates solutions, product and developer destinations'
         links,
         /label: 'Compiler\/runtime source',\s+href: 'https:\/\/github\.com\/OpenAdaptAI\/OpenAdapt'/
     )
+
+    // The hosted control plane is reachable from the top nav as a secondary
+    // "Sign in" affordance distinct from the primary evaluation CTA.
+    assert.match(nav, /const CLOUD_APP_URL = 'https:\/\/app\.openadapt\.ai'/)
+    assert.match(nav, /className=\{styles\.signIn\}[\s\S]*?Sign in/)
+    assert.match(nav, /className=\{styles\.cta\}[\s\S]*?Evaluate a workflow/)
 
     assert.doesNotMatch(nav, /'\/about'/)
     assert.match(footer, /href="\/about"/)
@@ -95,7 +108,10 @@ test('all dropdowns share the same keyboard, pointer and ARIA behavior', () => {
         1,
         'one reusable dropdown trigger implementation'
     )
-    assert.match(nav, /function NavDropdown\(\{ label, links, menuId, align \}\)/)
+    assert.match(
+        nav,
+        /function NavDropdown\(\{ label, links, menuId, align \}\)/
+    )
     for (const menuId of [
         'nav-solutions-menu',
         'nav-product-menu',


### PR DESCRIPTION
## Summary

Consolidates and professionalizes the site **header/nav** and **footer** so they read as one cohesive system, addresses the founder's "disjointed footer" and "Hosted dashboard link" feedback, and applies B2B/dev-tool nav + footer IA best practices. Scope is strictly the nav/footer components, their styles, and their contract tests.

## Top navigation — before → after

**Before:** Solutions ▾ · Product ▾ · Launch · Blog · Developers ▾ · Open source · [Evaluate a workflow]

**After:** Solutions ▾ · Product ▾ · **Pricing** · Developers ▾ (now includes Blog) · Open source · **[Sign in]** · [Evaluate a workflow]

- **Hosted dashboard decision → YES, in the top nav.** `app.openadapt.ai` is surfaced as a right-aligned secondary **"Sign in"** affordance in the header action cluster, clearly distinct from the single primary CTA ("Evaluate a workflow"). It also appears in the mobile menu, and remains in the footer Company column ("Hosted dashboard").
- Renamed the unclear **"Launch" → "Pricing"** (→ `/#pricing`).
- Consolidated **Blog into the Developers dropdown** (fewer, clearer top-level items; blog is a dev/content destination).
- Dropdown a11y (keyboard arrows, Escape, focus return, outside-click, ARIA `aria-expanded`/`aria-controls`, mobile labeled groups) is unchanged and still passing.

## Footer IA — columns + links

Rebuilt the flat, centered link soup into a clean multi-column structure with section headers, a brand block, and a bottom bar.

- **Brand block:** OpenAdapt wordmark, one-line positioning, "Evaluate a workflow" CTA, GitHub Star/Fork buttons, snapshot source line.
- **Product:** How it runs · Workflows · Templates · Compare · Safety · Download · Pricing
- **Solutions:** Healthcare · Lending · Insurance
- **Developers:** Compiler/runtime source · Docs · Technical paper source · Report an issue
- **Connect:** Blog · Discord · GitHub
- **Company:** About · Hosted dashboard · Contact · Email
- **Trust & legal:** Trust center (/security) · Privacy Notice · Terms of Service
- **Bottom bar:** © 2023–2026 OpenAdapt.AI and MLDSAI Inc. · MIT License line · social icons (GitHub, X, LinkedIn, Discord).

Developer/community destinations are sourced from the canonical `data/developerLinks.js`, so nav and footer can't drift. Every honest link (Trust center, Workflows, Compare, Download, etc.) stays reachable; no claim/label changes beyond "Launch"→"Pricing" in nav config. Responsive: 6 → 3 → 2 columns, brand stacks, no horizontal overflow at 375/390px.

## GitHub star/fork widget (founder request)

Replaced the custom `★ / ⑂` rendering with a **faithful lookalike of GitHub's official Star/Fork buttons** — real octicon SVGs (MIT), "Star"/"Fork" label, GitHub's light-gradient button chrome, and a count bubble with the classic triangle pointer. Counts stay accurate: live values from the existing server-side `/api/repository-stats` refresh (currently ~1,649 ★ / 258 ⑂), with the verified `1,648 / 258` snapshot as the fail-safe fallback. It is rendered entirely in our own markup and **never** loads the third-party embed widget (which would make every visitor's browser hit `api.github.com`) — this is enforced by tests.

## Best practices applied

- Few, clear top-level items; one prominent primary CTA; a separate secondary "Sign in" affordance.
- Dropdown grouping by audience/function (Solutions / Product / Developers); flagship "Open source" kept as a direct link.
- Comprehensive, sectioned footer as the home for utility/trust/legal links; consistent type scale, muted dividers, spacing rhythm; responsive column collapse.

## Tests / gates

- `npm test` (node): **93 pass** — updated `tests/navContract.test.js` to the new IA (a11y assertions preserved); added `tests/footerStructure.test.js` (required sections/links + GitHub-button anatomy + no api.github.com widget).
- `npm run build`: **green.**
- Cypress full suite: **32/32 pass** — updated the nav assertions in `basic.cy.js` and the footer-stats assertions in `public-surface-coherence.cy.js` to the new structure.

## Links fixed / notable

- **"Launch"** was an unclear label for a pricing/plans section → relabeled **"Pricing"**.
- **Hosted dashboard** was footer-only → now also a top-nav "Sign in" affordance.

## ⚠️ Follow-up for the conversion agent (`feat/conversion-optimize`) — do NOT double-edit `pages/index.js`

These six links now live in the **footer** (Developers + Connect columns) and can be removed from the **homepage body** to avoid duplication. I deliberately did **not** touch `pages/index.js` to avoid colliding with the parallel homepage-body edits:

- Compiler/runtime source → https://github.com/OpenAdaptAI/openadapt-flow
- Docs → https://docs.openadapt.ai
- Technical paper source → https://github.com/OpenAdaptAI/openadapt-flow/tree/main/paper
- Blog → https://blog.openadapt.ai
- Discord → https://discord.gg/yF527cQbDG
- Report an issue → https://github.com/OpenAdaptAI/openadapt-flow/issues/new/choose

(URLs verified against the canonical `data/developerLinks.js`.) Please remove the homepage-body copies in that branch or a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM