### PR TITLE
feat(hero): advertise governed AI repair + unify three-CTA hierarchy

### DIFF
--- a/components/MastHead.js
+++ b/components/MastHead.js
@@ -54,9 +54,10 @@ export default function Home({ githubStats }) {
                                 Demonstrate a repeated task once. OpenAdapt
                                 compiles it into a local program that replays at
                                 $0 per healthy run across browser, Windows,
-                                macOS, RDP, and Citrix. It re-checks its
-                                evidence at each step and halts for a person
-                                instead of guessing when the screen changes.{' '}
+                                macOS, RDP, and Citrix. When the screen changes,
+                                it re-checks its evidence, repairs with AI when
+                                it can, and halts for a person instead of
+                                guessing.{' '}
                                 <Link href="#product-status">
                                     See how it runs across every interface.
                                 </Link>
@@ -69,17 +70,6 @@ export default function Home({ githubStats }) {
                             <div id="register">
                                 <div className="flex flex-wrap items-center justify-center gap-3 mt-0 mb-4">
                                     <Link
-                                        className="btn-ink"
-                                        href="#book"
-                                        onClick={() =>
-                                            track(EVENTS.HERO_CTA_CLICK, {
-                                                cta: 'qualify_workflow',
-                                            })
-                                        }
-                                    >
-                                        Evaluate a workflow
-                                    </Link>
-                                    <Link
                                         className={styles.heroCloud}
                                         href="#cloud-product"
                                         onClick={() =>
@@ -89,6 +79,17 @@ export default function Home({ githubStats }) {
                                         }
                                     >
                                         Start with OpenAdapt Cloud
+                                    </Link>
+                                    <Link
+                                        className="btn-ghost-ink"
+                                        href="#book"
+                                        onClick={() =>
+                                            track(EVENTS.HERO_CTA_CLICK, {
+                                                cta: 'qualify_workflow',
+                                            })
+                                        }
+                                    >
+                                        Evaluate a workflow
                                     </Link>
                                     <Link
                                         className="btn-ghost-ink"

--- a/components/MastHead.module.css
+++ b/components/MastHead.module.css
@@ -22,26 +22,30 @@
     color: var(--ink-3);
 }
 
-/* Elevated OpenAdapt Cloud CTA — an accent-tinted pill that stands out from
-   the ink primary and ghost secondary without competing as a second solid. */
+/* Primary hero CTA: the elevated OpenAdapt Cloud action. A single solid
+   accent pill sized to match the ghost secondaries (Evaluate a workflow / Try
+   locally) so the row reads as one primary plus a consistent secondary set,
+   not three competing styles. */
 .heroCloud {
     display: inline-flex;
     align-items: center;
     gap: 0.4em;
-    padding: 0.5rem 1.1rem;
+    padding: 10px 22px;
     border-radius: 9999px;
     border: 1.5px solid var(--accent);
-    background: color-mix(in srgb, var(--accent) 10%, transparent);
-    color: var(--accent);
+    background: var(--accent);
+    color: var(--ground);
+    font-size: 14px;
     font-weight: 600;
     text-decoration: none;
     transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
 }
 
 .heroCloud:hover {
-    background: var(--accent);
+    background: var(--accent-hover);
     color: var(--ground);
-    border-color: var(--accent);
+    border-color: var(--accent-hover);
+    text-decoration: none;
 }
 
 /* Mono green bordered pill above the H2 */

--- a/cypress/e2e/public-surface-coherence.cy.js
+++ b/cypress/e2e/public-surface-coherence.cy.js
@@ -14,7 +14,12 @@ describe('public surface coherence', () => {
             'contain.text',
             'stars on OpenAdapt'
         )
-        cy.get('a.btn-ink')
+        cy.contains('a', 'Start with OpenAdapt Cloud').should(
+            'have.attr',
+            'href',
+            '/#cloud-product'
+        )
+        cy.get('a.btn-ghost-ink')
             .contains('Evaluate a workflow')
             .should('have.attr', 'href', '/#book')
         cy.get('a.btn-ghost-ink')


### PR DESCRIPTION
Two hero changes on the homepage (`components/MastHead.js` + `components/MastHead.module.css`). Does not touch `ReplayHero.js` or `DashboardShowcase.js`.

## Change 1 — subcopy: advertise AI-assisted (governed) repair
Rewrote the final sentence so the healthy path stays deterministic and $0, AI is surfaced as governed **repair**, and a person remains the final backstop. It never guesses.

- **Before:** "It re-checks its evidence at each step and halts for a person instead of guessing when the screen changes."
- **After:** "When the screen changes, it re-checks its evidence, repairs with AI when it can, and halts for a person instead of guessing."

## Change 2 — fix the three-CTA styling
The row previously read as three competing styles (ink primary / accent-tinted pill / ghost outline). Now one primary plus a consistent secondary set:

- **Primary:** "Start with OpenAdapt Cloud" — solid accent pill (the elevated hosted product), sized to match the buttons (10px 22px, 14px).
- **Secondary (matching):** "Evaluate a workflow" and "Try locally" — identical `btn-ghost-ink` pills (same size / padding / weight).

Order leads with the primary. All three actions and hrefs are unchanged. No horizontal overflow at 320/375px (guarded by the homepage mobile Cypress spec).

## Verification
- 93 node honesty guards: **pass**
- `next build`: **pass**
- Full Cypress suite (34 tests, incl. the 375px scrollWidth overflow guard): **pass**
- Updated the `public-surface-coherence` assertion to select hero CTAs by text + href (the "Evaluate a workflow" CTA is no longer `btn-ink`), preserving intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM