### PR TITLE
fix(workflows): stop catalog cards overflowing the viewport horizontally

### DIFF
--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -581,6 +581,53 @@ describe('public product truth', () => {
         ).should('be.visible')
     })
 
+    it('renders /workflows fully readable with no horizontal overflow on mobile', () => {
+        // Regression guard: catalog entries embed long unbreakable tokens
+        // (64-char SHA-256 hashes, commit ids) and a non-wrapping <pre>
+        // reproduction command. In implicit `auto` grid tracks these stretched
+        // each card far past the viewport, and body { overflow-x: hidden }
+        // clipped the excess with no way to scroll to it. Note that
+        // documentElement.scrollWidth is itself clamped by overflow-x: hidden,
+        // so we assert on real element geometry instead: no element may extend
+        // past the viewport's right edge.
+        cy.viewport(375, 812)
+        cy.visit('/workflows')
+        cy.contains('The workflows we').should('be.visible')
+        cy.contains('12/12 model-free rows correct')
+            .scrollIntoView()
+            .should('be.visible')
+        cy.window().then((win) => {
+            const doc = win.document
+            const viewportWidth = doc.documentElement.clientWidth
+            // Overflow is only acceptable when it lives inside a reachable
+            // scroll container (e.g. the reproduction <pre> with overflow-x
+            // auto). Any element extending past the viewport that is NOT inside
+            // such a container is clipped-and-unreachable — the reported bug.
+            const inScrollContainer = (el) => {
+                let node = el.parentElement
+                while (node) {
+                    const overflowX =
+                        win.getComputedStyle(node).overflowX
+                    if (overflowX === 'auto' || overflowX === 'scroll') {
+                        return true
+                    }
+                    node = node.parentElement
+                }
+                return false
+            }
+            const clipped = []
+            doc.querySelectorAll('body *').forEach((el) => {
+                if (
+                    el.getBoundingClientRect().right > viewportWidth + 1 &&
+                    !inScrollContainer(el)
+                ) {
+                    clipped.push(el.tagName + '.' + el.className)
+                }
+            })
+            expect(clipped, 'elements clipped past viewport').to.deep.equal([])
+        })
+    })
+
     it('starts the configured hosted checkout path', () => {
         cy.intercept('GET', '**/_next/data/**/pricing.json*', {
             statusCode: 200,

--- a/pages/workflows.js
+++ b/pages/workflows.js
@@ -23,11 +23,11 @@ const webPageSchema = {
 
 function Field({ label, children }) {
     return (
-        <div className="border-t border-hairline pt-4">
+        <div className="min-w-0 border-t border-hairline pt-4">
             <dt className="font-display text-xs font-semibold uppercase tracking-wide text-ink-3">
                 {label}
             </dt>
-            <dd className="mt-2 text-sm leading-relaxed text-ink-2">
+            <dd className="mt-2 break-words text-sm leading-relaxed text-ink-2">
                 {children}
             </dd>
         </div>
@@ -41,7 +41,7 @@ function CatalogEntry({ entry }) {
             className="rounded-2xl border-2 border-ink bg-panel p-6 md:p-8"
         >
             <div className="flex flex-wrap items-start justify-between gap-3">
-                <div>
+                <div className="min-w-0">
                     <p className="eyebrow">{entry.industry}</p>
                     <h2 className="font-display mt-2 text-2xl font-semibold tracking-tight text-ink">
                         {entry.application}{' '}
@@ -82,7 +82,7 @@ function CatalogEntry({ entry }) {
                 </p>
             </div>
 
-            <dl className="mt-6 grid gap-5 md:grid-cols-2">
+            <dl className="mt-6 grid grid-cols-1 gap-5 md:grid-cols-2">
                 <Field label="Task">{entry.task}</Field>
                 <Field label="Recording / bundle">
                     {entry.recording}{' '}
@@ -199,7 +199,7 @@ export default function WorkflowsPage() {
                     <p className="font-display text-sm font-semibold text-ink">
                         Execution substrates
                     </p>
-                    <ul className="mt-3 grid gap-2 text-sm text-ink-2 sm:grid-cols-2">
+                    <ul className="mt-3 grid grid-cols-1 gap-2 text-sm text-ink-2 sm:grid-cols-2">
                         <li>
                             <strong className="text-ink">Browser</strong> —{' '}
                             {SUBSTRATE_MATURITY.browser} (every catalog entry
@@ -226,7 +226,7 @@ export default function WorkflowsPage() {
             </div>
 
             <div className="mx-auto max-w-4xl px-4 pb-16">
-                <div className="grid gap-8">
+                <div className="grid grid-cols-1 gap-8">
                     {CATALOG.map((entry) => (
                         <CatalogEntry key={entry.id} entry={entry} />
                     ))}


### PR DESCRIPTION
## Problem
On `/workflows`, each workflow catalog card overflowed to the right at narrow widths. Because `html`/`body` set `overflow-x: hidden`, the clipped content was **unreachable** (no horizontal scroll), so parts of every workflow were cut off and unreadable. This matches the founder's report exactly.

## Root cause
The card grid, the per-entry field grid, and the substrate list all used **implicit `auto` grid tracks** (no `grid-cols-1`). An `auto` grid track sizes to its content's max-content and does **not** clamp to the container, so:

- the non-wrapping reproduction `<pre>` command, and
- the 64-char SHA-256 hashes / commit ids in the fields

stretched each `<article>` to ~1460px on a 375px viewport. `overflow-wrap: break-word` (Tailwind `break-words`) does **not** fix this on its own because it does not reduce an element's intrinsic/max-content width — it only breaks once a definite width is imposed.

## Fix
- Give the card grid, field grid, and substrate list an explicit `grid-cols-1` base (`minmax(0, 1fr)`), imposing a definite track width. Content now wraps, and the reproduction `<pre>`'s existing `overflow-x-auto` becomes a genuinely reachable scroll container for the one intentionally-wide element.
- Add `break-words` + `min-w-0` on the fields and the header column as belt-and-suspenders.

Content is now fully readable at 320 / 375 / 768 / 1440 with no page-level horizontal overflow. The two-column desktop layout is unchanged.

## Tests
- 93 Node guard tests: green.
- `next build`: green.
- Cypress `basic.cy.js`: 16/16 green, including a new regression guard that loads `/workflows` at 375 and asserts no element extends past the viewport unless it lives inside a scrollable container. (Note: `documentElement.scrollWidth` is itself clamped by `overflow-x: hidden`, so the guard checks real element geometry instead — the previous naive `scrollWidth` check would pass even while content was clipped.)

## Verification
Rendered `/workflows` at desktop 1440 and mobile 375 confirming the SHA-256 hash wraps in-cell and every workflow is fully visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM