### PR TITLE
fix(home): move Adoption section to right after Open source

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -290,9 +290,6 @@ export default function Home({ githubStats, buildWarnings, hostedOffer, installS
                 <DriftOutcomes />
             </Reveal>
             <Reveal>
-                <InstallStats stats={installStats} />
-            </Reveal>
-            <Reveal>
                 <ProductStatus />
             </Reveal>
             <Reveal>
@@ -316,6 +313,9 @@ export default function Home({ githubStats, buildWarnings, hostedOffer, installS
                     buildWarnings={buildWarnings}
                     githubStats={githubStats}
                 />
+            </Reveal>
+            <Reveal>
+                <InstallStats stats={installStats} />
             </Reveal>
             <Reveal>
                 <EmailForm />


### PR DESCRIPTION
Moves the `InstallStats` ("Adoption") section on the landing page to render immediately after the `Developers` ("Open source") section, per founder request. Previously it sat mid-page after `DriftOutcomes`.

Order now: … DriftOutcomes → ProductStatus → Pricing → Qualification → ContactBooking → **Developers (Open source) → InstallStats (Adoption)** → EmailForm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM