### PR TITLE
chore: add MIT LICENSE, brand NOTICE, and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing
+
+Thanks for contributing to OpenAdapt. A few things keep the project healthy and
+keep the company able to steward it.
+
+## Licensing of your contributions
+
+This repository's code is MIT-licensed. So that OpenAdapt (MLDSAI Inc.) can
+continue to steward and, if ever necessary, relicense the combined work, every
+contribution must be covered by BOTH of the following:
+
+1. **Developer Certificate of Origin (DCO) sign-off (required now).** Add a
+   `Signed-off-by` line to every commit certifying you wrote the change or have
+   the right to submit it under the project license:
+
+   ```
+   git commit -s -m "fix: ..."
+   ```
+
+   This produces `Signed-off-by: Your Name <you@example.com>`. See
+   https://developercertificate.org for the full DCO text.
+
+2. **Contributor License Agreement (CLA).** By opening a pull request you agree
+   to the OpenAdapt Contributor License Agreement. The canonical CLA text lives
+   at [`openadapt-flow/CLA.md`](https://github.com/OpenAdaptAI/openadapt-flow/blob/main/CLA.md).
+   When the CLA Assistant check is enabled on this repository, first-time
+   contributors sign it once by commenting on their PR.
+
+## Pull request guidelines
+
+- Use **Conventional Commits** for titles and commits (`feat:`, `fix:`,
+  `docs:`, `chore:`, `refactor:`, `test:`, `ci:`).
+- Keep PRs focused; separate mechanical changes from behavior changes.
+- Add or update tests for any behavior change.
+- Prefer honest, measured claims in docs. If something is experimental, say so.
+
+## Source-availability boundary
+
+OpenAdapt is open-core. Do not add private crown-jewel artifacts (grown
+hardening corpus, tuned adversary params, deployment-derived thresholds,
+per-system-of-record oracle/connector recipes, real-EMR datasets) to this public
+repository. Interfaces and mechanisms are public; data, recipes, and empirical
+tuning are private. See the OpenAdapt Source-Availability Boundary policy.
+
+## Reporting security issues
+
+Do not file security problems as public issues; see `SECURITY.md` if present, or
+email security@openadapt.ai.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 OpenAdapt.AI (MLDSAI Inc.)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,12 @@
+OpenAdapt Web - Notices
+
+The source CODE in this repository is licensed under the MIT License (see
+LICENSE).
+
+The OpenAdapt and OpenAdapt.AI names, logos, brand assets, product marketing
+copy, and site media are Copyright (c) 2026 MLDSAI Inc. (OpenAdapt.AI) and are
+NOT licensed under the MIT License. All rights in those materials are reserved.
+
+Only SYNTHETIC reference media may be published in this repository (for example,
+synthetic openIMIS / Frappe / OpenEMR reference frames). Do not add real-customer
+or real-EMR screenshots, recordings, datasets, or other confidential material.


### PR DESCRIPTION
License-file hygiene. `openadapt-web` (public marketing site) carried **no LICENSE**.

- **LICENSE** — canonical MIT (`Copyright (c) 2026 OpenAdapt.AI (MLDSAI Inc.)`) for the source code.
- **NOTICE** — clarifies that the OpenAdapt brand, marketing copy, and site media are copyright-reserved and NOT MIT; only synthetic reference media may ship (no real-customer/real-EMR media).
- **CONTRIBUTING.md** — DCO sign-off + CLA pointer + source-availability-boundary note.

Part of the source-availability-boundary + license-hygiene workstream (see openadapt-internal PR #3).