### PR TITLE
docs: refresh README with accurate stack, commands, and positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # openadapt-web
 
+**Lifecycle: Beta**
+
 Source for the [openadapt.ai](https://openadapt.ai) marketing site.
 
 OpenAdapt is a governed demonstration compiler for GUI workflows: record a task

--- a/README.md
+++ b/README.md
@@ -11,16 +11,19 @@ of guessing. Every execution substrate is first-class under one governed loop:
 browser, Windows, macOS, Linux, RDP, and Citrix/VDI. OpenAdapt is local-first
 and open-core (MIT); managed cloud is optional.
 
-This repository is the public website only. The product itself lives in
-[OpenAdaptAI/openadapt](https://github.com/OpenAdaptAI/openadapt), and product
-documentation lives at [docs.openadapt.ai](https://docs.openadapt.ai).
+This repository is the public website only. Installers and the unified CLI live
+in [OpenAdaptAI/OpenAdapt](https://github.com/OpenAdaptAI/OpenAdapt), the
+compiler/runtime lives in
+[OpenAdaptAI/openadapt-flow](https://github.com/OpenAdaptAI/openadapt-flow), and
+product documentation lives at [docs.openadapt.ai](https://docs.openadapt.ai).
 
-## Substrate maturity
+## Technical status data
 
 `public/status.json` is the canonical, machine-readable source of truth for
-substrate labels and component versions. The homepage imports it directly so
-rendered labels cannot drift, and `tests/statusManifest.test.js` guards it. Do
-not restate substrate maturity here; read the manifest instead.
+substrate lifecycle evidence and component versions, and
+`tests/statusManifest.test.js` guards it. The marketing homepage deliberately
+does not render this temporary maturity ledger; technical consumers can read the
+manifest directly.
 
 ## Tech stack
 
@@ -65,9 +68,9 @@ Next.js plugin are configured in `netlify.toml`.
 
 | Repository | Description |
 |------------|-------------|
-| [openadapt](https://github.com/OpenAdaptAI/openadapt) | Installer and unified CLI, the entry point to the product |
+| [OpenAdapt](https://github.com/OpenAdaptAI/OpenAdapt) | Installer and unified CLI, the entry point to the product |
 | [openadapt-flow](https://github.com/OpenAdaptAI/openadapt-flow) | Canonical engine: compiler, governed runtime, validation, and limits |
-| [openadapt-desktop](https://github.com/OpenAdaptAI/openadapt-desktop) | Desktop authoring and operator surface, in development |
+| [openadapt-desktop](https://github.com/OpenAdaptAI/openadapt-desktop) | Native authoring and local operator application |
 | [openadapt-evals](https://github.com/OpenAdaptAI/openadapt-evals) | Evaluation and benchmark research |
 | [openadapt-privacy](https://github.com/OpenAdaptAI/openadapt-privacy) | Optional PII/PHI scrubbing library |
 

--- a/README.md
+++ b/README.md
@@ -1,46 +1,47 @@
 # openadapt-web
 
-The official website for [OpenAdapt.AI](https://openadapt.ai), the governed
-compiler for repeated GUI workflows.
+Source for the [openadapt.ai](https://openadapt.ai) marketing site.
 
-**Lifecycle: Beta.** The website presents OpenAdapt's governed compiler as one
-product across every execution substrate — browser, Windows, macOS, RDP, and
-Citrix — under a single governed loop. This label describes the website
-project's own release stage, not a claim that every target application is
-production-ready.
+OpenAdapt is a governed demonstration compiler for GUI workflows: record a task
+once, compile it, and replay it deterministically with zero model calls on the
+healthy path. When replay cannot verify what it is about to do, it halts instead
+of guessing. Every execution substrate is first-class under one governed loop:
+browser, Windows, macOS, Linux, RDP, and Citrix/VDI. OpenAdapt is local-first
+and open-core (MIT); managed cloud is optional.
 
-## Overview
+This repository is the public website only. The product itself lives in
+[OpenAdaptAI/openadapt](https://github.com/OpenAdaptAI/openadapt), and product
+documentation lives at [docs.openadapt.ai](https://docs.openadapt.ai).
 
-This is the Next.js-based landing page for OpenAdapt, featuring:
+## Substrate maturity
 
-- **Canonical product truth** centred on deterministic compiled replay
-- **Audience paths** for developers, automation teams, and regulated enterprises
-- **Execution paths** for local, managed cloud, and customer-controlled operation
-- **Industries grid** showing use cases across different sectors
-- **Developer resources** and contribution information
-- **Email signup** for product and launch updates
-- **Single-page contact + booking flow** on landing (`#book`)
-- **Booking page** for intro calls (`/book`)
-- **Contact intake form** for sales workflows (`/contact`)
+`public/status.json` is the canonical, machine-readable source of truth for
+substrate labels and component versions. The homepage imports it directly so
+rendered labels cannot drift, and `tests/statusManifest.test.js` guards it. Do
+not restate substrate maturity here; read the manifest instead.
 
-## Tech Stack
+## Tech stack
 
-- [Next.js 14](https://nextjs.org/) - React framework
-- [Tailwind CSS](https://tailwindcss.com/) + [DaisyUI](https://daisyui.com/) - Styling
-- [Framer Motion](https://www.framer.com/motion/) - Animations
-- [Netlify](https://www.netlify.com/) - Hosting and forms
+- [Next.js](https://nextjs.org/) (React framework)
+- [Tailwind CSS](https://tailwindcss.com/) with [DaisyUI](https://daisyui.com/)
+- [Framer Motion](https://www.framer.com/motion/) for animation
+- [Netlify](https://www.netlify.com/) for hosting and forms
 
 ## Development
 
-```bash
-# Install dependencies
-npm install
+Node 22 is pinned in `.nvmrc`.
 
-# Run development server
-npm run dev
+```bash
+npm install      # install dependencies
+npm run dev      # start the dev server on http://localhost:3000
+npm test         # run the node:test unit suite (tests/*.test.js)
+npm run build    # fetch the paper PDF, run tests, then next build
 ```
 
-Open [http://localhost:3000](http://localhost:3000) to view the site.
+`npm run build` runs a `prebuild` step (`fetch:paper` plus `npm test`) before
+`next build`, so the unit tests gate every production build. Cypress end-to-end
+tests live under `cypress/` and run in CI and during the Netlify build. Avoid
+invoking the full Cypress suite locally without reason.
 
 ### Booking configuration
 
@@ -49,28 +50,28 @@ Booking is code-owned and always routes to the canonical Cal.com event:
 `https://cal.com/richard-abrich/30min?overlayCalendar=true`
 
 Deploy-time booking-provider overrides are intentionally ignored so stale
-environment variables cannot redirect the homepage form or `/book` embed.
+environment variables cannot redirect the homepage form or the `/book` embed.
 
 ## Deployment
 
-The site is automatically deployed to Netlify on push to the main branch.
+Netlify deploys production from the `main` branch. The build command and
+Next.js plugin are configured in `netlify.toml`.
 
 - **Production**: [openadapt.ai](https://openadapt.ai)
 
-## Product Repositories
+## Related repositories
 
 | Repository | Description |
 |------------|-------------|
+| [openadapt](https://github.com/OpenAdaptAI/openadapt) | Installer and unified CLI, the entry point to the product |
 | [openadapt-flow](https://github.com/OpenAdaptAI/openadapt-flow) | Canonical engine: compiler, governed runtime, validation, and limits |
-| [OpenAdapt](https://github.com/OpenAdaptAI/OpenAdapt) | Installer and unified CLI that routes `openadapt flow` to the engine |
 | [openadapt-desktop](https://github.com/OpenAdaptAI/openadapt-desktop) | Desktop authoring and operator surface, in development |
 | [openadapt-evals](https://github.com/OpenAdaptAI/openadapt-evals) | Evaluation and benchmark research |
 | [openadapt-privacy](https://github.com/OpenAdaptAI/openadapt-privacy) | Optional PII/PHI scrubbing library |
 
-The public product story must not treat repository count as product breadth.
-Research and internal tools belong in reference material, not top-level
-positioning.
+Repository count is not a measure of product breadth. Research and internal
+tools belong in reference material, not top-level positioning.
 
 ## License
 
-MIT - see [LICENSE](LICENSE) for details.
+MIT. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary

Refreshes `README.md` for openadapt-web (the source of the openadapt.ai marketing site) so it matches the current repository and house positioning standard. README-only change.

- Corrects the framework label (the site is on Next.js 15 per `package.json`, previously said 14).
- Documents the real commands from `package.json`: `npm install`, `npm run dev`, `npm test` (node:test suite), `npm run build` (with its `prebuild` = `fetch:paper` + `npm test` gate).
- Notes Node 22 pinned in `.nvmrc`.
- States the verified deploy mechanism: Netlify deploys production from `main` per `netlify.toml`.
- Points substrate maturity at the canonical `public/status.json` (guarded by `tests/statusManifest.test.js`) rather than restating labels that could drift.
- Adds governed-demonstration-compiler positioning with all substrates first-class; cross-links docs.openadapt.ai and OpenAdaptAI/openadapt.
- Preserves the accurate booking-configuration note and related-repositories table.
- Removes em dashes per house style.

## Verification

- `git diff --stat` shows only `README.md` changed.
- `node --test tests/statusManifest.test.js` passes (3/3).
- No em dashes in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM