### PR TITLE
feat(home): show the live cumulative-downloads chart on the homepage

### DIFF
--- a/components/InstallStats.js
+++ b/components/InstallStats.js
@@ -1,19 +1,31 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import dynamic from 'next/dynamic'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPython } from '@fortawesome/free-brands-svg-icons'
 
+import { getRecentDownloadStats } from 'utils/pypistatsHistory'
 import styles from './InstallStats.module.css'
 
-// Compact homepage adoption strip. Complements the hero's GitHub stars/forks
-// social proof with the one number the hero lacks: real PyPI installs.
+// Homepage adoption section: the SAME cumulative downloads-over-time chart the
+// /download page shows (components/PyPIDownloadChart in its compact cumulative
+// mode), plus a headline caption.
 //
-// Renders entirely from a COMMITTED snapshot (data/installStats.json, refreshed
-// out-of-band by scripts/fetch-install-stats.js via the refresh-install-stats
-// workflow) that the page passes in through getStaticProps. It never fetches at
-// build or request time, so the strip is in the initial HTML and can never
-// block or break the page over a flaky/rate-limited pypistats.org -- unlike the
-// runtime-fetching chart on /download, this instance is non-blocking by
-// construction. `stats` may be null/empty -> the strip renders nothing.
+// Fast + robust:
+//   - The caption's headline numbers are seeded from the committed snapshot
+//     (data/installStats.json) passed in via getStaticProps, so they are in the
+//     initial HTML and the section is never blank.
+//   - The chart is lazy-loaded (next/dynamic, ssr:false) so chart.js never
+//     bloats the initial homepage bundle or blocks first paint; a lightweight
+//     placeholder holds its space until it loads.
+//   - Both the chart and the caption then fetch LIVE client-side (same proxy /
+//     caching / 429 backoff as /download). The snapshot seeds the chart line and
+//     the caption so nothing waits on the network; live values replace them when
+//     they arrive, and if the fetch fails the snapshot simply stays shown.
+
+const PyPIDownloadChart = dynamic(() => import('./PyPIDownloadChart'), {
+    ssr: false,
+    loading: () => <div className={styles.chartPlaceholder} aria-hidden="true" />,
+})
 
 function formatCount(n) {
     const value = Number(n) || 0
@@ -22,107 +34,108 @@ function formatCount(n) {
     return value.toLocaleString()
 }
 
-function formatAsOf(asOf) {
-    if (!asOf) return ''
-    const date = new Date(`${asOf}T00:00:00Z`)
-    if (Number.isNaN(date.getTime())) return asOf
-    return date.toLocaleDateString('en-US', {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric',
-        timeZone: 'UTC',
-    })
-}
-
-// Tiny dependency-free inline-SVG sparkline of installs over time. No chart.js,
-// no client fetch; uses the site's CSS custom properties so it tracks the theme.
-function Sparkline({ history }) {
-    const points = (Array.isArray(history) ? history : []).filter(
-        (p) => p && Number.isFinite(Number(p.downloads))
-    )
-    if (points.length < 2) return null
-
-    const width = 96
-    const height = 26
-    const pad = 3
-    const values = points.map((p) => Number(p.downloads))
-    const max = Math.max(...values, 1)
-    const stepX = (width - pad * 2) / (points.length - 1)
-
-    const coords = points.map((p, i) => ({
-        x: pad + i * stepX,
-        y: pad + (height - pad * 2) * (1 - Number(p.downloads) / max),
+// Build a historyData-shaped seed from the committed snapshot so the reused
+// chart can paint a cumulative line instantly, before its live fetch resolves.
+function buildSeedHistory(stats) {
+    const history = Array.isArray(stats?.history) ? stats.history : []
+    if (history.length < 2) return null
+    const combined = history.map((h) => ({
+        date: `${h.month}-01`,
+        downloads: Number(h.downloads) || 0,
     }))
-    const linePath = coords
-        .map((c, i) => `${i === 0 ? 'M' : 'L'}${c.x.toFixed(1)},${c.y.toFixed(1)}`)
-        .join(' ')
-    const last = coords[coords.length - 1]
-
-    return (
-        <svg
-            className={styles.spark}
-            viewBox={`0 0 ${width} ${height}`}
-            role="img"
-            aria-label="PyPI installs trend over recent months"
-        >
-            <path className={styles.sparkLine} d={linePath} />
-            <circle className={styles.sparkDot} cx={last.x} cy={last.y} r={2.4} />
-        </svg>
-    )
+    let running = 0
+    const cumulativeHistory = combined.map((point) => {
+        running += point.downloads
+        return { date: point.date, downloads: running }
+    })
+    return {
+        combined,
+        cumulativeHistory,
+        packages: {},
+        packageNames: Array.isArray(stats?.packages)
+            ? stats.packages.map((p) => p.name)
+            : [],
+    }
 }
 
 export default function InstallStats({ stats = null }) {
-    const hasData =
+    const hasSeed =
         stats &&
         Number(stats.totalLastMonth) > 0 &&
         Array.isArray(stats.packages) &&
         stats.packages.length > 0
 
-    // Graceful empty state: render nothing rather than a broken strip. A valid
-    // snapshot is committed, so this should never trigger in practice.
-    if (!hasData) return null
+    const seedTop = hasSeed ? stats.topPackage || stats.packages[0] : null
 
-    const top = stats.topPackage || stats.packages[0]
-    const asOf = formatAsOf(stats.asOf)
-    const sourceUrl = stats.sourceUrl || 'https://pypistats.org/packages/openadapt'
+    // Headline numbers: seed from the snapshot, then update with live values.
+    const [totalMonth, setTotalMonth] = useState(
+        hasSeed ? stats.totalLastMonth : 0
+    )
+    const [topName, setTopName] = useState(seedTop ? seedTop.name : '')
+
+    useEffect(() => {
+        let cancelled = false
+        getRecentDownloadStats()
+            .then((live) => {
+                if (cancelled || !live) return
+                if (live.totals && live.totals.last_month > 0) {
+                    setTotalMonth(live.totals.last_month)
+                }
+                if (live.topPackage && live.topPackage.name) {
+                    setTopName(live.topPackage.name)
+                }
+            })
+            .catch(() => {
+                // Keep the snapshot-seeded numbers on any failure.
+            })
+        return () => {
+            cancelled = true
+        }
+    }, [])
+
+    // Graceful empty state: without a snapshot seed, render nothing rather than
+    // a blank/broken section. A valid snapshot is committed, so this should not
+    // trigger in practice.
+    if (!hasSeed) return null
+
+    const seedHistory = buildSeedHistory(stats)
 
     return (
-        <aside className={styles.strip} aria-label="PyPI install statistics">
+        <section className={styles.section} id="adoption" aria-label="Adoption">
             <div className={styles.inner}>
-                <span className={styles.metric}>
-                    <FontAwesomeIcon
-                        icon={faPython}
-                        className={styles.icon}
-                        aria-hidden="true"
-                    />
-                    <strong className={styles.value}>
-                        {formatCount(stats.totalLastMonth)}
-                    </strong>
-                    <span className={styles.label}>installs / month on PyPI</span>
-                </span>
+                <p className={styles.kicker}>Adoption</p>
+                <h2 className={styles.heading}>Installed from PyPI, and growing</h2>
+                <p className={styles.subtitle}>
+                    <strong className={styles.headline}>
+                        {formatCount(totalMonth)}
+                    </strong>{' '}
+                    installs a month across the OpenAdapt packages
+                    {topName ? (
+                        <>
+                            {' '}&middot; top package{' '}
+                            <span className={styles.top}>{topName}</span>
+                        </>
+                    ) : null}
+                </p>
 
-                <span className={styles.sep} aria-hidden="true" />
+                <div className={styles.chartCard}>
+                    <PyPIDownloadChart compact seedHistory={seedHistory} />
+                </div>
 
-                <span className={styles.metric}>
-                    <span className={styles.label}>top package</span>
-                    <strong className={styles.valueSmall}>{top.name}</strong>
-                </span>
-
-                <span className={styles.sep} aria-hidden="true" />
-
-                <Sparkline history={stats.history} />
-
-                <a
-                    className={styles.source}
-                    href={sourceUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    title={`Source: ${stats.source || 'pypistats.org'}`}
-                >
-                    {stats.source || 'pypistats.org'}
-                    {asOf ? ` · snapshot as of ${asOf}` : ''}
-                </a>
+                <p className={styles.attribution}>
+                    <FontAwesomeIcon icon={faPython} aria-hidden="true" /> Cumulative
+                    downloads over time, live from{' '}
+                    <a
+                        className={styles.sourceLink}
+                        href="https://pypistats.org/packages/openadapt-flow"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        pypistats.org
+                    </a>
+                    .
+                </p>
             </div>
-        </aside>
+        </section>
     )
 }

--- a/components/InstallStats.module.css
+++ b/components/InstallStats.module.css
@@ -1,117 +1,118 @@
-/* Compact adoption strip: a slim social-proof band that sits under the hero and
-   complements the GitHub stars/forks proof with real PyPI install counts. */
-.strip {
-    background: var(--panel);
+/* Homepage adoption section: a modest cumulative-downloads chart (reused from
+   /download) with a headline caption. Sized to complement the page, not
+   dominate it. Theme-aware via the site's CSS custom properties. */
+.section {
+    background: var(--ground);
     border-top: 1px solid var(--hairline);
     border-bottom: 1px solid var(--hairline);
-    padding: 0.7rem 1.25rem;
+    padding: 2.75rem 1.5rem;
 }
 
 .inner {
-    max-width: 960px;
+    max-width: 720px;
     margin: 0 auto;
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: center;
-    gap: 0.55rem 1rem;
+    text-align: center;
 }
 
-.metric {
-    display: inline-flex;
-    align-items: baseline;
-    gap: 0.4rem;
-    min-width: 0;
-}
-
-.icon {
+.kicker {
+    font-family: var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    font-size: 0.72rem;
     color: var(--accent);
-    font-size: 0.9rem;
-    align-self: center;
+    margin: 0 0 0.4rem;
 }
 
-.value {
+.heading {
+    font-family: var(--font-display);
+    color: var(--ink);
+    font-size: clamp(1.35rem, 3vw, 1.8rem);
+    line-height: 1.15;
+    margin: 0 0 0.5rem;
+}
+
+.subtitle {
+    color: var(--ink-2);
+    font-size: 0.98rem;
+    line-height: 1.5;
+    margin: 0 auto 1.5rem;
+    max-width: 48ch;
+}
+
+.headline {
     font-family: var(--font-display);
     font-weight: 700;
     color: var(--ink);
-    font-size: 1.05rem;
-    line-height: 1;
+    font-size: 1.15em;
 }
 
-.valueSmall {
+.top {
     font-family: var(--font-mono);
-    font-weight: 600;
-    color: var(--ink);
-    font-size: 0.9rem;
+    color: var(--accent);
     overflow-wrap: anywhere;
 }
 
-.label {
+.chartCard {
+    background: var(--panel);
+    border: 1px solid var(--hairline);
+    border-radius: 12px;
+    padding: 0.75rem;
+}
+
+/* Reserve the chart's height so lazy-loading never shifts the layout. */
+.chartPlaceholder {
+    height: 260px;
+    width: 100%;
+    border-radius: 8px;
+    background: linear-gradient(
+        100deg,
+        var(--panel) 30%,
+        var(--ground) 50%,
+        var(--panel) 70%
+    );
+    background-size: 200% 100%;
+    animation: installStatsShimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes installStatsShimmer {
+    0% {
+        background-position: 150% 0;
+    }
+    100% {
+        background-position: -50% 0;
+    }
+}
+
+.attribution {
     font-family: var(--font-mono);
     font-size: 0.72rem;
-    letter-spacing: 0.02em;
     color: var(--ink-3);
-    text-transform: uppercase;
+    margin: 0.85rem 0 0;
 }
 
-.sep {
-    width: 1px;
-    align-self: stretch;
-    min-height: 1rem;
-    background: var(--hairline);
-}
-
-.spark {
-    width: 96px;
-    height: 26px;
-    display: block;
-}
-
-.sparkLine {
-    fill: none;
-    stroke: var(--accent);
-    stroke-width: 2;
-    stroke-linejoin: round;
-    stroke-linecap: round;
-    vector-effect: non-scaling-stroke;
-}
-
-.sparkDot {
-    fill: var(--accent);
-    stroke: var(--panel);
-    stroke-width: 1.5;
-}
-
-.source {
-    font-family: var(--font-mono);
-    font-size: 0.7rem;
-    color: var(--ink-3);
+.sourceLink {
+    color: var(--accent);
     text-decoration: underline;
     text-decoration-color: var(--link-underline);
     text-underline-offset: 2px;
-    white-space: nowrap;
 }
 
-.source:hover {
+.sourceLink:hover {
     color: var(--accent-hover);
 }
 
-@media (max-width: 620px) {
-    .strip {
-        padding: 0.65rem 1rem;
+@media (max-width: 560px) {
+    .section {
+        padding: 2.25rem 1rem;
     }
 
-    .inner {
-        gap: 0.4rem 0.75rem;
+    .chartPlaceholder {
+        height: 220px;
     }
+}
 
-    /* Hide the vertical dividers on small screens; the wrap gap is enough. */
-    .sep {
-        display: none;
-    }
-
-    .source {
-        white-space: normal;
-        text-align: center;
+@media (prefers-reduced-motion: reduce) {
+    .chartPlaceholder {
+        animation: none;
     }
 }

--- a/components/PyPIDownloadChart.js
+++ b/components/PyPIDownloadChart.js
@@ -161,9 +161,14 @@ const packageColors = {
 // githubStats ({ stars, forks }) is server-rendered by the page's
 // getStaticProps — the browser must never call api.github.com (60 req/hr
 // per visitor IP means shared IPs get 403s).
-const PyPIDownloadChart = ({ githubStats = null }) => {
-    const [historyData, setHistoryData] = useState(null);
-    const [loading, setLoading] = useState(true);
+// compact: render only the cumulative line chart (no header/stats/controls/
+//   attribution) for embedding on the homepage. seedHistory: an initial
+//   historyData-shaped value (built from the committed snapshot) so the chart
+//   paints instantly and never blank/loading before the live fetch resolves;
+//   the live fetch then replaces it, and on failure the seed stays shown.
+const PyPIDownloadChart = ({ githubStats = null, compact = false, seedHistory = null }) => {
+    const [historyData, setHistoryData] = useState(seedHistory);
+    const [loading, setLoading] = useState(!seedHistory);
     const [error, setError] = useState(null);
     const [chartType, setChartType] = useState('cumulative'); // 'cumulative', 'combined', or 'packages'
     const [period, setPeriod] = useState('month');
@@ -174,7 +179,9 @@ const PyPIDownloadChart = ({ githubStats = null }) => {
 
     useEffect(() => {
         const fetchData = async () => {
-            setLoading(true);
+            // When seeded (homepage compact embed) keep the seed line visible
+            // during the refresh instead of flashing a spinner over it.
+            if (!seedHistory) setLoading(true);
             setError(null);
             try {
                 // Determine limit based on time range
@@ -190,7 +197,8 @@ const PyPIDownloadChart = ({ githubStats = null }) => {
 
                 if (!data.combined || data.combined.length === 0) {
                     setError('No download data available');
-                    setHistoryData(null);
+                    // Keep any seed so the embed never goes blank on empty data.
+                    if (!seedHistory) setHistoryData(null);
                 } else {
                     setHistoryData(data);
                     setGrowthStats(calculateGrowthStats(data.combined));
@@ -207,8 +215,11 @@ const PyPIDownloadChart = ({ githubStats = null }) => {
     }, [period, timeRange]);
 
     // Fetch recent stats and version history once on mount. GitHub stats
-    // are NOT fetched here — they arrive server-rendered via props.
+    // are NOT fetched here — they arrive server-rendered via props. In compact
+    // mode these feed only the hidden chrome, so skip them (the homepage
+    // caption does its own recent-stats fetch).
     useEffect(() => {
+        if (compact) return;
         const fetchAdditionalStats = async () => {
             try {
                 // Use Promise.allSettled to ensure all promises complete even if some fail
@@ -577,6 +588,29 @@ const PyPIDownloadChart = ({ githubStats = null }) => {
     const totalCumulative = historyData?.cumulativeHistory?.length > 0
         ? historyData.cumulativeHistory[historyData.cumulativeHistory.length - 1].downloads
         : 0;
+
+    // Compact homepage embed: just the cumulative line. The seed keeps a line
+    // on screen through refresh and failure, so we only surface the error
+    // overlay when there is nothing at all to draw.
+    if (compact) {
+        return (
+            <div className={styles.compactChart}>
+                {loading && (
+                    <div className={styles.loadingOverlay}>
+                        <div className={styles.spinner}></div>
+                        <span>Loading statistics...</span>
+                    </div>
+                )}
+                {chartData && <Line data={chartData} options={chartOptions} />}
+                {error && !chartData && (
+                    <div className={styles.errorOverlay}>
+                        <FontAwesomeIcon icon={faChartLine} className={styles.errorIcon} />
+                        <span>{error}</span>
+                    </div>
+                )}
+            </div>
+        );
+    }
 
     return (
         <div className={styles.container}>

--- a/components/PyPIDownloadChart.module.css
+++ b/components/PyPIDownloadChart.module.css
@@ -221,6 +221,20 @@
     border: 1px solid var(--hairline);
 }
 
+/* Compact homepage embed: modest height, bare (the homepage section owns the
+   surrounding card/caption). */
+.compactChart {
+    position: relative;
+    height: 260px;
+    width: 100%;
+}
+
+@media (max-width: 560px) {
+    .compactChart {
+        height: 220px;
+    }
+}
+
 /* Taller container for packages view with side legend */
 .chartContainerPackages {
     position: relative;

--- a/pages/index.js
+++ b/pages/index.js
@@ -203,7 +203,6 @@ export default function Home({ githubStats, buildWarnings, hostedOffer, installS
                 />
             </Head>
             <MastHead githubStats={githubStats} />
-            <InstallStats stats={installStats} />
             <Reveal>
                 <HowItWorksCondensed />
             </Reveal>
@@ -289,6 +288,9 @@ export default function Home({ githubStats, buildWarnings, hostedOffer, installS
             </Reveal>
             <Reveal>
                 <DriftOutcomes />
+            </Reveal>
+            <Reveal>
+                <InstallStats stats={installStats} />
             </Reveal>
             <Reveal>
                 <ProductStatus />

--- a/tests/installStats.test.js
+++ b/tests/installStats.test.js
@@ -46,34 +46,68 @@ test('install-stats snapshot is dated and attributed', () => {
     assert.match(snapshot.source, /pypistats/i, 'source names pypistats')
 })
 
-test('install-stats section shows the snapshot date and source, not a live claim', () => {
+// The section shows LIVE numbers with pypistats.org attribution. It must not
+// reintroduce the stale "snapshot as of <date>" wording (it is live now), but
+// it must still name the data source.
+test('install-stats section is attributed to pypistats and reads as live', () => {
     const component = read('components/InstallStats.js')
-    assert.match(component, /snapshot as of/, 'renders an "as of" freshness label')
-    assert.match(component, /stats\.source/, 'renders the data source')
+    assert.match(component, /pypistats\.org/, 'names the data source')
+    assert.match(component, /live from/i, 'reads as live, not a static snapshot')
     assert.doesNotMatch(
         component,
-        /\blive\b/i,
-        'must not imply the numbers are live — it is a dated snapshot'
+        /snapshot as of/i,
+        'must not show the stale "snapshot as of" label now that it is live'
     )
 })
 
-// The whole point of the snapshot pipeline: this section must never fetch at
-// build or request time. No runtime data fetch, no pypistats.org URL, no
-// api.github.com URL constructed in the component. It renders from props only.
-test('install-stats section never fetches at runtime', () => {
+// The section renders instantly without blocking on the network: the committed
+// snapshot seeds both the headline numbers and the chart line, and the LIVE
+// pypistats fetch is a client-side enhancement with a graceful fallback (it
+// keeps the seed on failure). The heavy chart is lazy-loaded so it never blocks
+// first paint or bloats the initial bundle.
+test('install-stats seeds from the snapshot, then fetches live client-side with a fallback', () => {
     const component = read('components/InstallStats.js')
-    assert.doesNotMatch(component, /\bfetch\s*\(/, 'no fetch() in the section')
-    assert.doesNotMatch(component, /useEffect/, 'no client data-loading effect')
-    assert.doesNotMatch(
+    // Seed / instant fallback: initial state comes from the `stats` prop.
+    assert.match(
         component,
-        /pypistats\.org\/api/,
-        'no pypistats API URL in the section'
+        /useState\(\s*\n?\s*hasSeed \? stats\.totalLastMonth/,
+        'headline seeds from the snapshot prop'
     )
-    assert.doesNotMatch(
+    assert.match(component, /buildSeedHistory/, 'chart line seeds from the snapshot')
+    assert.match(
         component,
-        /api\.github\.com/,
-        'no api.github.com URL in the section'
+        /seedHistory=\{seedHistory\}/,
+        'the seed is passed to the reused chart'
     )
+    // Live client-side fetch with a graceful catch that keeps the seed.
+    assert.match(component, /useEffect/, 'fetches live after render')
+    assert.match(
+        component,
+        /getRecentDownloadStats\(\)/,
+        'uses the same pypistats util as /download'
+    )
+    assert.match(component, /\.catch\(/, 'live fetch has a graceful fallback')
+    // Lazy-load the chart.js component so it does not block first paint.
+    assert.match(component, /next\/dynamic/, 'chart is lazy-loaded via next/dynamic')
+    assert.match(component, /ssr:\s*false/, 'chart is client-only (ssr: false)')
+    assert.match(component, /chartPlaceholder/, 'a placeholder holds space while it loads')
+})
+
+// The reused chart supports a compact, seedable embed without changing its
+// default /download behavior.
+test('PyPIDownloadChart supports a compact, seedable embed', () => {
+    const chart = read('components/PyPIDownloadChart.js')
+    assert.match(
+        chart,
+        /compact = false, seedHistory = null/,
+        'compact + seedHistory props default to the original /download behavior'
+    )
+    assert.match(
+        chart,
+        /useState\(seedHistory\)/,
+        'history state can be seeded so the embed is never blank'
+    )
+    assert.match(chart, /if \(compact\) \{/, 'compact mode renders a bare chart')
 })
 
 // The homepage must feed the snapshot in through getStaticProps (server-side),


### PR DESCRIPTION
## What

Follow-up to #245. The founder wants the homepage adoption section to show **LIVE** download numbers using the **same chart as `/download`** (the cumulative-downloads-over-time plot), not a static snapshot sparkline.

## How I reused the /download chart

`components/PyPIDownloadChart.js` (the exact chart on `/download`) gets two **additive, opt-in props** that leave its default `/download` behavior unchanged:

- `compact` -> renders only the cumulative `Line` (no header / stats grid / view+range toggles / attribution), for embedding.
- `seedHistory` -> an initial `historyData`-shaped value so the chart paints a line **instantly**, before its live fetch resolves; the seed also stays shown if the live fetch is empty or fails.

No chart logic was reimplemented -- same chart.js `Line`, same `utils/pypistatsHistory` fetch, same proxy (`pages/api/pypistats/[package].js`) with its existing caching + 429 backoff.

## Live + never blocks the page

- `components/InstallStats.js` builds the seed from the committed `data/installStats.json` and **lazy-loads** `PyPIDownloadChart` via `next/dynamic({ ssr: false })`, so chart.js never bloats the initial homepage bundle or blocks first paint. A shimmer **placeholder** holds the chart's height (no layout shift).
- The chart then fetches **live client-side** and replaces the seed line; on failure the seed stays.
- The **headline caption** (installs/month + top package) is seeded from the snapshot in the **server-rendered HTML**, then updated live via `getRecentDownloadStats`; on failure it keeps the seeded numbers.
- Attribution: "Cumulative downloads over time, live from pypistats.org" (dropped the "snapshot as of" wording since it is live now).
- Placed as a modest mid-page section (after `DriftOutcomes`), not full-bleed.

## Lazy-load approach

```js
const PyPIDownloadChart = dynamic(() => import('./PyPIDownloadChart'), {
  ssr: false,
  loading: () => <div className={styles.chartPlaceholder} aria-hidden="true" />,
})
```

The section's caption + numbers are server-rendered (instant, in the initial HTML); only the chart.js widget is client-only and progressively enhanced.

## Guards / CI

- `tests/installStats.test.js` updated: the old "never fetches at runtime" assertion is replaced by assertions that the section **seeds from the snapshot**, **fetches live client-side with a graceful fallback**, **lazy-loads** the chart, and that `PyPIDownloadChart`'s `compact`/`seed` props are additive.
- **99 node tests** green (was 98). Existing **Cypress e2e green (34)**, including `download.cy.js` which exercises the modified chart on `/download`. `next build` green.

## Screenshots

`/private/tmp/claude-501/install-stats/home-chart.png` (desktop, live) and `home-chart-mobile.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM
