### PR TITLE
test(download): guard against mobile horizontal scroll at 375/390

### DIFF
--- a/cypress/e2e/download.cy.js
+++ b/cypress/e2e/download.cy.js
@@ -117,6 +117,39 @@ describe('download page is server-rendered', () => {
     })
 })
 
+describe('download page does not scroll horizontally on mobile', () => {
+    // Common small-phone widths (iPhone SE / mini and iPhone 12/13/14).
+    for (const width of [375, 390]) {
+        it(`fits the viewport at ${width}px with no horizontal overflow`, () => {
+            cy.viewport(width, 800)
+            cy.visit('/download')
+            // The desktop-preview section always renders; wait for it so the
+            // measurement covers the real, fully laid-out page.
+            cy.get('[data-testid="desktop-preview"]').should('exist')
+            // Let the async PyPI chart and any client hints settle.
+            cy.wait(1500)
+
+            // globals.css sets `overflow-x: hidden` on html/body. That clamps
+            // documentElement.scrollWidth in Chrome, so measuring it directly
+            // would trivially pass and hide a real regression — and it does NOT
+            // reliably stop horizontal panning on iOS Safari, which is exactly
+            // the surface this guards. Neutralize the mask so scrollWidth
+            // reflects the true content width before asserting.
+            cy.document().then((doc) => {
+                const style = doc.createElement('style')
+                style.setAttribute('data-test-unmask', 'overflow')
+                style.innerHTML =
+                    'html, body { overflow-x: visible !important; width: auto !important; }'
+                doc.head.appendChild(style)
+            })
+
+            cy.document()
+                .its('documentElement.scrollWidth')
+                .should('be.lte', width)
+        })
+    }
+})
+
 describe('desktop release contract', () => {
     it('ignores legacy, draft, and incomplete releases', () => {
         const legacy = {


### PR DESCRIPTION
## Summary

Adds a Cypress regression assertion for the `/download` page that visits it at **375px** and **390px** and asserts `document.documentElement.scrollWidth` stays within the viewport (no horizontal scroll on mobile).

## Task 1 — horizontal scroll: investigation finding

I set out to diagnose and fix a horizontal-scroll overflow on `/download` at 375/390px. **On current `main` (96067ca) the page does not scroll horizontally at any width from 320–414px** in the fully-loaded ready state (recommended/all-downloads cards, PyPI chart with live data + secondary stats row, Windows install-flow strip, desktop preview, First-launch section — all render and fit). Verified two ways:

- Measured `documentElement.scrollWidth == viewport` at 320/360/375/390/414 (zero elements with `right > viewport`).
- Full-page mobile screenshot at 375px — no clipped/overflowing content.

`globals.css` applies `overflow-x: hidden` to `html`/`body`. To rule out that mask hiding a real overflow, I re-measured with it neutralized at runtime — still **zero overflow**. Recent download-page work (#215/#216/#219/#223/#229) appears to have already resolved any earlier overflow.

Rather than fabricate a fix for a bug that no longer reproduces, this PR lands the **requested regression guard**. Two details make it meaningful rather than trivially-green:

1. The global `overflow-x: hidden` would clamp `scrollWidth` in Chrome and make a naive check always pass — so the test **neutralizes that mask** before asserting, measuring the true content width. That mask also does not reliably stop horizontal panning on **iOS Safari**, which is the real surface this protects.
2. Proven meaningful: injecting a 900px element with the mask neutralized makes the assertion fail as expected.

## Task 2 — desktop screenshots: honest finding, no change made

The founder wanted the "Real screenshots" section to show more of the desktop app. Per the DesktopPreview honesty contract, `public/desktop-preview/MANIFEST.json`, and the capture provenance in the monorepo (`.private/desktop_capture_2026_07_19/macos/MANIFEST.md`): **with no engine connected, the desktop app only renders the first-run connect/Sign-in screen** — that is the only honest desktop-app state that exists. The in-app Settings page is an unimplemented TODO stub and is intentionally not captured; no authenticated/workflow states exist. The only additional real captures are **tray-companion** states (a separate `pip install openadapt-tray` package, explicitly de-emphasized on the page as not part of the installers), which don't honestly answer "show more of the desktop app."

Conclusion: the desktop-app section is already honest and complete for what the disconnected build renders. **No image was added, retouched, or fabricated; the manifest and honesty tests are untouched and green.**

## Gates (all green)

- `npm ci` ✅
- `npm test` (node --test): **93/93** ✅
- `npm run build` ✅
- Cypress (`baseUrl=http://127.0.0.1:3000`): **34/34** across all specs, including the 2 new download assertions ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM