### PR TITLE
feat(paper): auto-fetch latest built PDF at build time with safe fallback

### DIFF
--- a/.github/workflows/paper-redeploy.yml
+++ b/.github/workflows/paper-redeploy.yml
@@ -1,0 +1,46 @@
+name: Paper Redeploy
+
+# openadapt.ai deploys via Netlify's own git integration (see netlify.toml),
+# not GitHub Actions, so a repository_dispatch cannot rebuild the site directly.
+# Instead, openadapt-flow's Paper workflow fires a `paper-updated` dispatch when
+# it publishes a fresh paper PDF; this workflow relays that into a Netlify build
+# hook, which triggers a deploy whose prebuild step (scripts/fetch-paper-pdf.js)
+# re-fetches the latest release asset.
+#
+# Propagation is best-effort. Even with no dispatch and no build hook, every
+# Netlify deploy re-runs the fetch, so the served PDF converges to the latest
+# build on the next deploy regardless.
+#
+# Setup: add repository secret NETLIFY_BUILD_HOOK_URL (Netlify: Site
+# configuration -> Build & deploy -> Build hooks). Without it this workflow is a
+# logged no-op.
+
+on:
+  repository_dispatch:
+    types: [paper-updated]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: paper-redeploy
+  cancel-in-progress: true
+
+jobs:
+  trigger-netlify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Netlify build hook
+        env:
+          NETLIFY_BUILD_HOOK_URL: ${{ secrets.NETLIFY_BUILD_HOOK_URL }}
+        run: |
+          set -uo pipefail
+          if [ -z "${NETLIFY_BUILD_HOOK_URL:-}" ]; then
+            echo "::warning::NETLIFY_BUILD_HOOK_URL is not set; cannot trigger a redeploy. The paper PDF will refresh on the next Netlify deploy via the build-time fetch."
+            exit 0
+          fi
+          curl --fail --retry 5 --retry-all-errors --show-error --silent \
+            -X POST -d '{}' "${NETLIFY_BUILD_HOOK_URL}" \
+            && echo "Triggered Netlify redeploy to refresh the paper PDF." \
+            || { echo "::error::Netlify build hook POST failed after retries."; exit 1; }

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 .netlify
 
 *.sw[m-p]
+
+# Transient temp file written by scripts/fetch-paper-pdf.js during build
+public/.openadapt-paper.pdf.tmp

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     },
     "scripts": {
         "dev": "next dev",
-        "prebuild": "npm test",
+        "fetch:paper": "node scripts/fetch-paper-pdf.js",
+        "prebuild": "npm run fetch:paper && npm test",
         "build": "next build",
         "start": "next start -H 127.0.0.1 -p 3000",
         "test": "node --test tests/*.test.js",

--- a/scripts/fetch-paper-pdf.js
+++ b/scripts/fetch-paper-pdf.js
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * Build-time fetch for the OpenAdapt paper PDF.
+ *
+ * openadapt.ai serves the paper at https://openadapt.ai/openadapt-paper.pdf,
+ * which maps to public/openadapt-paper.pdf. To keep that URL always current
+ * without hand-committing a copy that drifts from the LaTeX source, this
+ * script downloads the freshest build from the openadapt-flow `paper-latest`
+ * GitHub release (published by openadapt-flow's Paper workflow) before
+ * `next build`.
+ *
+ * Safety contract (never break a deploy over a transient fetch problem):
+ *   - Download to a temp file, not the destination, so a partial/failed
+ *     download can never replace a good committed copy.
+ *   - Validate the download is a real PDF (`%PDF` magic bytes) and of
+ *     non-trivial size before promoting it into place.
+ *   - On ANY failure (network, non-200, non-PDF, too-small, timeout) keep the
+ *     committed fallback at public/openadapt-paper.pdf and log a clear warning.
+ *   - Always exit 0. This script is advisory: it upgrades the committed PDF
+ *     when it can, and is otherwise a no-op.
+ */
+
+const fs = require('node:fs')
+const path = require('node:path')
+
+const RELEASE_URL =
+  process.env.PAPER_PDF_URL ||
+  'https://github.com/OpenAdaptAI/openadapt-flow/releases/download/paper-latest/openadapt-paper.pdf'
+
+const DEST = path.join(__dirname, '..', 'public', 'openadapt-paper.pdf')
+const TMP = path.join(__dirname, '..', 'public', '.openadapt-paper.pdf.tmp')
+
+// A real paper PDF is hundreds of KB. Anything under this is almost certainly
+// an error page, an empty object, or a truncated download -- reject it.
+const MIN_BYTES = 20 * 1024
+const TIMEOUT_MS = 20000
+
+function warn(msg) {
+  console.warn(`[fetch-paper-pdf] WARNING: ${msg}`)
+}
+
+function info(msg) {
+  console.log(`[fetch-paper-pdf] ${msg}`)
+}
+
+function fallbackNotice(reason) {
+  if (fs.existsSync(DEST)) {
+    warn(
+      `${reason}. Keeping committed fallback at public/openadapt-paper.pdf ` +
+        `(${fs.statSync(DEST).size} bytes). The served PDF may be stale.`
+    )
+  } else {
+    warn(
+      `${reason}. No committed fallback at public/openadapt-paper.pdf exists; ` +
+        `the /openadapt-paper.pdf route will 404 until a build succeeds or the ` +
+        `fallback is committed.`
+    )
+  }
+}
+
+function cleanupTmp() {
+  try {
+    if (fs.existsSync(TMP)) fs.unlinkSync(TMP)
+  } catch (_) {
+    /* best-effort */
+  }
+}
+
+async function main() {
+  info(`Fetching latest paper PDF from ${RELEASE_URL}`)
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
+
+  let buf
+  try {
+    // Node 18+/22 global fetch follows redirects (GitHub release download
+    // 302s to objects.githubusercontent.com) automatically.
+    const res = await fetch(RELEASE_URL, {
+      signal: controller.signal,
+      redirect: 'follow',
+      headers: { 'User-Agent': 'openadapt-web-build' },
+    })
+    if (!res.ok) {
+      fallbackNotice(`Fetch returned HTTP ${res.status}`)
+      return
+    }
+    buf = Buffer.from(await res.arrayBuffer())
+  } catch (err) {
+    fallbackNotice(`Fetch failed (${err && err.name ? err.name : 'error'}: ${err && err.message ? err.message : err})`)
+    return
+  } finally {
+    clearTimeout(timer)
+  }
+
+  // Validate: real PDF magic bytes.
+  if (buf.length < 4 || buf.subarray(0, 4).toString('latin1') !== '%PDF') {
+    fallbackNotice('Downloaded file is not a PDF (missing %PDF magic bytes)')
+    return
+  }
+  // Validate: non-trivial size.
+  if (buf.length < MIN_BYTES) {
+    fallbackNotice(`Downloaded PDF is implausibly small (${buf.length} bytes)`)
+    return
+  }
+
+  try {
+    fs.writeFileSync(TMP, buf)
+    fs.renameSync(TMP, DEST) // atomic promote over the committed fallback
+    info(`Updated public/openadapt-paper.pdf from release (${buf.length} bytes).`)
+  } catch (err) {
+    cleanupTmp()
+    fallbackNotice(`Could not write PDF to disk (${err && err.message ? err.message : err})`)
+  }
+}
+
+main()
+  .catch((err) => {
+    cleanupTmp()
+    fallbackNotice(`Unexpected error (${err && err.message ? err.message : err})`)
+  })
+  .finally(() => {
+    // Advisory step: a fetch problem must never fail the deploy.
+    process.exit(0)
+  })


### PR DESCRIPTION
## What

Keeps https://openadapt.ai/openadapt-paper.pdf always current with the LaTeX source in openadapt-flow, without a hand-committed copy that drifts. This is the **openadapt-web half** (fetch + propagation); the companion openadapt-flow PR publishes the `paper-latest` release asset.

## Changes

- **`scripts/fetch-paper-pdf.js`** (new): before `next build`, downloads the freshest PDF from
  `https://github.com/OpenAdaptAI/openadapt-flow/releases/download/paper-latest/openadapt-paper.pdf`,
  validates it is a real PDF (`%PDF` magic bytes) of non-trivial size (>= 20 KB), and atomically promotes it over `public/openadapt-paper.pdf`. On **any** failure (network, non-200, non-PDF, too-small, timeout) it keeps the committed fallback, logs a clear warning, and **always exits 0** so a transient fetch problem can never break a deploy.
- **`package.json`**: `prebuild` now runs `fetch:paper` then the 93 honesty guards. Netlify's `npm run build` therefore self-heals the served PDF on every deploy.
- **`.github/workflows/paper-redeploy.yml`** (new): receives openadapt-flow's `paper-updated` `repository_dispatch` and POSTs to a Netlify build hook (`secrets.NETLIFY_BUILD_HOOK_URL`) to trigger a redeploy. Best-effort; a logged no-op if the secret is unset.
- **`.gitignore`**: ignore the transient temp file the fetch script writes.

## Propagation (how openadapt-web actually deploys)

openadapt-web deploys via **Netlify's git integration** (see `netlify.toml`, build command `npm run build`), not GitHub Actions. So:
1. Primary + self-healing: every Netlify build runs the prebuild fetch and pulls the latest release asset.
2. Prompt propagation: flow's publish -> `paper-updated` dispatch -> this workflow -> Netlify build hook -> redeploy.

## Fallback / coordination

The committed `public/openadapt-paper.pdf` is left untouched here and serves as the fallback (a concurrent PR is republishing its bytes). The fetch overrides it at build time.

## CI
- 93/93 honesty guards pass locally. `prebuild` chain verified (fetch fallback on 404 then guards green). Fetch tested against a valid PDF (promotes) and 404 (falls back), exit 0 in both.
- Not live until merged + deployed.