### PR TITLE
feat: complete PostHog funnel + GA4/DNT posture on marketing site

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,11 @@ NEXT_PUBLIC_POSTHOG_KEY=
 # PostHog API host (default: https://us.i.posthog.com; use https://eu.i.posthog.com for EU)
 NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 
+# Optional: turn on PostHog session replay for this low-sensitivity marketing
+# site. Off by default so the layer stays cookieless. When "true", all input
+# text is masked. Never set this on any surface that could receive PHI.
+NEXT_PUBLIC_POSTHOG_ENABLE_REPLAY=
+
 # --- Paid-acquisition measurement (E1) --------------------------------------
 # Both are publishable client-side ids, not secrets, and both are hard
 # no-ops when unset: no script loads, nothing renders. Only set them on

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -75,6 +75,7 @@ function snapshotLabel(stats) {
 // Attach the right funnel event to an external footer destination.
 function externalEvent(href) {
     if (!href) return null
+    if (href.includes('app.openadapt.ai')) return EVENTS.OPEN_CLOUD_APP_CLICK
     if (href.includes('github.com')) return EVENTS.GITHUB_CLICK
     if (href.includes('docs.openadapt.ai')) return EVENTS.DOCS_CLICK
     if (href.includes('discord.gg')) return EVENTS.DISCORD_CLICK

--- a/components/NavHeader.js
+++ b/components/NavHeader.js
@@ -9,6 +9,7 @@ import styles from './NavHeader.module.css'
 // Map an external nav link to its funnel event, if any.
 const externalEvent = (href) => {
     if (!href) return null
+    if (href.includes('app.openadapt.ai')) return EVENTS.OPEN_CLOUD_APP_CLICK
     if (href.includes('github.com')) return EVENTS.GITHUB_CLICK
     if (href.includes('docs.openadapt.ai')) return EVENTS.DOCS_CLICK
     if (href.includes('discord.gg')) return EVENTS.DISCORD_CLICK
@@ -337,6 +338,11 @@ export default function NavHeader() {
                         className={styles.signIn}
                         target="_blank"
                         rel="noopener noreferrer"
+                        onClick={() =>
+                            track(EVENTS.OPEN_CLOUD_APP_CLICK, {
+                                location: 'nav',
+                            })
+                        }
                     >
                         Sign in
                     </a>
@@ -418,6 +424,11 @@ export default function NavHeader() {
                         className={styles.mobileLink}
                         target="_blank"
                         rel="noopener noreferrer"
+                        onClick={() =>
+                            track(EVENTS.OPEN_CLOUD_APP_CLICK, {
+                                location: 'nav_mobile',
+                            })
+                        }
                     >
                         Sign in
                     </a>

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import Link from 'next/link'
 
+import { track, EVENTS } from 'utils/analytics'
 import status from '../public/status.json'
 
 const { monthlyRunCapLabel } = require('../lib/hostedOfferContract')
@@ -47,6 +48,9 @@ function HostedCheckoutButton({ available }) {
 
     const startCheckout = async (event) => {
         event.preventDefault()
+        // Funnel: intent to start the hosted subscription. No amounts, emails,
+        // or payment details are captured — only that checkout was initiated.
+        track(EVENTS.PRICING_CTA_CLICK, { plan: 'hosted', action: 'checkout' })
         setState('loading')
         setMessage('')
 
@@ -73,6 +77,12 @@ function HostedCheckoutButton({ available }) {
                     href="/#book"
                     data-testid="hosted-contact"
                     className="btn-ink block w-full text-center"
+                    onClick={() =>
+                        track(EVENTS.PRICING_CTA_CLICK, {
+                            plan: 'hosted',
+                            action: 'contact',
+                        })
+                    }
                 >
                     Start with our team
                 </Link>

--- a/components/analytics/GoogleAnalytics.js
+++ b/components/analytics/GoogleAnalytics.js
@@ -1,6 +1,8 @@
 import Script from 'next/script'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
+
+import { analyticsAllowed } from 'utils/consent'
 
 /**
  * GA4 loader — reusable, env-gated page-level integration.
@@ -39,15 +41,23 @@ export function gaPageview(url) {
 
 export default function GoogleAnalytics() {
     const router = useRouter()
+    // Gate on Do-Not-Track after mount. Server + first client render return
+    // null (DNT is a browser-only value), so there is no hydration mismatch;
+    // once mounted we load gtag only when the visitor allows analytics.
+    const [allowed, setAllowed] = useState(false)
 
     useEffect(() => {
-        if (!GA_MEASUREMENT_ID) return undefined
+        setAllowed(analyticsAllowed())
+    }, [])
+
+    useEffect(() => {
+        if (!GA_MEASUREMENT_ID || !allowed) return undefined
         const handleRouteChange = (url) => gaPageview(url)
         router.events.on('routeChangeComplete', handleRouteChange)
         return () => router.events.off('routeChangeComplete', handleRouteChange)
-    }, [router.events])
+    }, [router.events, allowed])
 
-    if (!GA_MEASUREMENT_ID) return null
+    if (!GA_MEASUREMENT_ID || !allowed) return null
 
     return (
         <>

--- a/components/analytics/MetaPixel.js
+++ b/components/analytics/MetaPixel.js
@@ -1,6 +1,8 @@
 import Script from 'next/script'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
+
+import { analyticsAllowed } from 'utils/consent'
 
 /**
  * Meta (Facebook) Pixel loader — reusable, env-gated.
@@ -34,15 +36,22 @@ function pixelPageview() {
 
 export default function MetaPixel() {
     const router = useRouter()
+    // Gate on Do-Not-Track after mount (browser-only value), so SSR and the
+    // first client render agree and there is no hydration mismatch.
+    const [allowed, setAllowed] = useState(false)
 
     useEffect(() => {
-        if (!META_PIXEL_ID) return undefined
+        setAllowed(analyticsAllowed())
+    }, [])
+
+    useEffect(() => {
+        if (!META_PIXEL_ID || !allowed) return undefined
         const handleRouteChange = () => pixelPageview()
         router.events.on('routeChangeComplete', handleRouteChange)
         return () => router.events.off('routeChangeComplete', handleRouteChange)
-    }, [router.events])
+    }, [router.events, allowed])
 
-    if (!META_PIXEL_ID) return null
+    if (!META_PIXEL_ID || !allowed) return null
 
     return (
         <Script id="meta-pixel-init" strategy="afterInteractive">

--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -10,36 +10,65 @@ and it never touches PHI or the OpenAdapt tool's runtime.
 
 ## What is tracked
 
-Page views (captured manually on each client-side route change) plus these
+Page views (captured manually on each client-side route change), PostHog
+**autocapture** of clicks/interactions on the public funnel pages, plus these
 named funnel events:
 
 | Event                     | Fires when the visitor…                              | Where                                   |
 | ------------------------- | ---------------------------------------------------- | --------------------------------------- |
-| `hero_cta_click`          | clicks a hero button ("Book a demo" / "See how it works") | `components/MastHead.js`           |
+| `hero_cta_click`          | clicks a hero button ("Book a demo" / "See how it works") | `components/MastHead.js`, `components/NavHeader.js` |
 | `book_pilot_click`        | clicks a "Book a demo" / "Book a Call" CTA           | `components/NavHeader.js`, `components/Footer.js` |
 | `github_click`            | clicks a GitHub link                                 | `components/NavHeader.js`, `components/Footer.js`, `components/MastHead.js` |
 | `install_command_copied`  | copies an install command (one-liner or step-by-step) | `components/InstallSection.js`         |
 | `docs_click`              | clicks the Docs link                                 | `components/Footer.js`                  |
 | `discord_click`           | clicks the Discord link                              | `components/Footer.js`                  |
+| `open_cloud_app_click`    | clicks any outbound link to `app.openadapt.ai` ("Sign in" / "Hosted dashboard") | `components/NavHeader.js`, `components/Footer.js` |
+| `download_click`          | clicks a desktop/CLI download asset                  | `pages/download.js`                     |
+| `compare_cta_click`       | clicks a CTA on `/compare`                            | `pages/compare.js`                      |
+| `workflow_card_click`     | opens a reference from the `/workflows` catalog      | `pages/workflows.js`                    |
+| `pricing_cta_click`       | starts hosted checkout or the "start with our team" path | `components/Pricing.js`             |
 
 Event properties are limited to non-identifying context such as the platform
 tab selected (`macOS`/`Linux`/`Windows`), the copy variant
-(`one_liner`/`step_by_step`), and the on-page `location` (`nav`, `footer`,
-`hero_stars`, …). No form contents, emails, or free-text are captured.
+(`one_liner`/`step_by_step`), the plan (`hosted`), the reference `industry`,
+and the on-page `location` (`nav`, `footer`, `compare_hero`, …). No form
+contents, emails, amounts, or free-text are captured.
+
+This taxonomy is shared across all OpenAdapt web properties. The docs site
+(`openadapt-ops`) also emits `outbound_click` and `docs_search`; the hosted app
+(`openadapt-cloud`) emits the product/activation funnel. All three report into
+the **same** PostHog project (same `NEXT_PUBLIC_POSTHOG_KEY` / host).
 
 ## Privacy posture
 
-- **Cookieless.** PostHog is initialized with `persistence: 'memory'` — no
-  cookies, no `localStorage`. Nothing survives a full page reload.
+- **Cookieless by default.** PostHog is initialized with `persistence:
+  'memory'` — no cookies, no `localStorage`. Nothing survives a full page
+  reload.
 - **No profiles.** `person_profiles: 'identified_only'` means no anonymous
-  person profiles are created; we never call `identify`.
-- **No session recording**, **no autocapture** — only the named events above.
+  person profiles are created; we never call `identify` on the marketing site.
+- **Autocapture ON.** This is a low-sensitivity public marketing site with no
+  PHI, so autocapture is enabled to record clicks/pageviews on the funnel pages
+  without hand-instrumenting every element.
+- **Session replay OFF by default, opt-in.** Set
+  `NEXT_PUBLIC_POSTHOG_ENABLE_REPLAY=true` to enable it; when on, all input
+  text is masked (`maskAllInputs`). Never enable on a PHI-adjacent surface.
+- **Do-Not-Track respected.** If the browser sends a DNT signal, PostHog, GA4,
+  and the Meta Pixel never initialize and no tracker script loads
+  (`utils/consent.js`, and PostHog's own `respect_dnt`).
 - **Opt-out by default in dev/CI.** With no `NEXT_PUBLIC_POSTHOG_KEY` set, the
   entire layer (`utils/analytics.js`) is a no-op; nothing loads.
 - **No PHI, ever.** This site handles no patient/customer runtime data, and the
   tracker only sees clicks on public marketing CTAs.
 - **No public counts.** Usage numbers are never rendered on the site (pre-launch
   they'd be zero — anti-proof). The funnel lives only in the PostHog dashboard.
+
+## Consent posture (and follow-up)
+
+The site is cookieless by default and honors Do-Not-Track, so it ships **no
+cookie-consent banner** today. If session replay or the Meta Pixel is turned on
+for a region that requires opt-in consent, add a lightweight consent manager as
+a follow-up and gate those two sinks behind it. That is a deliberate follow-up,
+not part of this layer.
 
 ## Enabling it
 

--- a/pages/compare.js
+++ b/pages/compare.js
@@ -2,6 +2,7 @@ import Head from 'next/head'
 import Link from 'next/link'
 
 import Footer from '@components/Footer'
+import { track, EVENTS } from 'utils/analytics'
 import BenchmarkCharts from '@components/BenchmarkCharts'
 import Faq, { faqItems } from '@components/Faq'
 import benchmark from '../data/benchmark.json'
@@ -152,10 +153,28 @@ export default function ComparePage() {
                     halts.
                 </p>
                 <div className="mt-6 flex flex-wrap gap-3">
-                    <a href="#side-by-side" className="btn-ink">
+                    <a
+                        href="#side-by-side"
+                        className="btn-ink"
+                        onClick={() =>
+                            track(EVENTS.COMPARE_CTA_CLICK, {
+                                cta: 'compare_approaches',
+                                location: 'compare_hero',
+                            })
+                        }
+                    >
                         Compare approaches
                     </a>
-                    <a href="#benchmark-evidence" className="btn-ghost-ink">
+                    <a
+                        href="#benchmark-evidence"
+                        className="btn-ghost-ink"
+                        onClick={() =>
+                            track(EVENTS.COMPARE_CTA_CLICK, {
+                                cta: 'see_results',
+                                location: 'compare_hero',
+                            })
+                        }
+                    >
                         See measured results
                     </a>
                 </div>

--- a/pages/workflows.js
+++ b/pages/workflows.js
@@ -2,6 +2,7 @@ import Head from 'next/head'
 import Link from 'next/link'
 
 import Footer from '@components/Footer'
+import { track, EVENTS } from 'utils/analytics'
 import { CATALOG, SUBSTRATE_MATURITY } from 'data/workflowCatalog'
 
 const webPageSchema = {
@@ -130,7 +131,15 @@ function CatalogEntry({ entry }) {
                     <code>{entry.reproduction}</code>
                 </pre>
                 <p className="mt-3 text-sm">
-                    <Link href={entry.solutionHref}>
+                    <Link
+                        href={entry.solutionHref}
+                        onClick={() =>
+                            track(EVENTS.WORKFLOW_CARD_CLICK, {
+                                industry: entry.industry,
+                                location: 'workflows_catalog',
+                            })
+                        }
+                    >
                         See the {entry.industry.toLowerCase()} reference →
                     </Link>
                 </p>

--- a/tests/e1Tracking.test.js
+++ b/tests/e1Tracking.test.js
@@ -16,8 +16,13 @@ test('GA4 loader is gated on NEXT_PUBLIC_GA_MEASUREMENT_ID', () => {
     assert.match(source, /process\.env\.NEXT_PUBLIC_GA_MEASUREMENT_ID/)
     assert.match(
         source,
-        /if \(!GA_MEASUREMENT_ID\) return null/,
+        /if \(!GA_MEASUREMENT_ID( \|\| !allowed)?\) return null/,
         'GA4 must render nothing without a measurement id'
+    )
+    assert.match(
+        source,
+        /analyticsAllowed\(\)/,
+        'GA4 must respect Do-Not-Track via the shared consent helper'
     )
     assert.match(
         source,
@@ -31,8 +36,13 @@ test('Meta Pixel is gated on NEXT_PUBLIC_META_PIXEL_ID', () => {
     assert.match(source, /process\.env\.NEXT_PUBLIC_META_PIXEL_ID/)
     assert.match(
         source,
-        /if \(!META_PIXEL_ID\) return null/,
+        /if \(!META_PIXEL_ID( \|\| !allowed)?\) return null/,
         'the pixel must render nothing without a pixel id'
+    )
+    assert.match(
+        source,
+        /analyticsAllowed\(\)/,
+        'the pixel must respect Do-Not-Track via the shared consent helper'
     )
 })
 

--- a/tests/funnelAnalytics.test.js
+++ b/tests/funnelAnalytics.test.js
@@ -1,0 +1,70 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+// Truth tests for the launch-funnel analytics layer: PostHog must stay
+// env-gated + Do-Not-Track aware, autocapture is on for the marketing site,
+// and the signup / hosted-app funnel events are wired at their call sites.
+
+function read(relativePath) {
+    return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+}
+
+test('PostHog init is env-gated, DNT-aware, and autocaptures the funnel', () => {
+    const source = read('utils/analytics.js')
+    assert.match(source, /process\.env\.NEXT_PUBLIC_POSTHOG_KEY/)
+    assert.match(source, /analyticsAllowed\(\)/, 'must gate on Do-Not-Track')
+    assert.match(source, /autocapture: true/, 'marketing autocapture is on')
+    assert.match(
+        source,
+        /respect_dnt: true/,
+        'PostHog SDK must also honor Do-Not-Track'
+    )
+    // Session replay stays off unless explicitly opted in via env.
+    assert.match(source, /NEXT_PUBLIC_POSTHOG_ENABLE_REPLAY/)
+    assert.match(source, /disable_session_recording: !ENABLE_REPLAY/)
+    assert.match(source, /maskAllInputs: true/)
+})
+
+test('consent helper reports Do-Not-Track and stays server-safe', () => {
+    const source = read('utils/consent.js')
+    assert.match(source, /doNotTrack/)
+    assert.match(
+        source,
+        /typeof window === 'undefined'/,
+        'must be a no-op on the server'
+    )
+    assert.match(source, /export function analyticsAllowed/)
+})
+
+test('the hosted-app (signup) funnel event is defined and wired', () => {
+    const analytics = read('utils/analytics.js')
+    assert.match(analytics, /OPEN_CLOUD_APP_CLICK: 'open_cloud_app_click'/)
+
+    // Both the nav "Sign in" and the footer "Hosted dashboard" map
+    // app.openadapt.ai outbound clicks to the signup funnel event.
+    const nav = read('components/NavHeader.js')
+    assert.match(nav, /OPEN_CLOUD_APP_CLICK/)
+    assert.match(nav, /app\.openadapt\.ai/)
+
+    const footer = read('components/Footer.js')
+    assert.match(footer, /app\.openadapt\.ai.*OPEN_CLOUD_APP_CLICK|OPEN_CLOUD_APP_CLICK/s)
+})
+
+test('compare / workflows / pricing funnel CTAs are instrumented', () => {
+    assert.match(read('pages/compare.js'), /EVENTS\.COMPARE_CTA_CLICK/)
+    assert.match(read('pages/workflows.js'), /EVENTS\.WORKFLOW_CARD_CLICK/)
+    assert.match(read('components/Pricing.js'), /EVENTS\.PRICING_CTA_CLICK/)
+})
+
+test('funnel events never carry free-text, emails, or amounts', () => {
+    // The pricing checkout event must not attach the price/amount or any
+    // form field; it only records that checkout was initiated.
+    const pricing = read('components/Pricing.js')
+    assert.doesNotMatch(
+        pricing,
+        /PRICING_CTA_CLICK[^)]*(email|amount|price)/i,
+        'pricing funnel event must not carry email/amount/price'
+    )
+})

--- a/utils/analytics.js
+++ b/utils/analytics.js
@@ -15,6 +15,8 @@
  * in the PostHog dashboard. See docs/ANALYTICS.md.
  */
 
+import { analyticsAllowed } from 'utils/consent'
+
 // Named funnel events. Keep this list in sync with docs/ANALYTICS.md.
 export const EVENTS = {
     HERO_CTA_CLICK: 'hero_cta_click',
@@ -23,6 +25,19 @@ export const EVENTS = {
     INSTALL_COMMAND_COPIED: 'install_command_copied',
     DOCS_CLICK: 'docs_click',
     DISCORD_CLICK: 'discord_click',
+    // Signup / hosted-app funnel: every outbound click to app.openadapt.ai
+    // (the "Sign in" / "Open Cloud app" / "Hosted dashboard" destinations).
+    OPEN_CLOUD_APP_CLICK: 'open_cloud_app_click',
+    // Formalized name for the /download page's per-asset click (the page
+    // already fires the string 'download_click'; this keeps the taxonomy
+    // in one place). Properties: { platform, kind, location }.
+    DOWNLOAD_CLICK: 'download_click',
+    // Named CTA clicks on the comparison / catalog / pricing funnel pages.
+    // Generic in-page interactions on these pages are also picked up by
+    // autocapture; these named events mark the load-bearing conversions.
+    COMPARE_CTA_CLICK: 'compare_cta_click',
+    WORKFLOW_CARD_CLICK: 'workflow_card_click',
+    PRICING_CTA_CLICK: 'pricing_cta_click',
 }
 
 const POSTHOG_KEY =
@@ -33,12 +48,27 @@ const POSTHOG_HOST =
     (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_POSTHOG_HOST) ||
     'https://us.i.posthog.com'
 
+// Opt-in session replay. Off by default so the layer stays cookieless; the
+// founder can enable it on this low-sensitivity marketing site by setting
+// NEXT_PUBLIC_POSTHOG_ENABLE_REPLAY=true. When on, all input text is masked.
+const ENABLE_REPLAY =
+    typeof process !== 'undefined' &&
+    process.env.NEXT_PUBLIC_POSTHOG_ENABLE_REPLAY === 'true'
+
 let client = null
 let initialized = false
 
-/** True when a PostHog key is configured and we're in the browser. */
+/**
+ * True when a PostHog key is configured, we're in the browser, and the
+ * visitor has not asked not to be tracked (Do-Not-Track is respected via
+ * utils/consent.js).
+ */
 function isEnabled() {
-    return Boolean(POSTHOG_KEY) && typeof window !== 'undefined'
+    return (
+        Boolean(POSTHOG_KEY) &&
+        typeof window !== 'undefined' &&
+        analyticsAllowed()
+    )
 }
 
 /**
@@ -54,11 +84,23 @@ export async function initAnalytics() {
             api_host: POSTHOG_HOST,
             // Privacy-respecting, local-first-friendly defaults:
             persistence: 'memory', // no cookies, no localStorage
-            disable_session_recording: true,
-            autocapture: false, // only the named funnel events below
+            // Autocapture is ON for the marketing site: it records clicks and
+            // pageviews on the public funnel pages (/compare, /workflows,
+            // /pricing, /download) so we do not have to hand-instrument every
+            // CTA. This is a low-sensitivity marketing site with no PHI.
+            autocapture: true,
             capture_pageview: false, // we capture pageviews manually on route change
             capture_pageleave: false,
             person_profiles: 'identified_only', // no anonymous profiles
+            // Session replay is opt-in (off by default to stay cookieless).
+            // When enabled it masks all input text as a defensive default even
+            // though this public site handles no sensitive data.
+            disable_session_recording: !ENABLE_REPLAY,
+            session_recording: {
+                maskAllInputs: true,
+            },
+            // Honor the browser Do-Not-Track signal at the SDK level too.
+            respect_dnt: true,
         })
         client = posthog
     } catch (err) {

--- a/utils/consent.js
+++ b/utils/consent.js
@@ -1,0 +1,31 @@
+/**
+ * Minimal consent / Do-Not-Track posture for the marketing site.
+ *
+ * The site has no cookie-consent banner today (it is cookieless by default:
+ * PostHog uses in-memory persistence and creates no profiles). The one signal
+ * we honor is the browser's Do-Not-Track flag: when a visitor sets DNT, no
+ * analytics initializes and no tracker script loads. A full CMP/consent banner
+ * is a documented follow-up (see docs/ANALYTICS.md), not part of this layer.
+ */
+
+/**
+ * True when the visitor's browser is sending a Do-Not-Track signal.
+ * Always false on the server so SSR output is deterministic.
+ */
+export function doNotTrackEnabled() {
+    if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+        return false
+    }
+    const dnt =
+        navigator.doNotTrack ||
+        window.doNotTrack ||
+        (typeof navigator.msDoNotTrack !== 'undefined'
+            ? navigator.msDoNotTrack
+            : undefined)
+    return dnt === '1' || dnt === 'yes' || dnt === true
+}
+
+/** True when analytics is permitted (i.e. Do-Not-Track is not set). */
+export function analyticsAllowed() {
+    return !doNotTrackEnabled()
+}


### PR DESCRIPTION
## What

Completes the marketing-site analytics into a full **launch funnel** reporting into the shared PostHog project, and hardens the privacy posture. Builds on the existing PostHog + GA4 + Meta Pixel layer (already env-gated no-ops).

## PostHog
- **Autocapture ON** for the low-sensitivity marketing site (records clicks/pageviews on funnel pages without hand-instrumenting every element).
- **Do-Not-Track respected**: new `utils/consent.js` short-circuits PostHog, GA4, and the Meta Pixel when the browser sends DNT; PostHog SDK also gets `respect_dnt: true`.
- **Session replay OFF by default**, opt-in via `NEXT_PUBLIC_POSTHOG_ENABLE_REPLAY=true` (masks all input text when on).
- Still cookieless (`persistence: 'memory'`), no anonymous profiles.

## Funnel events (shared taxonomy)
Added / formalized: `open_cloud_app_click` (every outbound click to `app.openadapt.ai` from nav "Sign in" and footer "Hosted dashboard" — the signup step), `download_click`, `compare_cta_click`, `workflow_card_click`, `pricing_cta_click`. Existing: `hero_cta_click`, `book_pilot_click`, `github_click`, `install_command_copied`, `docs_click`, `discord_click`, plus the E1 conversion events.

Event properties carry only enum labels / locations / plan / industry — **never** emails, amounts, or free text.

## Env vars the founder must set (production deploy env, not committed)
- `NEXT_PUBLIC_POSTHOG_KEY` (already present in the deploy env — the same key is reused by docs + app so all three report into ONE project)
- `NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com` (present)
- `NEXT_PUBLIC_GA_MEASUREMENT_ID` (optional; GA4 measurement id `G-XXXXXXXXXX`)
- `NEXT_PUBLIC_POSTHOG_ENABLE_REPLAY` (optional; defaults off)

## Tests / build
- `node --test tests/*.test.js`: 105/105 pass (updated `e1Tracking`, added `funnelAnalytics`).
- `next build`: passes.

Docs: `docs/ANALYTICS.md` rewritten for the shared cross-property taxonomy, autocapture + DNT posture, replay opt-in, and consent follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM