### PR TITLE
copy(hero+paper): reframe hero fit line and mark the typeset PDF as available

### DIFF
--- a/components/MastHead.js
+++ b/components/MastHead.js
@@ -63,8 +63,8 @@ export default function Home({ githubStats }) {
                             </p>
                             <p className={styles.fitLine}>
                                 Purpose-built for repeated, high-stakes GUI work
-                                that has no clean API and can be checked against
-                                an independent source of truth.
+                                with no clean API, where a wrong action is costly
+                                and the result should be verified, not assumed.
                             </p>
                             <div id="register">
                                 <div className="flex flex-wrap items-center justify-center gap-3 mt-0 mb-4">

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -52,7 +52,7 @@ describe('public product truth', () => {
         // evaluation CTA. The full "use APIs first" qualification moved LOW on
         // the page (next to the /compare link it feeds).
         cy.contains(
-            'Purpose-built for repeated, high-stakes GUI work'
+            'Purpose-built for repeated, high-stakes GUI work with no clean API'
         ).should('be.visible')
         cy.contains('a', 'Start with OpenAdapt Cloud').should(
             'have.attr',

--- a/pages/paper.js
+++ b/pages/paper.js
@@ -4,10 +4,9 @@ import Link from 'next/link'
 import Footer from '@components/Footer'
 import { getOpenAdaptRepositoryStats } from '../lib/openAdaptRepositoryStats'
 
-// Canonical location of the technical paper source (LaTeX + figures) until a
-// built PDF ships. A concurrent PR may add public/openadapt-paper.pdf or a
-// richer /paper route; this placeholder forwards readers to the source and
-// links the PDF path defensively so a landed PDF needs no further wiring.
+// The typeset PDF is live at public/openadapt-paper.pdf. PAPER_SOURCE_URL is
+// the canonical location of the paper source (LaTeX + figures) for readers who
+// want the raw materials behind the PDF.
 const PAPER_SOURCE_URL =
     'https://github.com/OpenAdaptAI/openadapt-flow/tree/main/paper'
 const PAPER_PDF_PATH = '/openadapt-paper.pdf'
@@ -81,8 +80,8 @@ export default function PaperPage({ githubStats }) {
                 </div>
 
                 <p className="mt-6 text-sm leading-relaxed text-ink-3">
-                    The typeset PDF is being finalized. Until it lands, the
-                    complete LaTeX source, figures, and evidence live in the{' '}
+                    The typeset PDF is available to read above. The complete
+                    LaTeX source, figures, and evidence live in the{' '}
                     <a
                         href={PAPER_SOURCE_URL}
                         target="_blank"
@@ -91,7 +90,12 @@ export default function PaperPage({ githubStats }) {
                     >
                         openadapt-flow paper directory
                     </a>
-                    . For measured benchmark results, see the{' '}
+                    , and the{' '}
+                    <Link href="/research" className="text-accent underline">
+                        research overview
+                    </Link>{' '}
+                    walks through the same method. For measured benchmark
+                    results, see the{' '}
                     <Link href="/compare" className="text-accent underline">
                         comparison page
                     </Link>


### PR DESCRIPTION
Two small, honest copy fixes on the homepage/paper page. Shipped together.

## 1. Hero fit line (components/MastHead.js)

Before:
> Purpose-built for repeated, high-stakes GUI work that has no clean API and can be checked against an independent source of truth.

After:
> Purpose-built for repeated, high-stakes GUI work with no clean API, where a wrong action is costly and the result should be verified, not assumed.

Why: "can be checked against an independent source of truth" reads as a prerequisite (the customer must already have a separate system of record), which self-disqualifies prospects. The new wording keeps the fit (repeated, high-stakes, no API) and keeps the verification differentiator, but frames verification as what OpenAdapt does rather than a gate the customer must pass. It is also more accurate given the auto-derived read-back oracle: OpenAdapt can verify by re-reading the record even with no customer API.

## 2. Paper page (pages/paper.js)

Before:
> The typeset PDF is being finalized. Until it lands, the complete LaTeX source, figures, and evidence live in the openadapt-flow paper directory. For measured benchmark results, see the comparison page.

After:
> The typeset PDF is available to read above. The complete LaTeX source, figures, and evidence live in the openadapt-flow paper directory, and the research overview walks through the same method. For measured benchmark results, see the comparison page.

Why: the author-correct typeset PDF is now live at /openadapt-paper.pdf (already shipped in public/), so claiming it is "being finalized" is false. Now presents it as available, keeps the source-directory link, and adds a link to /research. Also refreshed the stale source comment.

## Tests

- Updated the Cypress basic spec assertion (cypress/e2e/basic.cy.js) to the new, more specific stable substring "Purpose-built for repeated, high-stakes GUI work with no clean API". Intent unchanged.
- No test or honesty guard asserted the "being finalized" phrasing, so no test change was needed for the paper copy. The basic spec already asserts /paper links to /openadapt-paper.pdf and still passes.

## CI status (local)

- 93 honesty guards (node --test tests/*.test.js): 93 passing
- next build: success (prebuild reran the guards)
- Cypress basic.cy.js against the built server: 15/15 passing

## Scope

Only components/MastHead.js, pages/paper.js, and cypress/e2e/basic.cy.js. Did not touch components/ReplayHero.js or public/openadapt-paper.pdf.