### PR TITLE
copy: tighten landing page copy + consolidate reference label

### DIFF
--- a/components/CompiledProgramSection.js
+++ b/components/CompiledProgramSection.js
@@ -12,11 +12,11 @@ const FIGURES = [
         title: 'See what a demonstration compiled into.',
         body:
             'A recording under-specifies intent. The compiler turns it into a ' +
-            'program you can read before it ever runs: each step, the ' +
-            'resolution ladder it will try, where an identity gate is armed, ' +
-            'which writes carry an effect check, and every point the run is ' +
-            'allowed to halt. Render it from the CLI as a self-contained page ' +
-            'or Mermaid, or open the same graph in Cloud.',
+            'program you can read before it runs: each step, the resolution ' +
+            'ladder, where an identity gate is armed, which writes carry an ' +
+            'effect check, and every point the run can halt. Render it from the ' +
+            'CLI as a self-contained page or Mermaid, or open the same graph in ' +
+            'Cloud.',
         code: 'openadapt-flow visualize my-bundle --format html -o graph.html',
         image: '/cloud-preview/program-graph.png',
         alt:
@@ -32,9 +32,9 @@ const FIGURES = [
         body:
             'The catalog is a read-only readout across every compiled ' +
             'workflow: what each one automates, how its trials went, and the ' +
-            'return it stands to return. The step-level halt map shows where ' +
-            'runs stop and why, so you fix the demonstration or the policy at ' +
-            'the exact step instead of guessing.',
+            'return it stands to make. The step-level halt map shows where runs ' +
+            'stop and why, so you fix the demonstration or policy at the exact ' +
+            'step.',
         image: '/cloud-preview/workflow-catalog.png',
         alt:
             'OpenAdapt Cloud workflow catalog: a portfolio ROI readout with a ' +
@@ -57,12 +57,11 @@ export default function CompiledProgramSection() {
                         A demonstration compiles into a program you can inspect.
                     </h2>
                     <p className={styles.summary}>
-                        Compiling doesn&apos;t just replay one recorded path. A
-                        single demonstration can be authored into a governed
-                        loop that runs once per record of a worklist, bounded,
-                        identity-gated and effect-verified per record, and
-                        halting on ambiguity instead of guessing. That turns a
-                        replay of one path into governed execution over a queue.
+                        A single demonstration can become a governed loop that
+                        runs once per record in a worklist: bounded,
+                        identity-gated, and effect-verified per record, halting
+                        on ambiguity instead of guessing. One recorded path
+                        becomes governed execution over a queue.
                     </p>
                     <pre className={styles.queueCode}>
                         <code>

--- a/components/DriftOutcomes.js
+++ b/components/DriftOutcomes.js
@@ -10,7 +10,7 @@ const outcomes = [
     {
         status: 'Optional',
         title: 'AI-assisted proposal',
-        body: 'If deterministic evidence is insufficient and a model is configured, it can propose a target or confirm limited visual state. The model can be wrong; identity, policy, and postcondition gates still decide whether execution continues.',
+        body: 'If deterministic evidence is insufficient and a model is configured, it can propose a target or confirm limited visual state. The model can be wrong, so identity, policy, and postcondition gates still decide whether execution continues.',
     },
     {
         status: 'Operator path',

--- a/components/Faq.js
+++ b/components/Faq.js
@@ -1,15 +1,15 @@
 export const faqItems = [
     {
         question: 'What is OpenAdapt?',
-        answer: 'OpenAdapt is an open-source governed workflow compiler for repeated GUI work. You demonstrate a task, it compiles the trace into a deterministic local program, and configured verification decides whether UI drift can be re-resolved, needs a proposed repair, or must halt. A healthy replay makes no model calls.',
+        answer: 'OpenAdapt is an open-source governed workflow compiler for repeated GUI work. You demonstrate a task; it compiles the trace into a deterministic local program. Configured verification decides whether UI drift is re-resolved, needs a proposed repair, or must halt. A healthy replay makes no model calls.',
     },
     {
         question: 'How is OpenAdapt different from RPA tools like UiPath?',
-        answer: 'Conventional RPA is broad and mature, especially on Windows, but workflows are usually assembled around selectors and integrations. OpenAdapt targets the narrower case where work is repetitive and consequential but the interface is visual, variable, or integration-hostile. It compiles a demonstration and uses a resolution ladder under drift rather than asking a model to re-plan every run.',
+        answer: 'Conventional RPA is broad and mature, especially on Windows, but workflows are usually built around selectors and integrations. OpenAdapt targets the narrower case where work is repetitive and consequential but the interface is visual, variable, or integration-hostile. It compiles a demonstration and uses a resolution ladder under drift instead of asking a model to re-plan every run.',
     },
     {
         question: 'How is OpenAdapt different from AI computer-use agents?',
-        answer: 'A computer-use agent is appropriate for novel work because it can re-plan each run. OpenAdapt is for repeated work: healthy replay follows the compiled program locally with zero model calls. Under drift, deterministic structure, template, OCR, and geometry evidence run first. An optional model can propose a repair, but it does not make unsupported drift safe and remains subject to configured verification and policy.',
+        answer: 'A computer-use agent is appropriate for novel work because it can re-plan each run. OpenAdapt is for repeated work: healthy replay follows the compiled program locally with zero model calls. Under drift, deterministic structure, template, OCR, and geometry evidence run first. An optional model can propose a repair, but it does not make unsupported drift safe and stays subject to configured verification and policy.',
     },
     {
         question: 'Does “repair” mean every UI change is handled automatically?',

--- a/components/HomeReferenceWorkflow.js
+++ b/components/HomeReferenceWorkflow.js
@@ -110,7 +110,7 @@ export default function HomeReferenceWorkflow({ vertical, onSelectVertical }) {
             number: '1.0',
             name: 'Demonstrate',
             description:
-                'Complete one bounded, synthetic instance while OpenAdapt captures the browser evidence and input events.',
+                'Complete one bounded, synthetic instance while OpenAdapt captures browser evidence and input events.',
             visual: (
                 <Clip
                     key={`${reference.key}-record`}
@@ -134,7 +134,7 @@ export default function HomeReferenceWorkflow({ vertical, onSelectVertical }) {
             number: '3.0',
             name: 'Replay',
             description:
-                'Execute the compiled steps locally without asking a model to reinterpret the task.',
+                'Execute the compiled steps locally, with no model reinterpreting the task.',
             visual: (
                 <Clip
                     key={`${reference.key}-replay`}

--- a/components/HowItWorksCondensed.js
+++ b/components/HowItWorksCondensed.js
@@ -8,19 +8,19 @@ const steps = [
         number: '1',
         name: 'Record & compile',
         description:
-            'Demonstrate one bounded, repeated instance. OpenAdapt compiles the trace into a reviewable, parameterized program, not a prompt a model reinterprets each run.',
+            'Demonstrate one bounded, repeated task. OpenAdapt compiles the trace into a reviewable, parameterized program. Not a prompt a model rereads each run.',
     },
     {
         number: '2',
         name: 'Replay deterministically',
         description:
-            'Healthy runs execute the compiled steps locally with zero model calls, so repeat runs are fast and cost nothing per run.',
+            'Healthy runs execute the compiled steps locally with zero model calls. Repeat runs are fast and cost nothing per run.',
     },
     {
         number: '3',
         name: 'Resolve, repair, or halt',
         description:
-            'Under interface drift, deterministic evidence re-finds the target, an optional model proposes a governed repair, or configured verification halts and preserves a run report.',
+            'When the interface drifts, deterministic evidence re-finds the target, an optional model proposes a governed repair, or verification halts and keeps a run report.',
     },
 ]
 

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -136,11 +136,9 @@ export default function Pricing({ hostedOffer = null }) {
                 </h2>
                 <p className="mx-auto mt-3 max-w-2xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
                     Run the MIT-licensed engine yourself for free. Subscribe to
-                    OpenAdapt Cloud, the managed control plane that runs
-                    your approved workflows across every substrate with assisted
-                    onboarding. Or start a scoped paid pilot to bring regulated
-                    data and customer-controlled deployments under the same
-                    governance.
+                    OpenAdapt Cloud, the managed control plane that runs approved
+                    workflows across every substrate. Or start a scoped paid
+                    pilot for regulated data and customer-controlled deployments.
                 </p>
 
                 <div className="mt-10 grid items-start gap-6 md:grid-cols-3">
@@ -154,8 +152,8 @@ export default function Pricing({ hostedOffer = null }) {
                             <span className="text-sm text-ink-3">MIT</span>
                         </div>
                         <p className="mt-3 text-sm leading-relaxed text-ink-2">
-                            For builders and self-hosters who want it running on
-                            their own machines.
+                            For builders and self-hosters running it on their own
+                            machines.
                         </p>
                         <FeatureList
                             items={[
@@ -212,12 +210,12 @@ export default function Pricing({ hostedOffer = null }) {
                             </p>
                         )}
                         <p className="mt-3 text-sm leading-relaxed text-ink-2">
-                            The managed control plane for governed workflow
-                            execution across every substrate. Your approved
-                            workflows run in the managed runner with run history,
-                            reporting, and governed updates, across browser,
-                            Windows, macOS, RDP, and Citrix. Onboarding
-                            is assisted: we qualify the first workflow with you.
+                            The managed control plane for governed execution
+                            across every substrate: browser, Windows, macOS, RDP,
+                            and Citrix. Approved workflows run in the managed
+                            runner with run history, reporting, and governed
+                            updates. Onboarding is assisted: we qualify the first
+                            workflow with you.
                         </p>
                         <FeatureList
                             items={[
@@ -273,8 +271,8 @@ export default function Pricing({ hostedOffer = null }) {
                             Bring regulated data and customer-controlled
                             deployments under the same governed loop. We qualify
                             the artifact policy, effect oracle, and operating
-                            model with you inside your controlled boundary, then
-                            scope and price the pilot before production use.
+                            model inside your boundary, then scope and price the
+                            pilot before production use.
                         </p>
                         <FeatureList
                             items={[

--- a/components/ProductStatus.js
+++ b/components/ProductStatus.js
@@ -11,7 +11,7 @@ const workflow = [
     {
         number: '01',
         title: 'Capture the workflow',
-        detail: 'Demonstrate a bounded, repeated task, including the evidence OpenAdapt needs to identify targets and verify outcomes.',
+        detail: 'Demonstrate a bounded, repeated task, plus the evidence OpenAdapt needs to identify targets and verify outcomes.',
     },
     {
         number: '02',
@@ -79,9 +79,8 @@ export default function ProductStatus() {
                     One governed workflow, end to end
                 </h2>
                 <p className="mx-auto mt-3 max-w-3xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
-                    OpenAdapt turns a demonstration into an inspectable workflow
-                    that moves from local development to governed operation without
-                    changing the workflow model.
+                    A demonstration becomes an inspectable workflow that runs the
+                    same from local development through governed operation.
                 </p>
 
                 <ol className="mt-9 grid gap-4 md:grid-cols-2">
@@ -143,8 +142,8 @@ export default function ProductStatus() {
                         One governed loop across every surface
                     </h3>
                     <p className="mt-3 max-w-3xl text-sm leading-relaxed text-ink-2">
-                        Every surface below runs the same governed loop, with its
-                        label read directly from a single{' '}
+                        Every surface below runs the same governed loop. Each
+                        label is read from one{' '}
                         <a
                             href="/status.json"
                             target="_blank"
@@ -152,8 +151,8 @@ export default function ProductStatus() {
                             className="text-accent underline"
                         >
                             machine-readable status manifest
-                        </a>{' '}
-                        so the website, docs, launcher, and packages stay in
+                        </a>
+                        , so the website, docs, launcher, and packages stay in
                         lockstep.
                     </p>
                     <ul className="mt-6 grid gap-4 md:grid-cols-2">

--- a/components/Qualification.js
+++ b/components/Qualification.js
@@ -21,14 +21,14 @@ export default function Qualification() {
             className="border-b border-hairline bg-panel px-5 py-14 md:py-16"
         >
             <div className="mx-auto max-w-5xl">
-                <p className="eyebrow text-center">Is this the right tool?</p>
+                <p className="eyebrow text-center">The right fit</p>
                 <h2 className="mx-auto mt-2 max-w-2xl text-center font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl">
-                    Use APIs first. Use OpenAdapt for the UI-only last mile.
+                    Use OpenAdapt for the UI-only last mile.
                 </h2>
                 <p className="mx-auto mt-3 max-w-2xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
-                    OpenAdapt is deliberately narrow. It&rsquo;s for repeated,
-                    high-stakes GUI work that has no real API and can be checked
-                    against an independent source of truth.
+                    OpenAdapt is deliberately narrow: repeated, high-stakes GUI
+                    work that has no real API and can be checked against an
+                    independent source of truth.
                 </p>
                 <article className="mx-auto mt-8 max-w-2xl rounded-2xl border border-hairline bg-ground p-6 md:p-7">
                     <h3 className="font-display text-lg font-semibold tracking-tight text-ink">
@@ -50,10 +50,9 @@ export default function Qualification() {
                 </article>
                 <p className="mx-auto mt-6 max-w-2xl text-center text-sm leading-relaxed text-ink-3">
                     When work fits that shape, OpenAdapt runs it across every
-                    interface it touches, under one governed loop. That covers
-                    browser, Windows, macOS, RDP, and Citrix. See how it
-                    compares with RPA, computer-use agents, and browser recorders
-                    on the{' '}
+                    interface it touches under one governed loop: browser,
+                    Windows, macOS, RDP, and Citrix. See how it compares with
+                    RPA, computer-use agents, and browser recorders on the{' '}
                     <Link href="/compare" className="text-accent underline">
                         comparison page
                     </Link>

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -64,7 +64,7 @@ describe('public product truth', () => {
         // into a confident, positive statement — no disqualifier column, no
         // "when it isn't the right tool" section.
         cy.contains(
-            'Use APIs first. Use OpenAdapt for the UI-only last mile.'
+            'Use OpenAdapt for the UI-only last mile.'
         ).should('be.visible')
         cy.contains('When OpenAdapt fits').should('be.visible')
         cy.contains('OpenAdapt runs it across every').should('be.visible')

--- a/data/referenceWorkflows.js
+++ b/data/referenceWorkflows.js
@@ -30,7 +30,7 @@ export const HOME_REFERENCES = [
         // Exact label kept in sync with the reference list rendered from
         // pages/index.js (asserted by tests/insuranceReference.test.js).
         linkLabel: 'Healthcare workflow reference',
-        eyebrow: 'Real reference footage',
+        eyebrow: 'Real reference workflow',
         heading: 'From demonstration to a qualification-gated OpenEMR write',
         subheading:
             'Real OpenEMR footage on a pinned local instance. The effect oracle is deployment-specific and not established by this media.',


### PR DESCRIPTION
## Summary

The founder found the landing page too verbose. This tightens the homepage copy: cuts filler, redundancy, over-explanation, and hedging; prefers short punchy sentences. Every real fact, number, claim, and the target-state framing is preserved. Human-writing guide followed (no em dashes, plain phrasing, no "not just X but Y").

Also folds in two coordinator-requested consolidations.

## Biggest tightenings

- **Qualification** (coordinator ask): heading is now the positive lead **"Use OpenAdapt for the UI-only last mile."** Dropped the "Is this the right tool?" eyebrow and the "Use APIs first" directive (read as pointing people away before selling them). The no-clean-API fit stays covered in the fit criteria, so honesty is preserved.
- **Reference label** (coordinator ask): healthcare eyebrow `"Real reference footage"` -> `"Real reference workflow"` in `data/referenceWorkflows.js`, so all three verticals (healthcare/lending/insurance) share one term.
- **CompiledProgramSection**: removed a "Compiling doesn't just replay one recorded path" construction; rewrote the summary as a positive statement. Trimmed both figure bodies (e.g. "the return it stands to return" -> "the return it stands to make").
- **ProductStatus**: shortened the intro ("...moves from local development to governed operation without changing the workflow model" -> "...runs the same from local development through governed operation") and the manifest paragraph.
- **Pricing**: trimmed the section intro and all three card bodies (removed repeated "across every substrate with assisted onboarding" phrasing, folded the substrate list into the Cloud sentence).
- **HowItWorksCondensed / DriftOutcomes / HomeReferenceWorkflow / Faq**: removed hedging and connective filler; kept all facts ($500/month, MIT, zero model calls, provider names, verification model).

## Facts / claims preserved

All numbers, provider names, security-boundary language, and honesty envelopes are unchanged. Only phrasing was tightened.

## Test assertions updated

- `cypress/e2e/basic.cy.js`: the Qualification heading assertion `"Use APIs first. Use OpenAdapt for the UI-only last mile."` -> `"Use OpenAdapt for the UI-only last mile."` (matches the new heading; intent unchanged). All other asserted substrings kept intact.
- No `tests/*` honesty guard asserted the old "Real reference footage" or "Use APIs first" strings, so none needed weakening.

## Verification

- 93 honesty guards: **pass** (`node --test tests/*.test.js`)
- `next build`: **pass**
- Full Cypress suite (basic, public-surface-coherence, homepage-vertical-sync, dashboard-showcase, link-accessibility, download): **all green**
- Homepage rendered at desktop 1440 for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM