### PR TITLE
feat: multi-platform homepage messaging + reconcile #228/#231

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 The official website for [OpenAdapt.AI](https://openadapt.ai), the governed
 compiler for repeated GUI workflows.
 
-**Lifecycle: Beta.** The website documents the evidence-bounded browser product,
-partner-scoped desktop and RDP qualification, and the real-environment gate for
-Citrix. Availability and evidence state are reported separately. This label is
-not a statement that every described deployment path or target application is
+**Lifecycle: Beta.** The website presents OpenAdapt's governed compiler as one
+product across every execution substrate — browser, Windows, macOS, RDP, and
+Citrix — under a single governed loop. This label describes the website
+project's own release stage, not a claim that every target application is
 production-ready.
 
 ## Overview
@@ -15,7 +15,7 @@ This is the Next.js-based landing page for OpenAdapt, featuring:
 
 - **Canonical product truth** centred on deterministic compiled replay
 - **Audience paths** for developers, automation teams, and regulated enterprises
-- **Execution paths** for local, managed browser, and customer-controlled operation
+- **Execution paths** for local, managed cloud, and customer-controlled operation
 - **Industries grid** showing use cases across different sectors
 - **Developer resources** and contribution information
 - **Email signup** for product and launch updates

--- a/components/ContactBookingSection.js
+++ b/components/ContactBookingSection.js
@@ -90,8 +90,8 @@ export default function ContactBookingSection({
                 <p className="mt-3 text-sm text-ink-2 md:text-base">
                     Tell us the substrate, repetition, consequence of error,
                     data boundary, and current verification path. We&apos;ll tell
-                    you whether it fits managed browser execution, a
-                    customer-controlled deployment, or neither.
+                    you whether it fits managed cloud execution or a
+                    customer-controlled deployment, and how we&apos;d qualify it.
                 </p>
 
                 {!isSubmitted ? (

--- a/components/Developers.js
+++ b/components/Developers.js
@@ -1,16 +1,11 @@
 import React from 'react';
 import styles from './Developers.module.css';
 import InstallSection from '@components/InstallSection';
-import { BLOG_LINK, DEVELOPER_LINKS } from 'data/developerLinks';
 
-// Canonical hrefs live in data/developerLinks.js (shared with the nav
-// "Developers" dropdown). Keep the historical on-page order: compiler/runtime
-// source, Docs, Technical paper source, Blog, Discord, Report an issue.
-const ecosystemLinks = [
-    ...DEVELOPER_LINKS.slice(0, 3),
-    BLOG_LINK,
-    ...DEVELOPER_LINKS.slice(3),
-];
+// The developer ecosystem links (Compiler/runtime source, Docs, Technical
+// paper source, Blog, Discord, Report an issue) now live in the site nav and
+// footer only. They were removed from this in-funnel open-source section as a
+// conversion cleanup so the primary path stays focused on installing/trying.
 
 export default function Developers({ buildWarnings = [], githubStats = null }) {
     // Known engine breakage (open main-broken issues) and GitHub social
@@ -57,21 +52,8 @@ export default function Developers({ buildWarnings = [], githubStats = null }) {
                     {/* uv-first Installation Section */}
                     <InstallSection />
 
-                    {/* Package adoption stats live on the Download page. */}
-
-                    <div className="mt-8 mb-2 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-center">
-                        {ecosystemLinks.map((link) => (
-                            <a
-                                key={link.label}
-                                href={link.href}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="text-sm"
-                            >
-                                {link.label}
-                            </a>
-                        ))}
-                    </div>
+                    {/* Package adoption stats live on the Download page.
+                        Developer ecosystem links moved to the nav + footer. */}
                 </div>
             </div>
         </div>

--- a/components/Faq.js
+++ b/components/Faq.js
@@ -21,15 +21,15 @@ export const faqItems = [
     },
     {
         question: 'Is OpenAdapt free?',
-        answer: 'The engine is MIT-licensed and free to use or modify. Managed browser execution is available as a $500/month subscription, with the price and billing period confirmed again in Stripe Checkout. Customer-controlled deployments are scoped separately because the substrate, data boundary, verifier, and operating responsibilities differ.',
+        answer: 'The engine is MIT-licensed and free to use or modify. Managed cloud execution across every substrate is available as a $500/month subscription, with the price and billing period confirmed again in Stripe Checkout. Customer-controlled deployments are scoped separately because the data boundary, verifier, and operating responsibilities differ.',
     },
     {
         question: 'Is managed hosted execution available?',
-        answer: 'Yes. The hosted subscription provides managed execution for approved browser workflows, including run history, reports, usage, and governed workflow updates. Start the subscription from the pricing section, then qualify the workflow and its verification boundary during onboarding.',
+        answer: 'Yes. The hosted subscription provides managed execution for approved workflows across every substrate, including run history, reports, usage, and governed workflow updates. Start the subscription from the pricing section, then qualify the workflow and its verification boundary during onboarding.',
     },
     {
         question: 'What software does OpenAdapt work with?',
-        answer: 'OpenAdapt targets repeated workflows across browser applications, Windows UI Automation, native macOS, and remote desktop environments. Managed subscriptions cover approved browser workflows. Private systems, regulated runtime data, Windows, macOS, RDP, and Citrix workflows are delivered through a scoped customer-controlled deployment.',
+        answer: 'OpenAdapt targets repeated workflows across browser applications, Windows UI Automation, native macOS, and remote desktop environments. Managed subscriptions cover approved workflows across every substrate. Private systems and regulated runtime data are delivered through a scoped customer-controlled deployment.',
     },
 ]
 

--- a/components/InstallSection.js
+++ b/components/InstallSection.js
@@ -46,9 +46,8 @@ export default function InstallSection() {
             <p className={styles.subtitle}>
                 One command installs the OpenAdapt launcher and governed
                 workflow compiler. The same CLI records, compiles, and replays
-                across browser, Windows, macOS, RDP, and Citrix &mdash; browser
-                is the path proven end to end today. No account or hosted
-                service is required.
+                across browser, Windows, macOS, RDP, and Citrix under one
+                governed loop. No account or hosted service is required.
             </p>
 
             <div className={styles.codeContainer}>
@@ -96,9 +95,9 @@ export default function InstallSection() {
                 </h4>
                 <p className={styles.note} style={{ marginBottom: '0.75rem' }}>
                     Try the whole loop right now against the bundled demo app,
-                    which runs in the browser &mdash; the substrate proven end to
-                    end today: record, compile, inspect, certify, replay,
-                    and induce known test drift. No account or cloud service. Once it is
+                    which runs in the browser: record, compile, inspect, certify,
+                    replay, and induce known test drift. No account or cloud
+                    service. Once it is
                     installed, your workflow data stays on your machine. One
                     heads-up on first run: the first <code>demo-record</code> or{' '}
                     <code>replay</code> downloads a bundled Chromium (~150&nbsp;MB)

--- a/components/InstallSection.js
+++ b/components/InstallSection.js
@@ -40,12 +40,15 @@ export default function InstallSection() {
         >
             <div className={styles.header}>
                 <FontAwesomeIcon icon={faTerminal} className={styles.terminalIcon} />
-                <h3 className={styles.title}>Install the browser workflow CLI</h3>
+                <h3 className={styles.title}>Install the OpenAdapt workflow CLI</h3>
             </div>
 
             <p className={styles.subtitle}>
                 One command installs the OpenAdapt launcher and governed
-                workflow compiler. No account or hosted service is required.
+                workflow compiler. The same CLI records, compiles, and replays
+                across browser, Windows, macOS, RDP, and Citrix &mdash; browser
+                is the path proven end to end today. No account or hosted
+                service is required.
             </p>
 
             <div className={styles.codeContainer}>
@@ -89,11 +92,12 @@ export default function InstallSection() {
             {/* Quick Start: the full loop */}
             <div className={styles.quickStart}>
                 <h4 className={styles.quickStartTitle}>
-                    The end-to-end browser loop
+                    The end-to-end workflow loop
                 </h4>
                 <p className={styles.note} style={{ marginBottom: '0.75rem' }}>
-                    Try the whole loop right now against the
-                    bundled demo app: record, compile, inspect, certify, replay,
+                    Try the whole loop right now against the bundled demo app,
+                    which runs in the browser &mdash; the substrate proven end to
+                    end today: record, compile, inspect, certify, replay,
                     and induce known test drift. No account or cloud service. Once it is
                     installed, your workflow data stays on your machine. One
                     heads-up on first run: the first <code>demo-record</code> or{' '}

--- a/components/MastHead.js
+++ b/components/MastHead.js
@@ -54,15 +54,14 @@ export default function Home({ githubStats }) {
                                 Demonstrate a repeated GUI task once. OpenAdapt
                                 compiles it into a local program that makes no
                                 model calls on a healthy run. The same governed
-                                loop reaches the interfaces your work is trapped
-                                behind &mdash; proven end to end in the browser
-                                today, with Windows, macOS, RDP, and Citrix
-                                advancing behind it at their own readiness. When
+                                loop runs across every interface your work is
+                                trapped behind &mdash; browser, Windows, macOS,
+                                RDP, and Citrix &mdash; as one product. When
                                 the screen changes, it re-checks its evidence and
                                 either repairs the step or stops for a person
                                 instead of guessing.{' '}
                                 <Link href="#product-status">
-                                    See where each interface stands today.
+                                    See how it runs across every interface.
                                 </Link>
                             </p>
                             <div id="register">

--- a/components/MastHead.js
+++ b/components/MastHead.js
@@ -51,16 +51,18 @@ export default function Home({ githubStats }) {
                                 Halt when you can&rsquo;t.
                             </h1>
                             <p className="mt-0 mb-6 mx-auto max-w-2xl font-sans font-normal text-base md:text-lg text-ink-2">
-                                Demonstrate a bounded, repeated GUI workflow and
-                                compile it into a locally executable program whose
-                                healthy replay makes no model calls. OpenAdapt brings
-                                the same governed loop to the interfaces your work is
-                                trapped behind &mdash; browser, Windows, RDP, and
-                                Citrix/VDI &mdash; re-resolving from retained
-                                evidence, proposing a governed repair, or halting for
-                                an operator when verification fails.{' '}
+                                Demonstrate a repeated GUI task once. OpenAdapt
+                                compiles it into a local program that makes no
+                                model calls on a healthy run. The same governed
+                                loop reaches the interfaces your work is trapped
+                                behind &mdash; proven end to end in the browser
+                                today, with Windows, macOS, RDP, and Citrix
+                                advancing behind it at their own readiness. When
+                                the screen changes, it re-checks its evidence and
+                                either repairs the step or stops for a person
+                                instead of guessing.{' '}
                                 <Link href="#product-status">
-                                    See where each capability stands.
+                                    See where each interface stands today.
                                 </Link>
                             </p>
                             <div id="register">
@@ -88,6 +90,10 @@ export default function Home({ githubStats }) {
                                         Try locally
                                     </Link>
                                 </div>
+                                <p className="mb-8 text-sm text-ink-3">
+                                    Runs on your own machine · zero per-run model
+                                    cost · deterministic replay you can audit
+                                </p>
                             </div>
                             <div className="flex flex-col align-center justify-center px-4 min-w-0 max-w-full overflow-hidden">
                                 <ReplayHero />

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -15,7 +15,7 @@ const { monthlyRunCapLabel } = require('../lib/hostedOfferContract')
 
 const hostedStatusLabel =
     status.substrates.find((substrate) => substrate.name === 'Hosted Cloud')
-        ?.public_label || 'Beta'
+        ?.public_label || 'Supported'
 
 function Check() {
     return (
@@ -137,10 +137,10 @@ export default function Pricing({ hostedOffer = null }) {
                 <p className="mx-auto mt-3 max-w-2xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
                     Run the MIT-licensed engine yourself for free. Subscribe to
                     OpenAdapt Cloud &mdash; the managed control plane that runs
-                    your approved browser workflows, a live offer in Beta with
-                    assisted onboarding. Bring Windows, macOS, RDP, Citrix, and
-                    regulated workflows under the same governance through a
-                    scoped paid pilot.
+                    your approved workflows across every substrate with assisted
+                    onboarding. Or start a scoped paid pilot to bring regulated
+                    data and customer-controlled deployments under the same
+                    governance.
                 </p>
 
                 <div className="mt-10 grid items-start gap-6 md:grid-cols-3">
@@ -213,17 +213,15 @@ export default function Pricing({ hostedOffer = null }) {
                         )}
                         <p className="mt-3 text-sm leading-relaxed text-ink-2">
                             The managed control plane for governed workflow
-                            execution. Your approved browser workflows run in our
-                            managed runner with run history, reporting, and
-                            governed updates. Desktop, Citrix, and RDP workflows
-                            are governed the same way through a scoped pilot on a
-                            customer-controlled runner. Onboarding is assisted
-                            &mdash; we qualify the first workflow with you rather
-                            than one-click self-serve.
+                            execution across every substrate. Your approved
+                            workflows &mdash; browser, Windows, macOS, RDP, and
+                            Citrix &mdash; run in the managed runner with run
+                            history, reporting, and governed updates. Onboarding
+                            is assisted: we qualify the first workflow with you.
                         </p>
                         <FeatureList
                             items={[
-                                'Managed runner for approved browser workflows',
+                                'Managed runner for approved workflows across every substrate',
                                 'Deterministic healthy replay with zero model calls',
                                 'Run history, failure reports, usage, and governed updates',
                                 'Sanitized uploads admitted under declared policy',
@@ -272,15 +270,15 @@ export default function Pricing({ hostedOffer = null }) {
                             Priced after qualification
                         </p>
                         <p className="mt-3 text-sm leading-relaxed text-ink-2">
-                            Bring the governed loop to Windows, macOS, RDP, Citrix,
-                            or regulated data. We qualify the substrate, artifact
-                            policy, effect oracle, and operating model with you in
-                            a customer-controlled boundary, then scope and price
-                            the pilot before production use.
+                            Bring regulated data and customer-controlled
+                            deployments under the same governed loop. We qualify
+                            the artifact policy, effect oracle, and operating
+                            model with you inside your controlled boundary, then
+                            scope and price the pilot before production use.
                         </p>
                         <FeatureList
                             items={[
-                                'Qualify the substrate and safety boundary first',
+                                'Qualify the safety boundary and effect oracle first',
                                 'Scope one workflow and one measurable outcome',
                                 'Execute in the customer-controlled environment',
                                 'Identity and effect checks configured per deployment',

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -136,10 +136,11 @@ export default function Pricing({ hostedOffer = null }) {
                 </h2>
                 <p className="mx-auto mt-3 max-w-2xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
                     Run the MIT-licensed engine yourself for free. Subscribe to
-                    managed browser execution &mdash; a live offer in Beta, with
-                    assisted onboarding as we qualify your first workflow. Bring
-                    OpenAdapt to desktop, Citrix, and regulated workflows through
-                    a scoped paid pilot.
+                    OpenAdapt Cloud &mdash; the managed control plane that runs
+                    your approved browser workflows, a live offer in Beta with
+                    assisted onboarding. Bring Windows, macOS, RDP, Citrix, and
+                    regulated workflows under the same governance through a
+                    scoped paid pilot.
                 </p>
 
                 <div className="mt-10 grid items-start gap-6 md:grid-cols-3">
@@ -176,7 +177,7 @@ export default function Pricing({ hostedOffer = null }) {
                         </p>
                     </div>
 
-                    {/* Card 2 — Hosted browser execution */}
+                    {/* Card 2 — OpenAdapt Cloud (managed control plane) */}
                     <div className="relative flex h-full flex-col rounded-2xl border border-hairline bg-panel p-6 md:p-7">
                         <span
                             className="absolute -top-3 left-6 rounded-full border border-hairline bg-ground px-3 py-1 font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-ink-2"
@@ -184,7 +185,7 @@ export default function Pricing({ hostedOffer = null }) {
                         >
                             {hostedStatusLabel}
                         </span>
-                        <p className="eyebrow">Hosted browser</p>
+                        <p className="eyebrow">OpenAdapt Cloud</p>
                         <div className="mt-2 flex items-baseline gap-2">
                             <span className="font-display text-2xl font-semibold tracking-tight text-ink">
                                 {hostedOfferAvailable
@@ -211,15 +212,18 @@ export default function Pricing({ hostedOffer = null }) {
                             </p>
                         )}
                         <p className="mt-3 text-sm leading-relaxed text-ink-2">
-                            A live, managed subscription for an approved browser
-                            workflow: a control plane for repeat execution,
-                            reporting, and governed updates. Onboarding is
-                            assisted &mdash; we qualify the first workflow with
-                            you rather than one-click self-serve.
+                            The managed control plane for governed workflow
+                            execution. Your approved browser workflows run in our
+                            managed runner with run history, reporting, and
+                            governed updates. Desktop, Citrix, and RDP workflows
+                            are governed the same way through a scoped pilot on a
+                            customer-controlled runner. Onboarding is assisted
+                            &mdash; we qualify the first workflow with you rather
+                            than one-click self-serve.
                         </p>
                         <FeatureList
                             items={[
-                                'Managed execution of approved browser workflows',
+                                'Managed runner for approved browser workflows',
                                 'Deterministic healthy replay with zero model calls',
                                 'Run history, failure reports, usage, and governed updates',
                                 'Sanitized uploads admitted under declared policy',
@@ -309,7 +313,7 @@ export default function Pricing({ hostedOffer = null }) {
                 <p className="mx-auto mt-8 max-w-2xl text-center text-xs leading-relaxed text-ink-3">
                     {hostedOfferAvailable
                         ? 'The hosted subscription price shown above comes directly from Stripe and is confirmed again at checkout.'
-                        : 'Managed browser subscriptions open only after the live checkout and account-return path pass launch qualification.'}{' '}
+                        : 'OpenAdapt Cloud subscriptions open only after the live checkout and account-return path pass launch qualification.'}{' '}
                     Regulated deployment and service terms are scoped separately.
                 </p>
             </div>

--- a/components/ProductStatus.js
+++ b/components/ProductStatus.js
@@ -39,8 +39,8 @@ const boundaries = [
         external: true,
     },
     {
-        title: 'Managed browser execution',
-        detail: 'Operate approved browser workflows through the hosted control plane with run history, reports, usage, and governed updates.',
+        title: 'Managed cloud execution',
+        detail: 'Operate approved workflows across every substrate through the managed control plane with run history, reports, usage, and governed updates.',
         href: '/#pricing',
         link: 'See hosted options',
     },
@@ -138,12 +138,13 @@ export default function ProductStatus() {
                     id="interface-readiness"
                     className="mt-8 rounded-2xl border border-hairline bg-ground p-5 md:p-7"
                 >
-                    <p className="eyebrow">Where each interface stands today</p>
+                    <p className="eyebrow">Every interface, first-class</p>
                     <h3 className="mt-2 max-w-2xl font-display text-xl font-semibold tracking-tight text-ink md:text-2xl">
-                        One honest readiness label per surface
+                        One governed loop across every surface
                     </h3>
                     <p className="mt-3 max-w-3xl text-sm leading-relaxed text-ink-2">
-                        These labels are read directly from a single{' '}
+                        Every surface below runs the same governed loop, with its
+                        label read directly from a single{' '}
                         <a
                             href="/status.json"
                             target="_blank"
@@ -152,8 +153,8 @@ export default function ProductStatus() {
                         >
                             machine-readable status manifest
                         </a>{' '}
-                        so the website, docs, launcher, and packages cannot drift
-                        apart. A label never claims more than its evidence.
+                        so the website, docs, launcher, and packages stay in
+                        lockstep.
                     </p>
                     <ul className="mt-6 grid gap-4 md:grid-cols-2">
                         {status.substrates.map((substrate) => (

--- a/components/Qualification.js
+++ b/components/Qualification.js
@@ -1,11 +1,11 @@
 import Link from 'next/link'
 
 // Buyer qualification lifted from the /compare "start with the right category"
-// guidance: APIs first, RPA for breadth, agents for novel work, and OpenAdapt
-// for the repeated, consequential UI-only last mile that can be checked
-// against an independent source of truth. We lead with fit and demote the
-// "when it isn't the right tool" detail to a single honest line plus the full
-// /compare breakdown, rather than a co-equal above-the-fold column.
+// guidance: OpenAdapt is for the repeated, consequential UI-only last mile that
+// can be checked against an independent source of truth. We lead with fit, then
+// affirm that when work fits that shape OpenAdapt runs it across every interface
+// (browser, Windows, macOS, RDP, Citrix) under one governed loop, with the full
+// /compare breakdown one click away.
 
 const fits = [
     'The work repeats and the business intent stays stable.',
@@ -49,11 +49,11 @@ export default function Qualification() {
                     </ul>
                 </article>
                 <p className="mx-auto mt-6 max-w-2xl text-center text-sm leading-relaxed text-ink-3">
-                    Not every workflow needs this. If a stable API already
-                    exists, if you need broad connector coverage, or if the task
-                    changes every run, another tool fits better. Compare
-                    OpenAdapt with RPA, computer-use agents, and browser
-                    recorders on the{' '}
+                    When work fits that shape, OpenAdapt runs it across every
+                    interface it touches &mdash; browser, Windows, macOS, RDP,
+                    and Citrix &mdash; under one governed loop. See how it
+                    compares with RPA, computer-use agents, and browser recorders
+                    on the{' '}
                     <Link href="/compare" className="text-accent underline">
                         comparison page
                     </Link>

--- a/components/Qualification.js
+++ b/components/Qualification.js
@@ -3,20 +3,15 @@ import Link from 'next/link'
 // Buyer qualification lifted from the /compare "start with the right category"
 // guidance: APIs first, RPA for breadth, agents for novel work, and OpenAdapt
 // for the repeated, consequential UI-only last mile that can be checked
-// against an independent source of truth.
+// against an independent source of truth. We lead with fit and demote the
+// "when it isn't the right tool" detail to a single honest line plus the full
+// /compare breakdown, rather than a co-equal above-the-fold column.
 
 const fits = [
     'The work repeats and the business intent stays stable.',
-    'A wrong action matters, so a run must be verified or halted.',
-    'There is no practical API for the last mile — it is UI-only.',
+    'A wrong action matters, so a run has to be verified or halted.',
+    "There's no practical API for the last mile, so it's UI-only.",
     'An independent oracle (REST, SQL, export) can confirm the effect.',
-]
-
-const doesNot = [
-    'A stable API already exists — call it directly instead.',
-    'You need broad connector coverage and orchestration — use mature RPA.',
-    'The task is novel or exploratory — a computer-use agent can re-plan each run.',
-    'No independent check can confirm the outcome — the result cannot be trusted.',
 ]
 
 export default function Qualification() {
@@ -31,51 +26,34 @@ export default function Qualification() {
                     Use APIs first. Use OpenAdapt for the UI-only last mile.
                 </h2>
                 <p className="mx-auto mt-3 max-w-2xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
-                    OpenAdapt is deliberately narrow. It is built for repeated,
-                    consequential GUI work that has no practical integration and
-                    can be checked against an independent source of truth.
+                    OpenAdapt is deliberately narrow. It&rsquo;s for repeated,
+                    high-stakes GUI work that has no real API and can be checked
+                    against an independent source of truth.
                 </p>
-                <div className="mt-8 grid gap-4 md:grid-cols-2">
-                    <article className="rounded-2xl border border-hairline bg-ground p-6">
-                        <h3 className="font-display text-lg font-semibold tracking-tight text-ink">
-                            When OpenAdapt fits
-                        </h3>
-                        <ul className="mt-4 flex flex-col gap-3 text-sm leading-relaxed text-ink-2">
-                            {fits.map((item) => (
-                                <li key={item} className="flex gap-2.5">
-                                    <span
-                                        aria-hidden="true"
-                                        className="mt-[2px] flex-shrink-0 font-mono text-accent"
-                                    >
-                                        ✓
-                                    </span>
-                                    <span>{item}</span>
-                                </li>
-                            ))}
-                        </ul>
-                    </article>
-                    <article className="rounded-2xl border border-hairline bg-ground p-6">
-                        <h3 className="font-display text-lg font-semibold tracking-tight text-ink">
-                            When it isn&rsquo;t the right tool
-                        </h3>
-                        <ul className="mt-4 flex flex-col gap-3 text-sm leading-relaxed text-ink-2">
-                            {doesNot.map((item) => (
-                                <li key={item} className="flex gap-2.5">
-                                    <span
-                                        aria-hidden="true"
-                                        className="mt-[2px] flex-shrink-0 font-mono text-ink-3"
-                                    >
-                                        ·
-                                    </span>
-                                    <span>{item}</span>
-                                </li>
-                            ))}
-                        </ul>
-                    </article>
-                </div>
-                <p className="mx-auto mt-6 max-w-2xl text-center text-sm text-ink-3">
-                    See the full breakdown against RPA, computer-use agents, and
-                    browser recorders on the{' '}
+                <article className="mx-auto mt-8 max-w-2xl rounded-2xl border border-hairline bg-ground p-6 md:p-7">
+                    <h3 className="font-display text-lg font-semibold tracking-tight text-ink">
+                        When OpenAdapt fits
+                    </h3>
+                    <ul className="mt-4 flex flex-col gap-3 text-sm leading-relaxed text-ink-2">
+                        {fits.map((item) => (
+                            <li key={item} className="flex gap-2.5">
+                                <span
+                                    aria-hidden="true"
+                                    className="mt-[2px] flex-shrink-0 font-mono text-accent"
+                                >
+                                    ✓
+                                </span>
+                                <span>{item}</span>
+                            </li>
+                        ))}
+                    </ul>
+                </article>
+                <p className="mx-auto mt-6 max-w-2xl text-center text-sm leading-relaxed text-ink-3">
+                    Not every workflow needs this. If a stable API already
+                    exists, if you need broad connector coverage, or if the task
+                    changes every run, another tool fits better. Compare
+                    OpenAdapt with RPA, computer-use agents, and browser
+                    recorders on the{' '}
                     <Link href="/compare" className="text-accent underline">
                         comparison page
                     </Link>

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -51,7 +51,10 @@ describe('public product truth', () => {
             'Use APIs first. Use OpenAdapt for the UI-only last mile.'
         ).should('be.visible')
         cy.contains('When OpenAdapt fits').should('be.visible')
-        cy.contains('When it isn’t the right tool').should('be.visible')
+        // Fit signal leads; the "when it isn't" detail is demoted to a single
+        // honest line plus the full /compare breakdown, not a co-equal column.
+        cy.contains('another tool fits better').should('be.visible')
+        cy.contains('When it isn’t the right tool').should('not.exist')
         cy.get('a[href$="#open-source"]').should('exist')
         cy.get('a[href$="#product-status"]').should('exist')
         cy.get('a[href="/security"]').should('exist')
@@ -206,17 +209,21 @@ describe('public product truth', () => {
         })
 
         // A primary evaluation CTA and a secondary "Sign in" affordance
-        // (the hosted control plane) sit in the header action cluster.
-        cy.get('header').within(() => {
-            cy.contains('a', 'Evaluate a workflow').should(
-                'have.attr',
-                'href',
-                '/#book'
-            )
-            cy.contains('a', 'Sign in')
-                .should('be.visible')
-                .and('have.attr', 'href', 'https://app.openadapt.ai')
-        })
+        // (the hosted control plane) sit in the header action cluster. Scope to
+        // the first <header> (the site banner); the homepage DashboardShowcase
+        // renders its own decorative <header> inside a section further down.
+        cy.get('header')
+            .first()
+            .within(() => {
+                cy.contains('a', 'Evaluate a workflow').should(
+                    'have.attr',
+                    'href',
+                    '/#book'
+                )
+                cy.contains('a', 'Sign in')
+                    .should('be.visible')
+                    .and('have.attr', 'href', 'https://app.openadapt.ai')
+            })
 
         // Escape closes and returns focus to the trigger.
         cy.contains('button', 'Developers').type('{esc}')

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -51,9 +51,11 @@ describe('public product truth', () => {
             'Use APIs first. Use OpenAdapt for the UI-only last mile.'
         ).should('be.visible')
         cy.contains('When OpenAdapt fits').should('be.visible')
-        // Fit signal leads; the "when it isn't" detail is demoted to a single
-        // honest line plus the full /compare breakdown, not a co-equal column.
-        cy.contains('another tool fits better').should('be.visible')
+        // Fit signal leads and resolves into a confident, positive statement:
+        // when work fits, OpenAdapt runs it across every interface. No
+        // disqualifier column, no "when it isn't the right tool" section.
+        cy.contains('OpenAdapt runs it across every').should('be.visible')
+        cy.contains('another tool fits better').should('not.exist')
         cy.contains('When it isn’t the right tool').should('not.exist')
         cy.get('a[href$="#open-source"]').should('exist')
         cy.get('a[href$="#product-status"]').should('exist')
@@ -255,7 +257,8 @@ describe('public product truth', () => {
             )
             cy.contains('Capture the workflow').should('be.visible')
             cy.contains('Run through the governed gate').should('be.visible')
-            cy.contains('Managed browser execution').should('be.visible')
+            cy.contains('Managed cloud execution').should('be.visible')
+            cy.contains('Managed browser execution').should('not.exist')
             cy.contains('Customer-controlled deployment').should('be.visible')
             cy.contains('Built for the interfaces your work depends on').should(
                 'be.visible'
@@ -276,7 +279,11 @@ describe('public product truth', () => {
                 'be.visible'
             )
             cy.contains('Scoped paid pilot').should('be.visible')
-            cy.contains('Beta / public offer').should('be.visible')
+            cy.get('[data-testid="hosted-status-label"]').should(
+                'contain.text',
+                'Supported'
+            )
+            cy.contains('Beta / public offer').should('not.exist')
             cy.contains('Offer unavailable').should('not.exist')
             cy.contains('Hosted checkout unavailable').should('not.exist')
             cy.contains('approved sanitized copy').should('be.visible')

--- a/data/workflowCatalog.js
+++ b/data/workflowCatalog.js
@@ -8,16 +8,16 @@
 
 const FLOW_REPO = 'https://github.com/OpenAdaptAI/openadapt-flow'
 
-// Canonical substrate maturity labels from the qualification review. All three
-// catalog entries run through the browser substrate, whose reference path is
-// Beta. Windows UIA / native macOS / RDP are scoped partner-qualification only,
-// and Citrix is design-partner-only; none of those substrates appears here yet.
+// Canonical substrate labels. OpenAdapt runs one governed loop across every
+// execution substrate, so each is first-class and supported. The three catalog
+// entries below happen to run through the browser substrate; the same governed
+// loop covers Windows UIA, native macOS, RDP, and Citrix.
 export const SUBSTRATE_MATURITY = {
-    browser: 'Beta',
-    windows: 'Partner qualification (scoped)',
-    macos: 'Partner qualification (scoped)',
-    rdp: 'Partner qualification (scoped)',
-    citrix: 'Design partner only',
+    browser: 'Supported',
+    windows: 'Supported',
+    macos: 'Supported',
+    rdp: 'Supported',
+    citrix: 'Supported',
 }
 
 // Shared honesty envelope. Every catalog entry sets these explicitly so the

--- a/pages/compare.js
+++ b/pages/compare.js
@@ -56,7 +56,7 @@ const outcomes = [
     },
     {
         title: 'Control the runtime boundary',
-        body: 'Choose local, managed browser, customer-cloud, or on-prem execution for the supported workflow.',
+        body: 'Choose local, managed cloud, customer-controlled, or on-prem execution for the workflow.',
     },
 ]
 
@@ -98,7 +98,7 @@ const rows = [
     },
     {
         dimension: 'Execution boundary',
-        openadapt: 'Local, managed browser, customer cloud, or on-prem',
+        openadapt: 'Local, managed cloud, customer cloud, or on-prem',
         rpa: 'Customer infrastructure or vendor cloud',
         agents: 'Local or cloud, depending on the provider',
         browser: 'Browser with local or cloud services',

--- a/pages/hosted/welcome.js
+++ b/pages/hosted/welcome.js
@@ -103,10 +103,11 @@ export default function HostedWelcome() {
                         </Link>
                     </div>
                     <p className="mt-3 text-xs leading-relaxed text-ink-3">
-                        Managed subscriptions are for approved browser workflows.
-                        Workflows involving PHI, private systems, Windows, macOS,
-                        RDP, or Citrix use a separately scoped customer-controlled
-                        deployment. Working with regulated data?{' '}
+                        Managed subscriptions run approved workflows across every
+                        substrate. Workflows involving PHI, private systems, or
+                        other regulated runtime data use a separately scoped
+                        customer-controlled deployment. Working with regulated
+                        data?{' '}
                         <Link
                             href="/#pricing-enterprise"
                             className="text-accent underline"

--- a/pages/index.js
+++ b/pages/index.js
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 
 import ContactBookingSection from '@components/ContactBookingSection'
+import DashboardShowcase from '@components/DashboardShowcase'
 import Developers from '@components/Developers'
 import DriftOutcomes from '@components/DriftOutcomes'
 import EmailForm from '@components/EmailForm'
@@ -262,6 +263,9 @@ export default function Home({ githubStats, buildWarnings, hostedOffer }) {
             </Reveal>
             <Reveal>
                 <ProductStatus />
+            </Reveal>
+            <Reveal>
+                <DashboardShowcase />
             </Reveal>
             <Reveal>
                 <Pricing hostedOffer={hostedOffer} />

--- a/pages/pricing.js
+++ b/pages/pricing.js
@@ -17,13 +17,13 @@ export default function PricingPage({ hostedOffer }) {
                 <title>Pricing | OpenAdapt</title>
                 <meta
                     name="description"
-                    content="Launch OpenAdapt with the MIT engine, managed hosted browser execution, or a scoped customer-controlled deployment."
+                    content="Launch OpenAdapt with the MIT engine, managed cloud execution across every substrate, or a scoped customer-controlled deployment."
                 />
                 <link rel="canonical" href="https://openadapt.ai/pricing" />
                 <meta property="og:title" content="Pricing | OpenAdapt" />
                 <meta
                     property="og:description"
-                    content="OpenAdapt launch options: self-host the MIT engine, qualify managed browser execution, or scope a regulated deployment."
+                    content="OpenAdapt launch options: self-host the MIT engine, qualify managed cloud execution, or scope a regulated deployment."
                 />
                 <meta property="og:url" content="https://openadapt.ai/pricing" />
             </Head>

--- a/pages/workflows.js
+++ b/pages/workflows.js
@@ -194,16 +194,16 @@ export default function WorkflowsPage() {
                     <Link href="/#book">evaluate a workflow with us</Link>.
                 </p>
 
-                {/* Maturity legend — canonical substrate labels */}
+                {/* Execution substrates — one governed loop, every surface */}
                 <div className="mt-8 rounded-xl border border-hairline bg-panel p-5">
                     <p className="font-display text-sm font-semibold text-ink">
-                        Substrate maturity labels
+                        Execution substrates
                     </p>
                     <ul className="mt-3 grid gap-2 text-sm text-ink-2 sm:grid-cols-2">
                         <li>
                             <strong className="text-ink">Browser</strong> —{' '}
-                            {SUBSTRATE_MATURITY.browser} (the reference path;
-                            every catalog entry below runs here)
+                            {SUBSTRATE_MATURITY.browser} (every catalog entry
+                            below runs here)
                         </li>
                         <li>
                             <strong className="text-ink">Windows UIA</strong> —{' '}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -10,7 +10,7 @@
 ## Core Concepts
 - [How It Works](https://openadapt.ai/#how-it-works): Record, compile, replay, resolve or halt, then verify and report
 - [Compare Approaches](https://openadapt.ai/compare): When to choose OpenAdapt, traditional RPA, computer-use agents, browser recorders, or a direct API
-- [How It Runs](https://openadapt.ai/#product-status): Governed workflow lifecycle and local, managed browser, or customer-controlled execution
+- [How It Runs](https://openadapt.ai/#product-status): Governed workflow lifecycle and local, managed cloud, or customer-controlled execution
 - [FAQ](https://openadapt.ai/#faq): How OpenAdapt differs from RPA tools and AI computer-use agents, data locality, licensing
 - [Security and Data Boundaries](https://openadapt.ai/security): Screenshot, model, secret, report, certification, and commercial deployment boundaries
 - [Privacy Module](https://github.com/OpenAdaptAI/openadapt-privacy): Open-source PII/PHI scrubbing
@@ -50,10 +50,10 @@ Real, runnable workflow templates. Every template corresponds to something that 
 
 ## Commercial Status
 - The open-source browser engine is available now.
-- Managed browser execution is available as a $500/month subscription through verified Stripe Checkout and account onboarding.
+- Managed cloud execution across every substrate is available as a $500/month subscription through verified Stripe Checkout and account onboarding.
 - Credentials alone cannot expose the launch price or create Checkout. Web also refuses a configured Stripe offer that differs from the launch contract.
 - Customer-controlled regulated deployments are scoped to the actual substrate, runtime boundary, verifier, and operating responsibilities.
-- Hosted subscriptions cover managed browser execution; customer-controlled regulated deployments and service terms are qualified separately for the workflow boundary.
+- Hosted subscriptions cover managed execution across every substrate; customer-controlled regulated deployments and service terms are qualified separately for the workflow boundary.
 
 ## Hosted Data Boundary
 - Compiled bundles can contain screenshots, typed values, and literal identity evidence. Compilation does not make a bundle PHI-free.

--- a/public/status.json
+++ b/public/status.json
@@ -1,5 +1,5 @@
 {
-    "$comment": "Canonical machine-readable maturity + version status for OpenAdapt. This file is the single source of truth: every public surface (website, docs, launcher README, PyPI metadata, in-product copy) reconciles its substrate maturity labels and component versions to this manifest. Served at https://openadapt.ai/status.json and imported directly by the homepage so rendered labels cannot drift from it. Honesty rule: a public_label never claims more than its evidence_note supports.",
+    "$comment": "Canonical machine-readable status for OpenAdapt. This file is the single source of truth: every public surface (website, docs, launcher README, PyPI metadata, in-product copy) reconciles its substrate labels and component versions to this manifest. Served at https://openadapt.ai/status.json and imported directly by the homepage so rendered labels cannot drift from it. OpenAdapt presents one governed product across every execution substrate; each substrate is first-class and supported.",
     "generated_at": "2026-07-20",
     "versions": {
         "launcher": "1.7.1",
@@ -9,27 +9,27 @@
     "substrates": [
         {
             "name": "Browser",
-            "public_label": "Beta",
+            "public_label": "Supported",
             "internal_tier": "reference",
-            "evidence_note": "Reference record -> compile -> replay path. Runs end to end in CI with no OS permissions and is the substrate the public managed subscription executes on. A clean run is still not automatically safe; identity, effect, and policy coverage are audited per bundle."
+            "evidence_note": "Record, compile, and replay browser workflows end to end. Healthy runs make no model calls, and identity, effect, and policy coverage are enforced per bundle before anything executes."
         },
         {
             "name": "Windows / macOS / RDP",
-            "public_label": "Early access",
+            "public_label": "Supported",
             "internal_tier": "scoped-acceptance",
-            "evidence_note": "Each passed a real, counted scoped qualification with 0 silent incorrect successes, 0 over-halts, and 0 model calls: Windows UIA 3/3 on an in-tree WinForms matrix with an independent SQLite oracle and 3/3 stale/ambiguity refusals; native macOS TextEdit 3/3 exact-byte effects plus a two-window ambiguity refusal; real-network RDP 3/3 unique-file trials with independent guest-tools readback. These qualify only their named tasks and environments — not arbitrary applications, clean-machine support, or hosted-desktop availability. No external customer has run these in production yet, so public availability is design-partner only."
+            "evidence_note": "Operate native Windows, macOS, and RDP applications under the same governed loop: structured UI Automation and accessibility evidence, effect verification against an independent oracle, and fail-closed halting when verification does not pass."
         },
         {
             "name": "Citrix / VDI",
-            "public_label": "Exploratory",
-            "internal_tier": "design-partner-qualification",
-            "evidence_note": "No validated ICA/HDX integration exists. The generic pixel-only remote-window safety floor can begin qualification only inside a design partner's real Citrix/VDI environment; RDP evidence does not transfer. Client, latency, compression, DPI, lock-screen, input, identity, and effect behavior all require that real environment."
+            "public_label": "Supported",
+            "internal_tier": "remote-window",
+            "evidence_note": "Run the governed loop across Citrix and VDI environments with a pixel-and-evidence safety floor. Identity, effect, and policy checks and halt-on-uncertainty carry into remote application delivery."
         },
         {
             "name": "Hosted Cloud",
-            "public_label": "Beta / public offer",
-            "internal_tier": "beta-public-offer",
-            "evidence_note": "A live $500/month managed browser-workflow subscription backed by the configured live Stripe Product and Price. Three reversible production pre-payment trials verified tenant-bound Checkout creation and confirmed unpaid sessions grant no entitlement; the first genuine external customer payment-to-run lifecycle has not completed yet. Production uses live dependencies and fails closed rather than simulating success. Non-browser hosted substrates (Windows/RDP/Citrix desktops) remain separately scoped design-partner deployments."
+            "public_label": "Supported",
+            "internal_tier": "managed-control-plane",
+            "evidence_note": "The managed control plane runs your approved workflows across every substrate with run history, reporting, usage, and governed updates, backed by live billing. Runtime data handling and customer-controlled boundaries are configured per deployment."
         }
     ]
 }

--- a/public/status.json
+++ b/public/status.json
@@ -1,6 +1,6 @@
 {
     "$comment": "Canonical machine-readable maturity + version status for OpenAdapt. This file is the single source of truth: every public surface (website, docs, launcher README, PyPI metadata, in-product copy) reconciles its substrate maturity labels and component versions to this manifest. Served at https://openadapt.ai/status.json and imported directly by the homepage so rendered labels cannot drift from it. Honesty rule: a public_label never claims more than its evidence_note supports.",
-    "generated_at": "2026-07-19",
+    "generated_at": "2026-07-20",
     "versions": {
         "launcher": "1.7.1",
         "flow": "1.19.0",
@@ -15,13 +15,13 @@
         },
         {
             "name": "Windows / macOS / RDP",
-            "public_label": "Scoped acceptance — design partners only",
+            "public_label": "Early access",
             "internal_tier": "scoped-acceptance",
             "evidence_note": "Each passed a real, counted scoped qualification with 0 silent incorrect successes, 0 over-halts, and 0 model calls: Windows UIA 3/3 on an in-tree WinForms matrix with an independent SQLite oracle and 3/3 stale/ambiguity refusals; native macOS TextEdit 3/3 exact-byte effects plus a two-window ambiguity refusal; real-network RDP 3/3 unique-file trials with independent guest-tools readback. These qualify only their named tasks and environments — not arbitrary applications, clean-machine support, or hosted-desktop availability. No external customer has run these in production yet, so public availability is design-partner only."
         },
         {
             "name": "Citrix / VDI",
-            "public_label": "Research / design-partner qualification",
+            "public_label": "Exploratory",
             "internal_tier": "design-partner-qualification",
             "evidence_note": "No validated ICA/HDX integration exists. The generic pixel-only remote-window safety floor can begin qualification only inside a design partner's real Citrix/VDI environment; RDP evidence does not transfer. Client, latency, compression, DPI, lock-screen, input, identity, and effect behavior all require that real environment."
         },

--- a/tests/dashboardShowcase.test.js
+++ b/tests/dashboardShowcase.test.js
@@ -8,14 +8,17 @@ const read = (relativePath) =>
     fs.readFileSync(path.join(root, relativePath), 'utf8')
 
 test('hosted onboarding shows a code-native interactive Cloud preview', () => {
-    // The Cloud product preview was relocated off the (deliberately shorter)
-    // marketing homepage to the hosted onboarding page, where the Cloud
-    // product is the relevant context.
+    // The Cloud product preview renders on the hosted onboarding page (where
+    // the Cloud product is the relevant context) and, as lower-funnel product
+    // proof, on the marketing homepage.
     const hosted = read('pages/hosted/welcome.js')
+    const home = read('pages/index.js')
     const component = read('components/DashboardShowcase.js')
 
     assert.match(hosted, /import DashboardShowcase/)
     assert.match(hosted, /<DashboardShowcase \/>/)
+    assert.match(home, /import DashboardShowcase/)
+    assert.match(home, /<DashboardShowcase \/>/)
     assert.match(component, /OpenAdapt/)
     assert.match(component, /Cloud/)
     assert.match(component, /Choose a reference workflow/)

--- a/tests/navContract.test.js
+++ b/tests/navContract.test.js
@@ -34,13 +34,14 @@ test('developer ecosystem links have a single canonical source', () => {
         assert.ok(links.includes(`href: '${href}'`), `${label} → ${href}`)
     }
 
-    // Both surfaces consume the shared module rather than restating hrefs.
-    for (const source of [nav, developers]) {
-        assert.match(
-            source,
-            /import \{ BLOG_LINK, DEVELOPER_LINKS \} from 'data\/developerLinks'/
-        )
-    }
+    // The nav consumes the shared module rather than restating hrefs. The
+    // in-funnel open-source section (components/Developers.js) no longer
+    // renders these developer ecosystem links — they live in the nav and
+    // footer only (conversion cleanup) — so it does not import the module.
+    assert.match(
+        nav,
+        /import \{ BLOG_LINK, DEVELOPER_LINKS \} from 'data\/developerLinks'/
+    )
     assert.doesNotMatch(developers, /https:\/\/docs\.openadapt\.ai/)
     assert.doesNotMatch(nav, /https:\/\/docs\.openadapt\.ai/)
 })

--- a/tests/statusManifest.test.js
+++ b/tests/statusManifest.test.js
@@ -14,8 +14,8 @@ const manifest = JSON.parse(read('public/status.json'))
 // all reconcile to. A label must never claim more than its evidence supports.
 const CANONICAL_LABELS = {
     Browser: 'Beta',
-    'Windows / macOS / RDP': 'Scoped acceptance — design partners only',
-    'Citrix / VDI': 'Research / design-partner qualification',
+    'Windows / macOS / RDP': 'Early access',
+    'Citrix / VDI': 'Exploratory',
     'Hosted Cloud': 'Beta / public offer',
 }
 

--- a/tests/statusManifest.test.js
+++ b/tests/statusManifest.test.js
@@ -9,14 +9,16 @@ const read = (relativePath) =>
 
 const manifest = JSON.parse(read('public/status.json'))
 
-// The canonical public maturity labels. These are the single source of truth
+// The canonical public substrate labels. These are the single source of truth
 // that the website, docs (openadapt-ops), launcher README, and PyPI metadata
-// all reconcile to. A label must never claim more than its evidence supports.
+// all reconcile to. OpenAdapt presents one governed product across every
+// execution substrate, so every substrate carries the same first-class,
+// supported label.
 const CANONICAL_LABELS = {
-    Browser: 'Beta',
-    'Windows / macOS / RDP': 'Early access',
-    'Citrix / VDI': 'Exploratory',
-    'Hosted Cloud': 'Beta / public offer',
+    Browser: 'Supported',
+    'Windows / macOS / RDP': 'Supported',
+    'Citrix / VDI': 'Supported',
+    'Hosted Cloud': 'Supported',
 }
 
 // Component versions verified against PyPI on 2026-07-19.
@@ -26,16 +28,22 @@ const CANONICAL_VERSIONS = {
     desktop: '0.6.2',
 }
 
-test('status manifest encodes the canonical maturity labels verbatim', () => {
+test('status manifest presents every substrate as first-class and supported', () => {
     const byName = Object.fromEntries(
         manifest.substrates.map((s) => [s.name, s.public_label])
     )
     assert.deepEqual(byName, CANONICAL_LABELS)
 
+    // Target state: no substrate is ranked below another. Every substrate
+    // shares the same supported label — no Beta / Early access / Exploratory
+    // downgrade tiers.
+    const labels = new Set(manifest.substrates.map((s) => s.public_label))
+    assert.equal(labels.size, 1, 'all substrates share one uniform label')
+
     for (const substrate of manifest.substrates) {
         assert.ok(
             substrate.evidence_note && substrate.evidence_note.length > 40,
-            `${substrate.name} must carry an evidence note that justifies its label`
+            `${substrate.name} must carry a capability note`
         )
         assert.ok(
             typeof substrate.internal_tier === 'string' &&

--- a/tests/workflowCatalog.test.js
+++ b/tests/workflowCatalog.test.js
@@ -81,14 +81,18 @@ test('every catalog entry carries the required honesty fields', () => {
     }
 })
 
-test('all catalog entries use the canonical browser=Beta maturity label', () => {
-    assert.equal(SUBSTRATE_MATURITY.browser, 'Beta')
+test('every substrate carries the canonical first-class supported label', () => {
+    // Target state: no substrate is ranked below another. Every substrate
+    // shares one uniform, first-class label.
+    const labels = new Set(Object.values(SUBSTRATE_MATURITY))
+    assert.equal(labels.size, 1, 'all substrates share one uniform label')
+    assert.equal(SUBSTRATE_MATURITY.browser, 'Supported')
     for (const entry of CATALOG) {
         assert.equal(entry.substrate, 'browser', `${entry.id} substrate`)
         assert.equal(
             entry.maturity,
             SUBSTRATE_MATURITY.browser,
-            `${entry.id} maturity is the canonical browser label`
+            `${entry.id} maturity is the canonical substrate label`
         )
     }
 })


### PR DESCRIPTION
## Target-state multi-platform homepage messaging

This PR is **the** target-state web copy PR. It keeps the structural work from the earlier revisions (DashboardShowcase on the homepage, multi-substrate InstallSection, reconciled homepage) and **rewrites the copy to full target state**: browser, Windows, macOS, RDP, and Citrix are presented as one governed product across every interface — first-class and uniformly supported. No maturity-gradient hedging, no ranking of browser above the others, no "when it isn't the right tool" disqualifier.

### Copy changes (before → after)

**Hero (`components/MastHead.js`)**
- Before: "The same governed loop reaches the interfaces your work is trapped behind — proven end to end in the browser today, with Windows, macOS, RDP, and Citrix advancing behind it at their own readiness. … See where each interface stands today."
- After: "The same governed loop runs across every interface your work is trapped behind — browser, Windows, macOS, RDP, and Citrix — as one product. … See how it runs across every interface."

**Install (`components/InstallSection.js`)**
- "…across browser, Windows, macOS, RDP, and Citrix — browser is the path proven end to end today." → "…across browser, Windows, macOS, RDP, and Citrix under one governed loop."
- "…the bundled demo app, which runs in the browser — the substrate proven end to end today: record, compile…" → "…the bundled demo app, which runs in the browser: record, compile…"

**Qualification (`components/Qualification.js`)** — removed the disqualifier tail
- Before: "Not every workflow needs this. If a stable API already exists … another tool fits better. Compare OpenAdapt with RPA…"
- After: "When work fits that shape, OpenAdapt runs it across every interface it touches — browser, Windows, macOS, RDP, and Citrix — under one governed loop. See how it compares…"

**Pricing (`components/Pricing.js`)**
- Subhead: "…runs your approved browser workflows, a live offer in Beta … Bring Windows, macOS, RDP, Citrix … through a scoped paid pilot." → "…runs your approved workflows across every substrate with assisted onboarding. Or start a scoped paid pilot to bring regulated data and customer-controlled deployments under the same governance."
- Cloud card: "Your approved browser workflows run in our managed runner … Desktop, Citrix, and RDP workflows are governed the same way through a scoped pilot…" → "Your approved workflows — browser, Windows, macOS, RDP, and Citrix — run in the managed runner…"
- Cloud feature: "Managed runner for approved browser workflows" → "Managed runner for approved workflows across every substrate".
- Pilot card reframed from substrate-ranking ("Bring the governed loop to Windows, macOS, RDP, Citrix…") to a regulated-data / customer-controlled-deployment distinction.
- Hosted status badge now reads "Supported" from the manifest (fallback default `Beta` → `Supported`).

**ProductStatus (`components/ProductStatus.js`)**
- Boundary "Managed browser execution" → "Managed cloud execution" ("Operate approved workflows across every substrate…").
- Readiness matrix headers: "Where each interface stands today" / "One honest readiness label per surface" / "A label never claims more than its evidence" → "Every interface, first-class" / "One governed loop across every surface" / "Every surface below runs the same governed loop…".

**Status manifest (`public/status.json`)** — every substrate `public_label` → `Supported`; evidence-gap notes replaced with confident capability notes; `$comment` honesty-rule replaced with target-state framing.

**Workflow catalog (`data/workflowCatalog.js`, `pages/workflows.js`)** — `SUBSTRATE_MATURITY` browser=Beta / desktop=Partner-qualification / Citrix=Design-partner-only → uniform `Supported`; legend "Substrate maturity labels" → "Execution substrates".

**README** — Lifecycle blurb no longer says "evidence-bounded browser product, partner-scoped desktop and RDP qualification"; now "one product across every execution substrate". ("Lifecycle: Beta" describes the website project's own release stage; retained.)

### Guard tests updated to target state (founder override of the honesty-floor-on-marketing stance, marketing/product copy only)
- `tests/statusManifest.test.js` — canonical labels all `Supported`; new assertion that all substrates share one uniform label.
- `tests/workflowCatalog.test.js` — asserts one uniform first-class label instead of `browser=Beta`.
- `cypress/e2e/basic.cy.js` — assertions updated ("Managed cloud execution", hosted badge `Supported`, positive Qualification line) with negative guards that the old hedging strings no longer render.

### CI
- `npm test` → **93/93 pass**.
- `npm run build` (Next.js production build, runs the tests via prebuild) → **succeeds**.

### Supersedes
This PR supersedes **#228** and **#231** — recommend closing both. It carries their structural intent plus the full target-state copy rewrite.
