### PR TITLE
feat(home): add a compact PyPI install-stats strip below the hero

### DIFF
--- a/.github/workflows/refresh-install-stats.yml
+++ b/.github/workflows/refresh-install-stats.yml
@@ -1,0 +1,69 @@
+name: Refresh install stats
+
+# Scheduled snapshot for the homepage adoption section.
+#
+# The homepage renders installs-this-month / top-package / installs-over-time
+# from a COMMITTED snapshot at data/installStats.json. The site never calls
+# pypistats.org at build or request time (pypistats.org 429s aggressively), so
+# the section is always fast and can never break the page.
+#
+# This workflow is the only thing that refreshes that snapshot: weekly (and on
+# demand) it runs scripts/fetch-install-stats.js and, if the numbers changed,
+# opens a PR. Per repo policy it never pushes to main directly. If the fetch
+# fails the script keeps the committed snapshot and exits 0, so this workflow is
+# a safe no-op on a bad upstream day.
+
+on:
+  schedule:
+    # Mondays 06:00 UTC.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: refresh-install-stats
+  cancel-in-progress: true
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Fetch latest PyPI install stats
+        run: node scripts/fetch-install-stats.js
+
+      - name: Open a PR if the snapshot changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          if git diff --quiet -- data/installStats.json; then
+            echo "Install stats snapshot unchanged; nothing to do."
+            exit 0
+          fi
+
+          AS_OF=$(node -e "process.stdout.write(require('./data/installStats.json').asOf || 'unknown')")
+          TOTAL=$(node -e "process.stdout.write(String(require('./data/installStats.json').totalLastMonth || 0))")
+          BRANCH="chore/install-stats-${AS_OF}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${BRANCH}"
+          git add data/installStats.json
+          git commit -m "chore(stats): refresh homepage install snapshot (as of ${AS_OF})"
+          git push --force-with-lease origin "${BRANCH}"
+
+          gh pr create \
+            --base main \
+            --head "${BRANCH}" \
+            --title "chore(stats): refresh homepage install snapshot (${AS_OF})" \
+            --body "Automated weekly refresh of \`data/installStats.json\` (the committed snapshot the homepage adoption section renders from). Total installs last month: ${TOTAL}. Source: pypistats.org, mirror traffic excluded." \
+            || echo "::warning::Could not open PR (a PR for ${BRANCH} may already exist)."

--- a/components/InstallStats.js
+++ b/components/InstallStats.js
@@ -1,0 +1,128 @@
+import React from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faPython } from '@fortawesome/free-brands-svg-icons'
+
+import styles from './InstallStats.module.css'
+
+// Compact homepage adoption strip. Complements the hero's GitHub stars/forks
+// social proof with the one number the hero lacks: real PyPI installs.
+//
+// Renders entirely from a COMMITTED snapshot (data/installStats.json, refreshed
+// out-of-band by scripts/fetch-install-stats.js via the refresh-install-stats
+// workflow) that the page passes in through getStaticProps. It never fetches at
+// build or request time, so the strip is in the initial HTML and can never
+// block or break the page over a flaky/rate-limited pypistats.org -- unlike the
+// runtime-fetching chart on /download, this instance is non-blocking by
+// construction. `stats` may be null/empty -> the strip renders nothing.
+
+function formatCount(n) {
+    const value = Number(n) || 0
+    if (value >= 1000000) return `${(value / 1000000).toFixed(1)}M`
+    if (value >= 1000) return `${(value / 1000).toFixed(1)}k`
+    return value.toLocaleString()
+}
+
+function formatAsOf(asOf) {
+    if (!asOf) return ''
+    const date = new Date(`${asOf}T00:00:00Z`)
+    if (Number.isNaN(date.getTime())) return asOf
+    return date.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        timeZone: 'UTC',
+    })
+}
+
+// Tiny dependency-free inline-SVG sparkline of installs over time. No chart.js,
+// no client fetch; uses the site's CSS custom properties so it tracks the theme.
+function Sparkline({ history }) {
+    const points = (Array.isArray(history) ? history : []).filter(
+        (p) => p && Number.isFinite(Number(p.downloads))
+    )
+    if (points.length < 2) return null
+
+    const width = 96
+    const height = 26
+    const pad = 3
+    const values = points.map((p) => Number(p.downloads))
+    const max = Math.max(...values, 1)
+    const stepX = (width - pad * 2) / (points.length - 1)
+
+    const coords = points.map((p, i) => ({
+        x: pad + i * stepX,
+        y: pad + (height - pad * 2) * (1 - Number(p.downloads) / max),
+    }))
+    const linePath = coords
+        .map((c, i) => `${i === 0 ? 'M' : 'L'}${c.x.toFixed(1)},${c.y.toFixed(1)}`)
+        .join(' ')
+    const last = coords[coords.length - 1]
+
+    return (
+        <svg
+            className={styles.spark}
+            viewBox={`0 0 ${width} ${height}`}
+            role="img"
+            aria-label="PyPI installs trend over recent months"
+        >
+            <path className={styles.sparkLine} d={linePath} />
+            <circle className={styles.sparkDot} cx={last.x} cy={last.y} r={2.4} />
+        </svg>
+    )
+}
+
+export default function InstallStats({ stats = null }) {
+    const hasData =
+        stats &&
+        Number(stats.totalLastMonth) > 0 &&
+        Array.isArray(stats.packages) &&
+        stats.packages.length > 0
+
+    // Graceful empty state: render nothing rather than a broken strip. A valid
+    // snapshot is committed, so this should never trigger in practice.
+    if (!hasData) return null
+
+    const top = stats.topPackage || stats.packages[0]
+    const asOf = formatAsOf(stats.asOf)
+    const sourceUrl = stats.sourceUrl || 'https://pypistats.org/packages/openadapt'
+
+    return (
+        <aside className={styles.strip} aria-label="PyPI install statistics">
+            <div className={styles.inner}>
+                <span className={styles.metric}>
+                    <FontAwesomeIcon
+                        icon={faPython}
+                        className={styles.icon}
+                        aria-hidden="true"
+                    />
+                    <strong className={styles.value}>
+                        {formatCount(stats.totalLastMonth)}
+                    </strong>
+                    <span className={styles.label}>installs / month on PyPI</span>
+                </span>
+
+                <span className={styles.sep} aria-hidden="true" />
+
+                <span className={styles.metric}>
+                    <span className={styles.label}>top package</span>
+                    <strong className={styles.valueSmall}>{top.name}</strong>
+                </span>
+
+                <span className={styles.sep} aria-hidden="true" />
+
+                <Sparkline history={stats.history} />
+
+                <a
+                    className={styles.source}
+                    href={sourceUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title={`Source: ${stats.source || 'pypistats.org'}`}
+                >
+                    {stats.source || 'pypistats.org'}
+                    {asOf ? ` · snapshot as of ${asOf}` : ''}
+                </a>
+            </div>
+        </aside>
+    )
+}

--- a/components/InstallStats.module.css
+++ b/components/InstallStats.module.css
@@ -1,0 +1,117 @@
+/* Compact adoption strip: a slim social-proof band that sits under the hero and
+   complements the GitHub stars/forks proof with real PyPI install counts. */
+.strip {
+    background: var(--panel);
+    border-top: 1px solid var(--hairline);
+    border-bottom: 1px solid var(--hairline);
+    padding: 0.7rem 1.25rem;
+}
+
+.inner {
+    max-width: 960px;
+    margin: 0 auto;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 0.55rem 1rem;
+}
+
+.metric {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.4rem;
+    min-width: 0;
+}
+
+.icon {
+    color: var(--accent);
+    font-size: 0.9rem;
+    align-self: center;
+}
+
+.value {
+    font-family: var(--font-display);
+    font-weight: 700;
+    color: var(--ink);
+    font-size: 1.05rem;
+    line-height: 1;
+}
+
+.valueSmall {
+    font-family: var(--font-mono);
+    font-weight: 600;
+    color: var(--ink);
+    font-size: 0.9rem;
+    overflow-wrap: anywhere;
+}
+
+.label {
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.02em;
+    color: var(--ink-3);
+    text-transform: uppercase;
+}
+
+.sep {
+    width: 1px;
+    align-self: stretch;
+    min-height: 1rem;
+    background: var(--hairline);
+}
+
+.spark {
+    width: 96px;
+    height: 26px;
+    display: block;
+}
+
+.sparkLine {
+    fill: none;
+    stroke: var(--accent);
+    stroke-width: 2;
+    stroke-linejoin: round;
+    stroke-linecap: round;
+    vector-effect: non-scaling-stroke;
+}
+
+.sparkDot {
+    fill: var(--accent);
+    stroke: var(--panel);
+    stroke-width: 1.5;
+}
+
+.source {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    color: var(--ink-3);
+    text-decoration: underline;
+    text-decoration-color: var(--link-underline);
+    text-underline-offset: 2px;
+    white-space: nowrap;
+}
+
+.source:hover {
+    color: var(--accent-hover);
+}
+
+@media (max-width: 620px) {
+    .strip {
+        padding: 0.65rem 1rem;
+    }
+
+    .inner {
+        gap: 0.4rem 0.75rem;
+    }
+
+    /* Hide the vertical dividers on small screens; the wrap gap is enough. */
+    .sep {
+        display: none;
+    }
+
+    .source {
+        white-space: normal;
+        text-align: center;
+    }
+}

--- a/data/installStats.json
+++ b/data/installStats.json
@@ -1,0 +1,75 @@
+{
+  "asOf": "2026-07-20",
+  "source": "pypistats.org",
+  "sourceUrl": "https://pypistats.org/packages/openadapt",
+  "note": "Excludes mirror traffic. Aggregated across core openadapt-* PyPI packages.",
+  "totalLastMonth": 16027,
+  "topPackage": {
+    "name": "openadapt-flow",
+    "lastMonth": 8139
+  },
+  "packages": [
+    {
+      "name": "openadapt-flow",
+      "lastDay": 1209,
+      "lastWeek": 7804,
+      "lastMonth": 8139
+    },
+    {
+      "name": "openadapt-capture",
+      "lastDay": 665,
+      "lastWeek": 2190,
+      "lastMonth": 2677
+    },
+    {
+      "name": "openadapt",
+      "lastDay": 227,
+      "lastWeek": 1317,
+      "lastMonth": 1841
+    },
+    {
+      "name": "openadapt-privacy",
+      "lastDay": 311,
+      "lastWeek": 1294,
+      "lastMonth": 1522
+    },
+    {
+      "name": "openadapt-types",
+      "lastDay": 114,
+      "lastWeek": 788,
+      "lastMonth": 954
+    },
+    {
+      "name": "openadapt-ml",
+      "lastDay": 121,
+      "lastWeek": 443,
+      "lastMonth": 894
+    }
+  ],
+  "history": [
+    {
+      "month": "2026-01",
+      "downloads": 882
+    },
+    {
+      "month": "2026-02",
+      "downloads": 3519
+    },
+    {
+      "month": "2026-03",
+      "downloads": 9122
+    },
+    {
+      "month": "2026-04",
+      "downloads": 1944
+    },
+    {
+      "month": "2026-05",
+      "downloads": 2304
+    },
+    {
+      "month": "2026-06",
+      "downloads": 3476
+    }
+  ]
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -12,6 +12,7 @@ import EmailForm from '@components/EmailForm'
 import Footer from '@components/Footer'
 import HomeReferenceWorkflow from '@components/HomeReferenceWorkflow'
 import HowItWorksCondensed from '@components/HowItWorksCondensed'
+import InstallStats from '@components/InstallStats'
 import MastHead from '@components/MastHead'
 import Pricing from '@components/Pricing'
 import ProductStatus from '@components/ProductStatus'
@@ -138,13 +139,18 @@ export async function getStaticProps() {
     ])
     const { getHostedOffer } = await import('../lib/hostedOffer')
     const hostedOffer = await getHostedOffer()
+    // Adoption proof renders from a committed snapshot (data/installStats.json),
+    // refreshed out-of-band by the refresh-install-stats workflow. Reading it
+    // here means the homepage never calls pypistats.org at build or request
+    // time, so this section can never block or break the page.
+    const { default: installStats } = await import('../data/installStats.json')
     return {
-        props: { githubStats, buildWarnings, hostedOffer },
+        props: { githubStats, buildWarnings, hostedOffer, installStats },
         revalidate: 300,
     }
 }
 
-export default function Home({ githubStats, buildWarnings, hostedOffer }) {
+export default function Home({ githubStats, buildWarnings, hostedOffer, installStats }) {
     const router = useRouter()
     // ONE lifted selection shared by every reference-aware homepage section:
     // the process/reference-workflow demo and the "More reference workflows"
@@ -197,6 +203,7 @@ export default function Home({ githubStats, buildWarnings, hostedOffer }) {
                 />
             </Head>
             <MastHead githubStats={githubStats} />
+            <InstallStats stats={installStats} />
             <Reveal>
                 <HowItWorksCondensed />
             </Reveal>

--- a/scripts/fetch-install-stats.js
+++ b/scripts/fetch-install-stats.js
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+/**
+ * Scheduled snapshot fetch for the homepage install-stats visual.
+ *
+ * The homepage renders PyPI adoption (installs this month, top package, and an
+ * installs-over-time plot) from a COMMITTED snapshot at data/installStats.json.
+ * The site never calls pypistats.org at build or request time -- it reads the
+ * committed JSON in getStaticProps. That keeps the homepage always fast and
+ * impossible to break over a flaky/rate-limited upstream (pypistats.org 429s
+ * aggressively; see pages/api/pypistats/[package].js for the history).
+ *
+ * This script is the ONLY thing that talks to pypistats.org. It is run by the
+ * scheduled GitHub Action (.github/workflows/refresh-install-stats.yml), which
+ * opens a PR with the refreshed JSON. It can also be run by hand:
+ *
+ *     node scripts/fetch-install-stats.js
+ *
+ * Safety contract (never emit a broken snapshot):
+ *   - Fetch everything first, aggregate, and VALIDATE before writing.
+ *   - Write to a temp file, then promote, so a partial run can never replace a
+ *     good committed snapshot.
+ *   - On ANY failure (network, non-200, empty/short data, validation) keep the
+ *     committed data/installStats.json untouched and exit 0. The snapshot is
+ *     advisory: it upgrades the committed numbers when it can, else no-op.
+ *   - `mirrors=false` so counts reflect real installs, not mirror traffic.
+ */
+
+const fs = require('node:fs')
+const path = require('node:path')
+
+// Core, user-facing openadapt packages. Dev tools (herald/crier/wright/etc.)
+// and internal infra are intentionally excluded so the homepage number is
+// "people installing the product", not automation noise. Keep in sync with the
+// core set in lib/packageDiscovery.js.
+const PACKAGES = [
+  'openadapt',
+  'openadapt-flow',
+  'openadapt-capture',
+  'openadapt-ml',
+  'openadapt-types',
+  'openadapt-privacy',
+]
+
+const DEST = path.join(__dirname, '..', 'data', 'installStats.json')
+const TMP = path.join(__dirname, '..', 'data', '.installStats.json.tmp')
+
+const TIMEOUT_MS = 20000
+const MAX_RETRIES = 4
+// pypistats.org retains ~180 days of daily "overall" data. Anything shorter
+// than this many aggregated months is almost certainly a truncated fetch.
+const MIN_HISTORY_MONTHS = 2
+
+function warn(msg) {
+  console.warn(`[fetch-install-stats] WARNING: ${msg}`)
+}
+function info(msg) {
+  console.log(`[fetch-install-stats] ${msg}`)
+}
+
+function keepFallback(reason) {
+  if (fs.existsSync(DEST)) {
+    warn(
+      `${reason}. Keeping committed snapshot at data/installStats.json ` +
+        `(the homepage numbers may be stale until the next successful run).`
+    )
+  } else {
+    warn(
+      `${reason}. No committed data/installStats.json exists; the homepage ` +
+        `install-stats section will render its empty fallback until a run succeeds.`
+    )
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function fetchJson(url) {
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
+    let res
+    try {
+      res = await fetch(url, {
+        signal: controller.signal,
+        headers: { 'User-Agent': 'openadapt-web install-stats snapshot' },
+      })
+    } catch (error) {
+      clearTimeout(timer)
+      if (attempt === MAX_RETRIES) throw error
+      await sleep(Math.min(8000, 800 * 2 ** attempt) * (0.5 + Math.random()))
+      continue
+    }
+    clearTimeout(timer)
+
+    if (res.ok) return res.json()
+
+    const retryable = res.status === 429 || res.status >= 500
+    if (!retryable || attempt === MAX_RETRIES) {
+      const err = new Error(`pypistats.org returned ${res.status} for ${url}`)
+      err.status = res.status
+      throw err
+    }
+    const retryAfter = Number(res.headers.get('retry-after'))
+    const backoff = Math.min(8000, 800 * 2 ** attempt) * (0.5 + Math.random())
+    const wait =
+      Number.isFinite(retryAfter) && retryAfter > 0
+        ? Math.min(retryAfter * 1000, 10000)
+        : backoff
+    await sleep(wait)
+  }
+  throw new Error(`pypistats.org fetch failed for ${url}`)
+}
+
+async function fetchRecent(pkg) {
+  const data = await fetchJson(
+    `https://pypistats.org/api/packages/${pkg}/recent?mirrors=false`
+  )
+  const d = (data && data.data) || {}
+  return {
+    name: pkg,
+    lastDay: Number(d.last_day) || 0,
+    lastWeek: Number(d.last_week) || 0,
+    lastMonth: Number(d.last_month) || 0,
+  }
+}
+
+// Aggregate daily "overall" (mirrors excluded) into a per-month combined total
+// across all packages. Returns a Map<'YYYY-MM', downloads>.
+async function accumulateMonthly(pkg, monthly) {
+  const data = await fetchJson(
+    `https://pypistats.org/api/packages/${pkg}/overall?mirrors=false`
+  )
+  const rows = (data && data.data) || []
+  for (const row of rows) {
+    if (!row || !row.date) continue
+    const month = String(row.date).slice(0, 7) // YYYY-MM
+    monthly.set(month, (monthly.get(month) || 0) + (Number(row.downloads) || 0))
+  }
+}
+
+async function main() {
+  info(`Fetching PyPI stats for ${PACKAGES.length} packages from pypistats.org`)
+
+  let recents
+  const monthly = new Map()
+  try {
+    recents = []
+    for (const pkg of PACKAGES) {
+      recents.push(await fetchRecent(pkg))
+      await sleep(1500) // be polite to pypistats.org; avoid 429s
+    }
+    for (const pkg of PACKAGES) {
+      await accumulateMonthly(pkg, monthly)
+      await sleep(1500)
+    }
+  } catch (error) {
+    keepFallback(`Upstream fetch failed (${error.message})`)
+    return
+  }
+
+  // Build the monthly history series, oldest -> newest. Drop the current
+  // (in-progress) partial month so the plot never shows a misleading dip.
+  const nowMonth = new Date().toISOString().slice(0, 7)
+  const history = Array.from(monthly.entries())
+    .filter(([month]) => month < nowMonth)
+    .sort((a, b) => (a[0] < b[0] ? -1 : 1))
+    .map(([month, downloads]) => ({ month, downloads }))
+
+  const totalLastMonth = recents.reduce((acc, p) => acc + p.lastMonth, 0)
+  const packages = recents
+    .slice()
+    .sort((a, b) => b.lastMonth - a.lastMonth)
+  const topPackage = packages[0] || null
+
+  // Validation: refuse to write a snapshot that would degrade the homepage.
+  if (!Number.isFinite(totalLastMonth) || totalLastMonth <= 0) {
+    keepFallback('Aggregated last-month total is zero or invalid')
+    return
+  }
+  if (!topPackage || topPackage.lastMonth <= 0) {
+    keepFallback('No package has a positive last-month total')
+    return
+  }
+  if (history.length < MIN_HISTORY_MONTHS) {
+    keepFallback(
+      `Only ${history.length} full month(s) of history (need >= ${MIN_HISTORY_MONTHS})`
+    )
+    return
+  }
+
+  const snapshot = {
+    asOf: new Date().toISOString().slice(0, 10), // YYYY-MM-DD
+    source: 'pypistats.org',
+    sourceUrl: 'https://pypistats.org/packages/openadapt',
+    note: 'Excludes mirror traffic. Aggregated across core openadapt-* PyPI packages.',
+    totalLastMonth,
+    topPackage: { name: topPackage.name, lastMonth: topPackage.lastMonth },
+    packages: packages.map((p) => ({
+      name: p.name,
+      lastDay: p.lastDay,
+      lastWeek: p.lastWeek,
+      lastMonth: p.lastMonth,
+    })),
+    history,
+  }
+
+  try {
+    fs.writeFileSync(TMP, JSON.stringify(snapshot, null, 2) + '\n')
+    fs.renameSync(TMP, DEST)
+  } catch (error) {
+    try {
+      if (fs.existsSync(TMP)) fs.unlinkSync(TMP)
+    } catch (_) {
+      /* best-effort */
+    }
+    keepFallback(`Could not write snapshot (${error.message})`)
+    return
+  }
+
+  info(
+    `Wrote data/installStats.json: ${totalLastMonth.toLocaleString()} installs ` +
+      `last month across ${packages.length} packages; top = ${topPackage.name} ` +
+      `(${topPackage.lastMonth.toLocaleString()}); ${history.length} months of history.`
+  )
+}
+
+main().catch((error) => {
+  // Absolute last-resort guard: never fail the workflow over a snapshot.
+  keepFallback(`Unexpected error (${error && error.message})`)
+  process.exit(0)
+})

--- a/tests/installStats.test.js
+++ b/tests/installStats.test.js
@@ -1,0 +1,90 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+const root = path.join(__dirname, '..')
+const read = (relativePath) =>
+    fs.readFileSync(path.join(root, relativePath), 'utf8')
+
+const snapshot = JSON.parse(read('data/installStats.json'))
+
+// The homepage adoption section renders from this committed snapshot. Guard the
+// shape so a bad refresh (or a hand-edit) can't ship a broken/empty section.
+test('install-stats snapshot has a presentable, well-formed shape', () => {
+    assert.ok(
+        Number.isInteger(snapshot.totalLastMonth) && snapshot.totalLastMonth > 0,
+        'totalLastMonth must be a positive integer'
+    )
+    assert.ok(
+        Array.isArray(snapshot.packages) && snapshot.packages.length > 0,
+        'packages must be a non-empty array'
+    )
+    for (const pkg of snapshot.packages) {
+        assert.match(pkg.name, /^openadapt(-[a-z]+)?$/, 'package names are openadapt-*')
+        assert.ok(Number.isFinite(pkg.lastMonth), 'each package has a numeric lastMonth')
+    }
+    assert.ok(snapshot.topPackage && snapshot.topPackage.name, 'topPackage is set')
+    assert.ok(
+        Array.isArray(snapshot.history) && snapshot.history.length >= 2,
+        'history must carry at least two months so the plot can draw a trend'
+    )
+    for (const point of snapshot.history) {
+        assert.match(point.month, /^\d{4}-\d{2}$/, 'history months are YYYY-MM')
+        assert.ok(Number.isFinite(point.downloads), 'history points are numeric')
+    }
+})
+
+// Honesty: the snapshot must be dated and attributed, and the section must
+// surface that provenance so real numbers never read as live/unsourced.
+test('install-stats snapshot is dated and attributed', () => {
+    assert.match(snapshot.asOf, /^\d{4}-\d{2}-\d{2}$/, 'asOf is an ISO date')
+    assert.ok(
+        !Number.isNaN(new Date(`${snapshot.asOf}T00:00:00Z`).getTime()),
+        'asOf is a real date'
+    )
+    assert.match(snapshot.source, /pypistats/i, 'source names pypistats')
+})
+
+test('install-stats section shows the snapshot date and source, not a live claim', () => {
+    const component = read('components/InstallStats.js')
+    assert.match(component, /snapshot as of/, 'renders an "as of" freshness label')
+    assert.match(component, /stats\.source/, 'renders the data source')
+    assert.doesNotMatch(
+        component,
+        /\blive\b/i,
+        'must not imply the numbers are live — it is a dated snapshot'
+    )
+})
+
+// The whole point of the snapshot pipeline: this section must never fetch at
+// build or request time. No runtime data fetch, no pypistats.org URL, no
+// api.github.com URL constructed in the component. It renders from props only.
+test('install-stats section never fetches at runtime', () => {
+    const component = read('components/InstallStats.js')
+    assert.doesNotMatch(component, /\bfetch\s*\(/, 'no fetch() in the section')
+    assert.doesNotMatch(component, /useEffect/, 'no client data-loading effect')
+    assert.doesNotMatch(
+        component,
+        /pypistats\.org\/api/,
+        'no pypistats API URL in the section'
+    )
+    assert.doesNotMatch(
+        component,
+        /api\.github\.com/,
+        'no api.github.com URL in the section'
+    )
+})
+
+// The homepage must feed the snapshot in through getStaticProps (server-side),
+// so the section is part of the initial HTML and independent of client network.
+test('homepage renders install stats from a server-side snapshot prop', () => {
+    const index = read('pages/index.js')
+    assert.match(index, /import InstallStats from '@components\/InstallStats'/)
+    assert.match(index, /data\/installStats\.json/, 'snapshot read in getStaticProps')
+    assert.match(
+        index,
+        /<InstallStats stats=\{installStats\} \/>/,
+        'section is passed the server-loaded snapshot'
+    )
+})


### PR DESCRIPTION
## What

Adds a compact **PyPI install-stats strip** on the homepage, directly under the hero, to complement the hero's GitHub stars/forks social proof with the one number it lacks: real installs.

## Context (not a removal)

The install-stats chart is **already live on `/download`** (relocated there from the homepage in #223 as a homepage-focus refactor). This PR does **not** touch `/download`; it adds a homepage strip.

The `/download` chart is a **runtime client-side fetch** (`react-chartjs-2` + `useEffect` -> `/api/pypistats/*` -> pypistats.org). Reusing it verbatim on the homepage would reintroduce a slow/blocking fetch, so this strip renders from a committed snapshot instead (non-blocking by construction).

## Current numbers (real, presentable -> GO)

pypistats.org, mirror traffic excluded, as of 2026-07-20:

| Package | installs / month |
|---|---|
| openadapt-flow | 8,139 (top) |
| openadapt-capture | 2,677 |
| openadapt | 1,841 |
| openadapt-privacy | 1,522 |
| openadapt-types | 954 |
| openadapt-ml | 894 |
| **Total** | **16,027** |

## Presentation (compact, does not dominate)

`components/InstallStats.js` -- a slim strip: `16.0k installs / month on PyPI · top package openadapt-flow · <tiny inline-SVG sparkline> · pypistats.org · snapshot as of <date>`. Theme-aware (site CSS tokens), dependency-free, no runtime fetch. Wraps to 3 lines on mobile. Renders nothing on an empty/missing snapshot.

`pages/index.js`: one import + one placement (right after `MastHead`) + a server-side snapshot read in `getStaticProps`. Minimal, to stay clear of concurrent homepage edits.

## Data pipeline (robust snapshot, not a fragile live fetch)

- `data/installStats.json` -- committed snapshot the strip renders from.
- `scripts/fetch-install-stats.js` -- fetches recent + overall stats for core `openadapt-*` packages, aggregates monthly history, **validates**, writes JSON; on ANY failure keeps the committed snapshot and exits 0.
- `.github/workflows/refresh-install-stats.yml` -- weekly + on-demand refresh that **opens a PR** (never pushes to main).

Honesty: "snapshot as of &lt;date&gt;" with a pypistats.org source link; never implies live.

## Guards / CI

- `tests/installStats.test.js`: snapshot shape/attribution, no runtime fetch, homepage feeds it server-side.
- Node test suite green (**98**, was 93). Existing Cypress e2e green (34). `next build` green.

## Screenshots

Rendered to `/private/tmp/claude-501/install-stats/home-stats{,-hero,-mobile}.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM
