### PR TITLE
feat(home): wow-hero upgrade, elevate Cloud, move qualification down

### DIFF
--- a/components/MastHead.js
+++ b/components/MastHead.js
@@ -50,7 +50,7 @@ export default function Home({ githubStats }) {
                                 Compile repeated GUI work. Verify the result.
                                 Halt when you can&rsquo;t.
                             </h1>
-                            <p className="mt-0 mb-6 mx-auto max-w-2xl font-sans font-normal text-base md:text-lg text-ink-2">
+                            <p className="mt-0 mb-4 mx-auto max-w-2xl font-sans font-normal text-base md:text-lg text-ink-2">
                                 Demonstrate a repeated GUI task once. OpenAdapt
                                 compiles it into a local program that makes no
                                 model calls on a healthy run. The same governed
@@ -64,8 +64,13 @@ export default function Home({ githubStats }) {
                                     See how it runs across every interface.
                                 </Link>
                             </p>
+                            <p className={styles.fitLine}>
+                                Purpose-built for repeated, high-stakes GUI work
+                                that has no clean API and can be checked against
+                                an independent source of truth.
+                            </p>
                             <div id="register">
-                                <div className="flex flex-wrap items-center justify-center gap-3 mt-0 mb-8">
+                                <div className="flex flex-wrap items-center justify-center gap-3 mt-0 mb-4">
                                     <Link
                                         className="btn-ink"
                                         href="#book"
@@ -76,6 +81,17 @@ export default function Home({ githubStats }) {
                                         }
                                     >
                                         Evaluate a workflow
+                                    </Link>
+                                    <Link
+                                        className={styles.heroCloud}
+                                        href="#cloud-product"
+                                        onClick={() =>
+                                            track(EVENTS.HERO_CTA_CLICK, {
+                                                cta: 'start_cloud',
+                                            })
+                                        }
+                                    >
+                                        Start with OpenAdapt Cloud
                                     </Link>
                                     <Link
                                         className="btn-ghost-ink"
@@ -89,9 +105,15 @@ export default function Home({ githubStats }) {
                                         Try locally
                                     </Link>
                                 </div>
+                                <p className="mb-2 text-sm text-ink-3">
+                                    Hosted runs in minutes · or run it entirely on
+                                    your own machine · zero per-run model cost ·
+                                    deterministic replay you can audit
+                                </p>
                                 <p className="mb-8 text-sm text-ink-3">
-                                    Runs on your own machine · zero per-run model
-                                    cost · deterministic replay you can audit
+                                    <Link href="/paper">
+                                        Read the technical paper
+                                    </Link>
                                 </p>
                             </div>
                             <div className="flex flex-col align-center justify-center px-4 min-w-0 max-w-full overflow-hidden">

--- a/components/MastHead.module.css
+++ b/components/MastHead.module.css
@@ -9,6 +9,41 @@
     border-bottom: 1px solid var(--hairline);
 }
 
+/* Brief, confident positive-fit line under the hero subhead. The full
+   qualification / "use APIs first" detail moved lower on the page and to
+   /compare — this leads with fit instead of disqualifying up top. */
+.fitLine {
+    margin: 0 auto 1.25rem;
+    max-width: 40rem;
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    line-height: 1.6;
+    letter-spacing: 0.01em;
+    color: var(--ink-3);
+}
+
+/* Elevated OpenAdapt Cloud CTA — an accent-tinted pill that stands out from
+   the ink primary and ghost secondary without competing as a second solid. */
+.heroCloud {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4em;
+    padding: 0.5rem 1.1rem;
+    border-radius: 9999px;
+    border: 1.5px solid var(--accent);
+    background: color-mix(in srgb, var(--accent) 10%, transparent);
+    color: var(--accent);
+    font-weight: 600;
+    text-decoration: none;
+    transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+}
+
+.heroCloud:hover {
+    background: var(--accent);
+    color: var(--ground);
+    border-color: var(--accent);
+}
+
 /* Mono green bordered pill above the H2 */
 .heroPill {
     display: inline-block;

--- a/components/ReplayHero.js
+++ b/components/ReplayHero.js
@@ -5,15 +5,34 @@ import styles from './ReplayHero.module.css'
 
 /**
  * ReplayHero — a stylized, illustrative depiction of a compiled workflow
- * replaying as a run report. Steps resolve through the deterministic ladder,
- * one hits UI drift and re-resolves deterministically, and the run closes
- * with zero model calls. The numbers shown are an illustration of the
- * intended behavior, not captured benchmark data — a visible caption says so,
- * and measured results live on the Compare page.
- * Pure DOM + CSS (no video, no canvas); plays while visible and restarts
- * from the top whenever it scrolls back into view, so every viewing starts
- * at step 1.0; static final frame under prefers-reduced-motion.
+ * replaying as a run report. The same governed loop is shown running across
+ * every interface the work is trapped behind (browser, Windows, macOS, RDP,
+ * Citrix): a substrate strip cycles while steps resolve through the
+ * deterministic ladder, one hits UI drift and re-resolves deterministically,
+ * and the run closes with zero model calls. A cursor tracks the trace, a scan
+ * sweep fires on the drift beat, and a VERIFIED stamp punches in as the
+ * emotional peak. A real OpenAdapt Cloud screenshot sits alongside as
+ * shipping-product proof.
+ *
+ * The numbers shown are an illustration of the intended behavior, not
+ * captured benchmark data — a visible caption says so, and measured results
+ * live on the Compare page.
+ *
+ * Pure DOM + CSS (no video, no canvas); plays while visible and restarts from
+ * the top whenever it scrolls back into view, so every viewing starts at step
+ * 1.0; static final frame under prefers-reduced-motion.
  */
+
+// The substrate set OpenAdapt runs the one governed loop across. Target-state:
+// every interface is first-class. The strip cycles through them so the hero
+// reads as "the same loop, every interface," not a browser-only demo.
+const SUBSTRATES = [
+    { key: 'browser', label: 'Browser', chrome: 'app.openemr — referral-intake' },
+    { key: 'windows', label: 'Windows', chrome: 'OpenEMR (Win32) — referral-intake' },
+    { key: 'macos', label: 'macOS', chrome: 'OpenEMR.app — referral-intake' },
+    { key: 'rdp', label: 'RDP', chrome: 'RDP · win-emr-01 — referral-intake' },
+    { key: 'citrix', label: 'Citrix', chrome: 'Citrix HDX · EMR — referral-intake' },
+]
 
 const ROWS = [
     { n: '1.0', action: 'click', target: "'Sign In'", rung: 'template', ms: '12ms', status: 'ok' },
@@ -33,6 +52,9 @@ const LOOP_MS = 12000
 export default function ReplayHero() {
     const frameRef = useRef(null)
     const [cycle, setCycle] = useState(0)
+    // The substrate label advances one notch per loop so the run visibly
+    // repeats across every interface over successive plays.
+    const [substrateIndex, setSubstrateIndex] = useState(0)
 
     useEffect(() => {
         if (
@@ -45,7 +67,10 @@ export default function ReplayHero() {
         let timer = null
         const startLoop = () => {
             if (timer) return
-            timer = setInterval(() => setCycle((c) => c + 1), LOOP_MS)
+            timer = setInterval(() => {
+                setCycle((c) => c + 1)
+                setSubstrateIndex((s) => (s + 1) % SUBSTRATES.length)
+            }, LOOP_MS)
         }
         const stopLoop = () => {
             if (!timer) return
@@ -80,80 +105,136 @@ export default function ReplayHero() {
         }
     }, [])
 
+    const substrate = SUBSTRATES[substrateIndex]
+
     return (
         <figure className={styles.figure}>
-        <div
-            ref={frameRef}
-            className={styles.frame}
-            aria-label="Illustrative example of a compiled workflow replaying and re-resolving UI drift"
-        >
-            <div className={styles.titlebar}>
-                <span className={styles.dot} />
-                <span className={styles.dot} />
-                <span className={styles.dot} />
-                <span className={styles.title}>referral-intake · illustrative replay</span>
-                <span className={styles.badge}>
-                    <span className={styles.badgeDot} aria-hidden="true" />
-                    illustrative
-                </span>
-            </div>
-            <div className={styles.body} key={cycle}>
-                <div className={styles.rail} aria-hidden="true">
-                    {Array.from({ length: STEP_COUNT }, (_, i) => (
-                        <span
-                            key={`${cycle}-tick-${i}`}
-                            className={`${styles.tick} ${
-                                i === DRIFT_INDEX ? styles.tickDrift : ''
-                            }`}
-                            style={{ animationDelay: `${ROW_DELAY_S(i)}s` }}
-                        />
-                    ))}
-                </div>
-                {ROWS.map((row, i) => (
-                    <div
-                        key={`${cycle}-${i}`}
-                        className={`${styles.row} ${styles[row.status]}`}
-                        style={{ animationDelay: `${ROW_DELAY_S(i)}s` }}
-                    >
-                        {row.status === 'heal' ? (
-                            <span className={styles.healText}>
-                                {'└'} {row.target}
-                            </span>
-                        ) : row.status === 'done' ? (
-                            <span className={styles.doneText}>{row.target}</span>
-                        ) : (
-                            <>
-                                <span className={styles.num}>{row.n}</span>
-                                <span className={styles.action}>{row.action}</span>
-                                <span className={styles.target}>{row.target}</span>
-                                <span className={styles.rung}>
-                                    {row.status === 'drift'
-                                        ? '⚠ UI drift detected'
-                                        : row.rung}
-                                </span>
-                                <span className={styles.ms}>{row.ms}</span>
-                                <span className={styles.check}>
-                                    {row.status === 'drift' ? '' : '✓'}
-                                </span>
-                            </>
-                        )}
-                    </div>
-                ))}
+            <div className={styles.stage}>
                 <div
-                    className={`${styles.row} ${styles.summary}`}
-                    style={{ animationDelay: `${ROW_DELAY_S(ROWS.length)}s` }}
+                    ref={frameRef}
+                    className={styles.frame}
+                    aria-label="Illustrative example of one governed workflow replaying and re-resolving UI drift across every interface"
                 >
-                    <span>
-                        total 2.4s &nbsp;·&nbsp; model calls: 0 &nbsp;·&nbsp;
-                        cost per run: $0.00
-                        <span className={styles.cursor} aria-hidden="true" />
-                    </span>
-                    <span className={styles.stamp}>
-                        VERIFIED · 0 MODEL CALLS
-                    </span>
+                    <div className={styles.titlebar}>
+                        <span className={styles.dot} />
+                        <span className={styles.dot} />
+                        <span className={styles.dot} />
+                        <span className={styles.title}>{substrate.chrome}</span>
+                        <span className={styles.badge}>
+                            <span className={styles.badgeDot} aria-hidden="true" />
+                            illustrative
+                        </span>
+                    </div>
+
+                    {/* Substrate strip: the one governed loop, every interface. */}
+                    <div
+                        className={styles.substrates}
+                        aria-label="Runs across every interface"
+                    >
+                        {SUBSTRATES.map((item, i) => (
+                            <span
+                                key={item.key}
+                                className={`${styles.substrate} ${
+                                    i === substrateIndex ? styles.substrateOn : ''
+                                }`}
+                            >
+                                {item.label}
+                            </span>
+                        ))}
+                        <span className={styles.substrateNote}>one loop</span>
+                    </div>
+
+                    <div className={styles.body} key={cycle}>
+                        {/* Scan sweep fires on the drift beat. */}
+                        <span className={styles.scan} aria-hidden="true" />
+
+                        <div className={styles.rail} aria-hidden="true">
+                            {Array.from({ length: STEP_COUNT }, (_, i) => (
+                                <span
+                                    key={`${cycle}-tick-${i}`}
+                                    className={`${styles.tick} ${
+                                        i === DRIFT_INDEX ? styles.tickDrift : ''
+                                    }`}
+                                    style={{ animationDelay: `${ROW_DELAY_S(i)}s` }}
+                                />
+                            ))}
+                        </div>
+                        {ROWS.map((row, i) => (
+                            <div
+                                key={`${cycle}-${i}`}
+                                className={`${styles.row} ${styles[row.status]}`}
+                                style={{ animationDelay: `${ROW_DELAY_S(i)}s` }}
+                            >
+                                {row.status === 'heal' ? (
+                                    <span className={styles.healText}>
+                                        {'└'} {row.target}
+                                    </span>
+                                ) : row.status === 'done' ? (
+                                    <span className={styles.doneText}>{row.target}</span>
+                                ) : (
+                                    <>
+                                        <span className={styles.num}>{row.n}</span>
+                                        <span className={styles.action}>{row.action}</span>
+                                        <span className={styles.target}>{row.target}</span>
+                                        <span className={styles.rung}>
+                                            {row.status === 'drift'
+                                                ? '⚠ UI drift detected'
+                                                : row.rung}
+                                        </span>
+                                        <span className={styles.ms}>{row.ms}</span>
+                                        <span className={styles.check}>
+                                            {row.status === 'drift' ? '' : '✓'}
+                                        </span>
+                                    </>
+                                )}
+                            </div>
+                        ))}
+                        <div
+                            className={`${styles.row} ${styles.summary}`}
+                            style={{ animationDelay: `${ROW_DELAY_S(ROWS.length)}s` }}
+                        >
+                            <span>
+                                total 2.4s &nbsp;·&nbsp; model calls: 0 &nbsp;·&nbsp;
+                                cost per run: $0.00
+                                <span className={styles.cursor} aria-hidden="true" />
+                            </span>
+                            <span className={styles.stamp}>
+                                VERIFIED · 0 MODEL CALLS
+                            </span>
+                        </div>
+                    </div>
                 </div>
+
+                {/* Shipping-product proof: a real OpenAdapt Cloud capture that
+                    reads the same run out of the hosted dashboard. */}
+                <aside
+                    className={styles.proof}
+                    aria-label="The same run in OpenAdapt Cloud"
+                >
+                    <div className={styles.proofChrome}>
+                        <span className={styles.proofBrand}>
+                            <b>OpenAdapt</b> Cloud
+                        </span>
+                        <span className={styles.proofUrl}>app.openadapt.ai</span>
+                    </div>
+                    <img
+                        className={styles.proofShot}
+                        src="/cloud-preview/healthcare-run.jpg"
+                        width="880"
+                        height="550"
+                        alt="OpenAdapt Cloud run detail for a completed synthetic OpenEMR run: step metrics and a verified-effect timeline in the real hosted dashboard."
+                        loading="lazy"
+                        decoding="async"
+                    />
+                    <div className={styles.proofFoot}>
+                        <span className={styles.proofPill}>Effect verified</span>
+                        <Link href="#cloud-product" className={styles.proofLink}>
+                            See the shipping product →
+                        </Link>
+                    </div>
+                </aside>
             </div>
-        </div>
+
             <figcaption className={styles.illustrative}>
                 Illustrative — a stylized depiction of a compiled replay, not
                 captured benchmark data. See{' '}

--- a/components/ReplayHero.module.css
+++ b/components/ReplayHero.module.css
@@ -1,13 +1,30 @@
 .figure {
     margin: 0 auto;
     width: 100%;
-    max-width: 640px;
+    max-width: 980px;
     min-width: 0;
 }
 
+/* Two-up stage: the animated governed-replay trace beside a real product
+   screenshot. Collapses to a single column on narrow viewports. */
+.stage {
+    display: grid;
+    grid-template-columns: 1.45fr 1fr;
+    gap: 16px;
+    align-items: stretch;
+    min-width: 0;
+}
+
+@media (max-width: 860px) {
+    .stage {
+        grid-template-columns: 1fr;
+        gap: 12px;
+    }
+}
+
 .illustrative {
-    margin: 0.6rem auto 0;
-    max-width: 640px;
+    margin: 0.7rem auto 0;
+    max-width: 980px;
     text-align: center;
     font-family: var(--font-mono);
     font-size: 0.72rem;
@@ -20,17 +37,19 @@
     color: var(--accent);
 }
 
+/* ── The animated replay trace ─────────────────────────────────────────── */
 .frame {
+    position: relative;
     width: 100%;
-    max-width: 640px;
     min-width: 0;
-    margin: 0 auto;
     border: 1px solid var(--inset-border);
     border-radius: 12px;
     background: var(--inset-bg);
     box-shadow: 0 8px 32px rgba(35, 40, 31, 0.18);
     overflow: hidden;
     text-align: left;
+    display: flex;
+    flex-direction: column;
 }
 
 .titlebar {
@@ -54,10 +73,16 @@
     font-family: var(--font-mono);
     font-size: 0.78rem;
     color: rgba(217, 222, 230, 0.65);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+    transition: color 0.4s ease;
 }
 
 .badge {
     margin-left: auto;
+    flex-shrink: 0;
     display: inline-flex;
     align-items: center;
     gap: 5px;
@@ -79,12 +104,98 @@
     animation: badgePulse 2.4s ease-in-out infinite;
 }
 
+/* Substrate strip — the one governed loop, every interface. */
+.substrates {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+    padding: 8px 14px;
+    border-bottom: 1px solid var(--inset-border);
+    background: rgba(255, 255, 255, 0.015);
+}
+
+.substrate {
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: rgba(217, 222, 230, 0.4);
+    border: 1px solid rgba(217, 222, 230, 0.14);
+    border-radius: 999px;
+    padding: 2px 9px;
+    transition: color 0.4s ease, border-color 0.4s ease,
+        background 0.4s ease, box-shadow 0.4s ease;
+}
+
+.substrateOn {
+    color: var(--inset-bg);
+    background: #86d9a8;
+    border-color: #86d9a8;
+    box-shadow: 0 0 0 3px rgba(134, 217, 168, 0.14);
+}
+
+.substrateNote {
+    margin-left: auto;
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: rgba(217, 222, 230, 0.32);
+}
+
 .body {
+    position: relative;
+    flex: 1;
     padding: 14px 16px 16px;
     font-family: var(--font-mono);
     font-size: 0.8rem;
     line-height: 1.9;
     font-variant-numeric: tabular-nums;
+    overflow: hidden;
+}
+
+/* Scan sweep — a light bar that rakes down the trace on the drift beat,
+   reading as "re-checking its evidence." */
+.scan {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    height: 46px;
+    pointer-events: none;
+    background: linear-gradient(
+        180deg,
+        rgba(227, 179, 79, 0) 0%,
+        rgba(227, 179, 79, 0.16) 50%,
+        rgba(227, 179, 79, 0) 100%
+    );
+    opacity: 0;
+    animation: scanSweep 12s linear forwards;
+}
+
+@keyframes scanSweep {
+    0%,
+    40% {
+        opacity: 0;
+        transform: translateY(0);
+    }
+    41% {
+        opacity: 1;
+        transform: translateY(30px);
+    }
+    52% {
+        opacity: 0.9;
+        transform: translateY(150px);
+    }
+    56% {
+        opacity: 0;
+        transform: translateY(170px);
+    }
+    100% {
+        opacity: 0;
+        transform: translateY(170px);
+    }
 }
 
 /* Replay rail — one tick per compiled step, filling at real row cadence.
@@ -189,6 +300,22 @@
     color: #e3b34f;
 }
 
+/* The drift row flashes amber as it is detected, then settles. */
+.drift {
+    animation: rowIn 0.35s ease forwards, driftFlash 1.15s ease forwards;
+}
+
+@keyframes driftFlash {
+    0%,
+    100% {
+        background: transparent;
+    }
+    30%,
+    70% {
+        background: rgba(227, 179, 79, 0.1);
+    }
+}
+
 .healText {
     color: #86d9a8;
     padding-left: 2.2em;
@@ -207,12 +334,14 @@
     align-items: center;
 }
 
-/* The one "stamp" moment: rotated bordered chip in the summary row */
+/* The one "stamp" moment: rotated bordered chip punches into the summary
+   row as the run verifies — the emotional peak. */
 .stamp {
     margin-left: auto;
     flex-shrink: 0;
     display: inline-block;
-    transform: rotate(-6deg);
+    transform: rotate(-6deg) scale(1);
+    transform-origin: center;
     font-family: var(--font-mono);
     font-size: 0.58rem;
     font-weight: 600;
@@ -223,7 +352,27 @@
     border: 1.5px solid #86d9a8;
     border-radius: 4px;
     padding: 2px 7px;
-    opacity: 0.9;
+    opacity: 0;
+    animation: stampPunch 0.5s cubic-bezier(0.2, 1.5, 0.4, 1) forwards;
+    animation-delay: 8.6s;
+    box-shadow: 0 0 0 0 rgba(134, 217, 168, 0.5);
+}
+
+@keyframes stampPunch {
+    0% {
+        opacity: 0;
+        transform: rotate(-6deg) scale(2.1);
+        box-shadow: 0 0 0 0 rgba(134, 217, 168, 0.55);
+    }
+    70% {
+        opacity: 0.95;
+        transform: rotate(-6deg) scale(0.92);
+    }
+    100% {
+        opacity: 0.9;
+        transform: rotate(-6deg) scale(1);
+        box-shadow: 0 0 0 10px rgba(134, 217, 168, 0);
+    }
 }
 
 @keyframes rowIn {
@@ -235,6 +384,90 @@
         opacity: 1;
         transform: translateY(0);
     }
+}
+
+/* ── Real-product proof card ───────────────────────────────────────────── */
+.proof {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    border: 1px solid var(--hairline);
+    border-radius: 12px;
+    background: var(--panel);
+    box-shadow: 0 8px 32px rgba(35, 40, 31, 0.1);
+    overflow: hidden;
+}
+
+.proofChrome {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 9px 12px;
+    border-bottom: 1px solid var(--hairline);
+    background: var(--ground);
+}
+
+.proofBrand {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.02em;
+    color: var(--ink-2);
+}
+
+.proofBrand b {
+    color: var(--ink);
+    font-weight: 600;
+}
+
+.proofUrl {
+    margin-left: auto;
+    font-family: var(--font-mono);
+    font-size: 0.64rem;
+    color: var(--ink-3);
+    background: var(--panel);
+    border: 1px solid var(--hairline);
+    border-radius: 999px;
+    padding: 1px 9px;
+}
+
+.proofShot {
+    display: block;
+    width: 100%;
+    height: auto;
+    flex: 1;
+    object-fit: cover;
+    object-position: top left;
+}
+
+.proofFoot {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+    border-top: 1px solid var(--hairline);
+}
+
+.proofPill {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--accent);
+    border: 1px solid var(--accent);
+    border-radius: 999px;
+    padding: 2px 9px;
+}
+
+.proofLink {
+    margin-left: auto;
+    font-size: 0.78rem;
+    color: var(--accent);
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.proofLink:hover {
+    text-decoration: underline;
 }
 
 @media (max-width: 640px) {
@@ -297,7 +530,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-    .row {
+    .row,
+    .drift {
         animation: none;
         opacity: 1;
         transform: none;
@@ -309,8 +543,22 @@
         background: #86d9a8;
     }
 
+    .scan {
+        display: none;
+    }
+
+    .stamp {
+        animation: none;
+        opacity: 0.9;
+        transform: rotate(-6deg) scale(1);
+    }
+
     .badgeDot,
     .cursor {
         animation: none;
+    }
+
+    .substrate {
+        transition: none;
     }
 }

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -47,13 +47,26 @@ describe('public product truth', () => {
             'contain.text',
             'Compile repeated GUI work. Verify the result. Halt when you can’t.'
         )
+        // The hero leads with value: a brief, confident positive-fit line and
+        // an elevated OpenAdapt Cloud call to action next to the primary
+        // evaluation CTA. The full "use APIs first" qualification moved LOW on
+        // the page (next to the /compare link it feeds).
+        cy.contains(
+            'Purpose-built for repeated, high-stakes GUI work'
+        ).should('be.visible')
+        cy.contains('a', 'Start with OpenAdapt Cloud').should(
+            'have.attr',
+            'href',
+            '/#cloud-product'
+        )
+        cy.get('a[href="/paper"]').should('exist')
+        // Qualification is still present, now lower on the page: it resolves
+        // into a confident, positive statement — no disqualifier column, no
+        // "when it isn't the right tool" section.
         cy.contains(
             'Use APIs first. Use OpenAdapt for the UI-only last mile.'
         ).should('be.visible')
         cy.contains('When OpenAdapt fits').should('be.visible')
-        // Fit signal leads and resolves into a confident, positive statement:
-        // when work fits, OpenAdapt runs it across every interface. No
-        // disqualifier column, no "when it isn't the right tool" section.
         cy.contains('OpenAdapt runs it across every').should('be.visible')
         cy.contains('another tool fits better').should('not.exist')
         cy.contains('When it isn’t the right tool').should('not.exist')

--- a/pages/index.js
+++ b/pages/index.js
@@ -197,9 +197,6 @@ export default function Home({ githubStats, buildWarnings, hostedOffer }) {
             </Head>
             <MastHead githubStats={githubStats} />
             <Reveal>
-                <Qualification />
-            </Reveal>
-            <Reveal>
                 <HowItWorksCondensed />
             </Reveal>
             <Reveal>
@@ -258,6 +255,17 @@ export default function Home({ githubStats, buildWarnings, hostedOffer }) {
                     </div>
                 </div>
             </section>
+            {/*
+             * OpenAdapt Cloud is surfaced UPPER-MIDDLE — right after the
+             * reference-workflow sections — so "there is a hosted product you
+             * can start now" is visible mid-page. The DashboardShowcase is the
+             * condensed hosted-product teaser (real Cloud footage + "Open the
+             * Cloud app" / "See launch plans"); the full Pricing detail stays
+             * lower.
+             */}
+            <Reveal>
+                <DashboardShowcase />
+            </Reveal>
             <Reveal>
                 <DriftOutcomes />
             </Reveal>
@@ -265,10 +273,17 @@ export default function Home({ githubStats, buildWarnings, hostedOffer }) {
                 <ProductStatus />
             </Reveal>
             <Reveal>
-                <DashboardShowcase />
-            </Reveal>
-            <Reveal>
                 <Pricing hostedOffer={hostedOffer} />
+            </Reveal>
+            {/*
+             * Buyer qualification ("use APIs first / UI-only last mile") sits
+             * LOW, next to the /compare link it feeds — the page leads with
+             * value and qualifies later. A brief positive-fit line lives in the
+             * hero; the full fit criteria and the RPA / agent / recorder
+             * breakdown live here and on /compare.
+             */}
+            <Reveal>
+                <Qualification />
             </Reveal>
             <Reveal>
                 <ContactBookingSection />

--- a/pages/paper.js
+++ b/pages/paper.js
@@ -1,0 +1,105 @@
+import Head from 'next/head'
+import Link from 'next/link'
+
+import Footer from '@components/Footer'
+import { getOpenAdaptRepositoryStats } from '../lib/openAdaptRepositoryStats'
+
+// Canonical location of the technical paper source (LaTeX + figures) until a
+// built PDF ships. A concurrent PR may add public/openadapt-paper.pdf or a
+// richer /paper route; this placeholder forwards readers to the source and
+// links the PDF path defensively so a landed PDF needs no further wiring.
+const PAPER_SOURCE_URL =
+    'https://github.com/OpenAdaptAI/openadapt-flow/tree/main/paper'
+const PAPER_PDF_PATH = '/openadapt-paper.pdf'
+
+const webPageSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    name: 'OpenAdapt technical paper',
+    url: 'https://openadapt.ai/paper',
+    description:
+        'The OpenAdapt technical paper: how a demonstrated GUI workflow is compiled into a deterministic local program that re-resolves interface drift, verifies effects against an independent oracle, and halts under governance.',
+    isPartOf: {
+        '@type': 'WebSite',
+        name: 'OpenAdapt.AI',
+        url: 'https://openadapt.ai',
+    },
+    inLanguage: 'en',
+}
+
+export async function getStaticProps() {
+    const githubStats = await getOpenAdaptRepositoryStats()
+    return { props: { githubStats }, revalidate: 300 }
+}
+
+export default function PaperPage({ githubStats }) {
+    return (
+        <div className="min-h-screen bg-ground text-ink">
+            <Head>
+                <title>OpenAdapt technical paper</title>
+                <meta
+                    name="description"
+                    content="The OpenAdapt technical paper: compiling a demonstrated GUI workflow into a deterministic local program that re-resolves drift, verifies effects, and halts under governance."
+                />
+                <link rel="canonical" href="https://openadapt.ai/paper" />
+                <meta property="og:title" content="OpenAdapt technical paper" />
+                <meta property="og:url" content="https://openadapt.ai/paper" />
+                <script
+                    type="application/ld+json"
+                    dangerouslySetInnerHTML={{
+                        __html: JSON.stringify(webPageSchema),
+                    }}
+                />
+            </Head>
+
+            <section className="mx-auto max-w-3xl px-5 py-16 md:py-20">
+                <p className="eyebrow">Technical paper</p>
+                <h1 className="mt-2 font-display text-3xl font-semibold tracking-tight text-ink md:text-4xl">
+                    How OpenAdapt compiles, verifies, and halts.
+                </h1>
+                <p className="mt-4 max-w-2xl text-base leading-relaxed text-ink-2 md:text-lg">
+                    The paper describes the governed workflow compiler: how a
+                    bounded demonstration becomes a deterministic local program,
+                    how the deterministic ladder re-resolves interface drift
+                    without per-run model calls, how effects are checked against
+                    an independent oracle, and how the loop halts for a person
+                    when configured verification cannot be established.
+                </p>
+
+                <div className="mt-8 flex flex-wrap gap-3">
+                    <a className="btn-ink" href={PAPER_PDF_PATH}>
+                        Read the paper (PDF)
+                    </a>
+                    <a
+                        className="btn-ghost-ink"
+                        href={PAPER_SOURCE_URL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        View the paper source
+                    </a>
+                </div>
+
+                <p className="mt-6 text-sm leading-relaxed text-ink-3">
+                    The typeset PDF is being finalized. Until it lands, the
+                    complete LaTeX source, figures, and evidence live in the{' '}
+                    <a
+                        href={PAPER_SOURCE_URL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-accent underline"
+                    >
+                        openadapt-flow paper directory
+                    </a>
+                    . For measured benchmark results, see the{' '}
+                    <Link href="/compare" className="text-accent underline">
+                        comparison page
+                    </Link>
+                    .
+                </p>
+            </section>
+
+            <Footer repositoryStats={githubStats} />
+        </div>
+    )
+}


### PR DESCRIPTION
## Summary

Overhauls the openadapt.ai homepage for conversion and a differentiated **wow** hero, in target-state (confident; browser/Windows/macOS/RDP/Citrix all first-class; no hedging). All copy/honesty guards stay green.

### Before → after section order

| # | Before | After |
|---|--------|-------|
| 1 | MastHead (hero) | MastHead (**upgraded hero** + Cloud CTA + brief positive-fit line + paper link) |
| 2 | **Qualification** | HowItWorksCondensed |
| 3 | HowItWorksCondensed | HomeReferenceWorkflow |
| 4 | HomeReferenceWorkflow | references (inline) |
| 5 | references (inline) | **DashboardShowcase** (OpenAdapt Cloud teaser, moved up to upper-middle) |
| 6 | DriftOutcomes | DriftOutcomes |
| 7 | ProductStatus | ProductStatus |
| 8 | **DashboardShowcase** | Pricing (full detail stays lower) |
| 9 | Pricing | **Qualification** (moved down, next to the /compare link) |
| 10 | ContactBookingSection | ContactBookingSection |
| 11 | Developers | Developers |
| 12 | EmailForm | EmailForm |
| 13 | Footer | Footer |

### 1. Hero — upgraded animated demo (not a static-screenshot downgrade)

Kept the differentiated **governed-replay trace** and made it richer:

- **Substrate strip** (Browser / Windows / macOS / RDP / Citrix + "one loop") that **cycles each play**, so the same governed loop visibly runs across *every interface* — target-state, all first-class.
- App/browser **window chrome** whose title changes per substrate.
- **Drift → re-resolve → VERIFIED** beat as the emotional peak: a scan-sweep rakes the trace on the drift step, the drift row flashes amber, then a spring **"VERIFIED · 0 MODEL CALLS"** stamp punches in. `0 model calls / $0.00 / effect-verified` punchline retained.
- Paired with a **real OpenAdapt Cloud screenshot** (reuses `DashboardShowcase`'s `/cloud-preview/healthcare-run.jpg`) in its own product chrome with an "Effect verified" pill + link into the Cloud section — clearly a shipping product.
- Pure **DOM/CSS/SVG** (no video/canvas), theme-aware via design tokens, responsive (two-up grid collapses to one column; verified **no horizontal overflow at 375/320px**), `prefers-reduced-motion` shows a static final frame.

Verified rendering (headless Chrome, desktop):

- Substrate strip + trace + real Cloud proof card render together; the drift/heal/verified rows and stamp all present.

**Alternative directions considered** (not taken, single strongest implemented):
- Full **Canvas/WebGL** particle "compile" animation — higher wow ceiling but heavier, worse a11y/reduced-motion story, and dilutes the trace's *legibility* which is the actual differentiator.
- **Faux live cursor** gliding to each step target — nice motion but fragile across the responsive trace; the scan-sweep + row cascade already carry the motion.
- **Autoplaying screen-recording video** of the real Cloud app — most "real" but a differentiation downgrade (any RPA vendor has a product video) and heavier; the static real screenshot beside the animated trace gets the "shipping product" proof without losing the concept.

### 2. Elevate OpenAdapt Cloud
- New accent **"Start with OpenAdapt Cloud"** CTA in the hero, beside the primary "Evaluate a workflow".
- `DashboardShowcase` (the real Cloud footage + "Open the Cloud app" / "See launch plans" teaser) moved to **upper-middle**, right after the reference sections, so "there's a hosted product you can start now" is visible mid-page. Full **Pricing** detail stays lower.

### 3. Move Qualification down
- The "Use APIs first / UI-only last mile" section moves from **#2** to **low on the page**, adjacent to the `/compare` link it feeds. Fit criteria are **relocated, not deleted**. A brief, confident **positive-fit line** now leads in the hero ("Purpose-built for repeated, high-stakes GUI work…"). Lead with value; qualify later.

### Paper
- No paper asset existed. Added a **`/paper`** route (placeholder) linking the canonical `openadapt-flow/paper` source and a defensive `/openadapt-paper.pdf` path, and linked it from the hero. **A concurrent PR may add the paper PDF/route and may also touch the homepage — expect a possible trivial rebase.**

### Tests / CI
- Updated `cypress/e2e/basic.cy.js` for the new hero (Cloud CTA, `/paper` link, positive-fit line) and the relocated Qualification.
- `npm test` — **93/93** honesty guards pass. `next build` — **green** (includes `/paper`).
- Section order verified in rendered HTML; hero verified via headless-Chrome screenshots; no horizontal overflow at 375/320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM