### PR TITLE
feat(footer): live-updating GitHub stats with an honest timestamp

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -14,7 +14,19 @@ import {
 } from 'data/repositoryStats'
 import { BLOG_LINK, DEVELOPER_LINKS } from 'data/developerLinks'
 import { track, EVENTS } from 'utils/analytics'
+import repositoryStatsView from 'utils/repositoryStatsView'
 import styles from './Footer.module.css'
+
+const { sourceLabel } = repositoryStatsView
+
+// Client refresh cadence for the same-origin stats endpoint. Stars/forks move
+// over hours, so a static Netlify site does not need (and cannot host) a
+// streaming server: a light visibility-aware poll is the right tool. See the
+// PR description for the SSE-vs-poll evaluation. Responses are CDN- and
+// server-cached (s-maxage=600), so this poll almost always hits cache rather
+// than GitHub.
+const POLL_INTERVAL_MS = 90 * 1000
+const MAX_BACKOFF_MS = 10 * 60 * 1000
 
 // The hosted control plane. Mirrors NEXT_PUBLIC_CLOUD_APP_URL (.env.example)
 // and the top-nav "Sign in" destination so the two surfaces never drift.
@@ -62,14 +74,68 @@ function validStats(value) {
     )
 }
 
-function snapshotLabel(stats) {
-    if (stats.source === 'github' && !stats.stale) {
-        return 'GitHub · refreshed recently'
-    }
-    if (stats.source === 'stale') {
-        return 'GitHub · last-known counts'
-    }
-    return 'GitHub snapshot · refreshed when available'
+function usePrefersReducedMotion() {
+    const [reduced, setReduced] = useState(false)
+    useEffect(() => {
+        if (typeof window === 'undefined' || !window.matchMedia) return
+        const media = window.matchMedia('(prefers-reduced-motion: reduce)')
+        const update = () => setReduced(media.matches)
+        update()
+        media.addEventListener?.('change', update)
+        return () => media.removeEventListener?.('change', update)
+    }, [])
+    return reduced
+}
+
+// The honest, live-ticking "GitHub · updated Ns ago" line. The relative time
+// is recomputed locally (no network) on a gentle cadence: 1s normally so the
+// seconds counter reads true, or 30s under prefers-reduced-motion so there is
+// no visible per-second animation. The tick pauses while the tab is hidden and
+// snaps to the current time when it returns. `suppressHydrationWarning` is the
+// documented escape hatch for timestamps whose server and client renders may
+// legitimately differ by a second.
+function RepositorySource({ stats }) {
+    const reducedMotion = usePrefersReducedMotion()
+    const [now, setNow] = useState(() => Date.now())
+
+    useEffect(() => {
+        const cadence = reducedMotion ? 30 * 1000 : 1000
+        let timer = null
+        const tick = () => setNow(Date.now())
+        const start = () => {
+            if (document.visibilityState === 'hidden') return
+            timer = setInterval(tick, cadence)
+        }
+        const onVisibility = () => {
+            clearInterval(timer)
+            if (document.visibilityState === 'visible') {
+                tick()
+                start()
+            }
+        }
+        start()
+        document.addEventListener('visibilitychange', onVisibility)
+        return () => {
+            clearInterval(timer)
+            document.removeEventListener('visibilitychange', onVisibility)
+        }
+    }, [reducedMotion])
+
+    const label = sourceLabel(stats, now)
+    return (
+        <p
+            className={styles.repositorySource}
+            data-testid="footer-repository-source"
+        >
+            {stats.observedAt ? (
+                <time dateTime={stats.observedAt} suppressHydrationWarning>
+                    {label}
+                </time>
+            ) : (
+                label
+            )}
+        </p>
+    )
 }
 
 // Attach the right funnel event to an external footer destination.
@@ -134,26 +200,72 @@ export default function Footer({ repositoryStats = OPENADAPT_STATS_SNAPSHOT }) {
     )
 
     useEffect(() => {
-        const controller = new AbortController()
-        fetch('/api/repository-stats', {
-            headers: { Accept: 'application/json' },
-            signal: controller.signal,
-        })
-            .then((response) => {
+        // Live-refresh the counts with a visibility-aware poll. We never blank
+        // the widget: a failed fetch or a server-reported stale/snapshot value
+        // simply keeps the last good numbers and backs the poll off (up to
+        // MAX_BACKOFF_MS) so a rate-limited or down endpoint is not hammered.
+        let cancelled = false
+        let timer = null
+        let controller = null
+        let backoff = POLL_INTERVAL_MS
+
+        const schedule = () => {
+            clearTimeout(timer)
+            // A hidden tab schedules nothing; it resumes on visibilitychange.
+            if (document.visibilityState === 'hidden') return
+            timer = setTimeout(fetchOnce, backoff)
+        }
+
+        const fetchOnce = async () => {
+            controller = new AbortController()
+            try {
+                const response = await fetch('/api/repository-stats', {
+                    headers: { Accept: 'application/json' },
+                    signal: controller.signal,
+                })
                 if (!response.ok) {
-                    throw new Error(
-                        `Repository stats request failed: ${response.status}`
-                    )
+                    throw new Error(`stats request failed: ${response.status}`)
                 }
-                return response.json()
-            })
-            .then((nextStats) => {
-                if (validStats(nextStats)) setStats(nextStats)
-            })
-            .catch(() => {
-                // Keep the server-rendered snapshot/last-known value.
-            })
-        return () => controller.abort()
+                const next = await response.json()
+                if (cancelled) return
+                if (validStats(next)) setStats(next)
+                // Fresh live data resets the cadence; a server-reported
+                // stale/snapshot value means GitHub was unreachable, so back
+                // off rather than re-poll a struggling upstream every 90s.
+                if (next && next.source === 'github' && !next.stale) {
+                    backoff = POLL_INTERVAL_MS
+                } else {
+                    backoff = Math.min(backoff * 2, MAX_BACKOFF_MS)
+                }
+            } catch {
+                // Network error, non-OK, or rate limit: keep the last good
+                // value and back off exponentially.
+                if (cancelled) return
+                backoff = Math.min(backoff * 2, MAX_BACKOFF_MS)
+            } finally {
+                controller = null
+                if (!cancelled) schedule()
+            }
+        }
+
+        const onVisibility = () => {
+            if (document.visibilityState === 'visible') {
+                // Refresh immediately on return, then resume the poll.
+                fetchOnce()
+            } else {
+                clearTimeout(timer)
+                if (controller) controller.abort()
+            }
+        }
+
+        fetchOnce()
+        document.addEventListener('visibilitychange', onVisibility)
+        return () => {
+            cancelled = true
+            clearTimeout(timer)
+            if (controller) controller.abort()
+            document.removeEventListener('visibilitychange', onVisibility)
+        }
     }, [])
 
     return (
@@ -230,12 +342,7 @@ export default function Footer({ repositoryStats = OPENADAPT_STATS_SNAPSHOT }) {
                                 </span>
                             </a>
                         </div>
-                        <p
-                            className={styles.repositorySource}
-                            data-testid="footer-repository-source"
-                        >
-                            {snapshotLabel(stats)}
-                        </p>
+                        <RepositorySource stats={stats} />
                     </div>
 
                     <nav className={styles.columns} aria-label="Footer">

--- a/cypress/e2e/public-surface-coherence.cy.js
+++ b/cypress/e2e/public-surface-coherence.cy.js
@@ -93,11 +93,13 @@ describe('public surface coherence', () => {
                         'a[href="https://github.com/OpenAdaptAI/OpenAdapt"]'
                     ).should('exist')
                 })
+            // Honest, live-updating attribution tied to the actual last
+            // successful fetch: "GitHub · updated just now / Ns ago / ...".
             cy.get('[data-testid="footer-repository-source"]')
                 .invoke('text')
                 .should(
                     'match',
-                    /^GitHub(?: · (?:refreshed recently|last-known counts)| snapshot · refreshed when available)$/
+                    /^GitHub · updated (?:just now|\d+[smhd] ago)$/
                 )
         }
 
@@ -126,9 +128,11 @@ describe('public surface coherence', () => {
                     '258'
                 )
             })
+        // The refresh failed, so the committed snapshot survives and is
+        // labelled honestly as a snapshot rather than a fresh fetch.
         cy.get('[data-testid="footer-repository-source"]').should(
             'contain.text',
-            'GitHub snapshot'
+            'GitHub · snapshot'
         )
     })
 })

--- a/tests/publicTruth.test.js
+++ b/tests/publicTruth.test.js
@@ -45,7 +45,8 @@ test('GitHub proof uses the canonical repository and a verified fallback', () =>
     assert.match(home, /<Footer repositoryStats=\{githubStats\} \/>/)
     assert.match(footer, /repositoryStats = OPENADAPT_STATS_SNAPSHOT/)
     assert.match(footer, /fetch\('\/api\/repository-stats'/)
-    assert.match(footer, /Keep the server-rendered snapshot\/last-known value/)
+    // A failed/rate-limited refresh must keep the last good value, never blank.
+    assert.match(footer, /keep the last good/i)
     assert.match(loader, /const FRESH_TTL_MS = 10 \* 60 \* 1000/)
     assert.match(loader, /if \(inFlight\) return inFlight/)
     assert.match(loader, /source:[\s\S]*?'stale'[\s\S]*?'snapshot'/)

--- a/tests/repositoryStatsView.test.js
+++ b/tests/repositoryStatsView.test.js
@@ -1,0 +1,96 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const {
+    formatRelativeTime,
+    sourceLabel,
+} = require('../utils/repositoryStatsView')
+
+const NOW = Date.parse('2026-07-21T12:00:00.000Z')
+const ago = (ms) => NOW - ms
+
+test('formatRelativeTime buckets seconds, minutes, hours, and days', () => {
+    assert.equal(formatRelativeTime(ago(0), NOW), 'just now')
+    assert.equal(formatRelativeTime(ago(3 * 1000), NOW), 'just now')
+    assert.equal(formatRelativeTime(ago(12 * 1000), NOW), '12s ago')
+    assert.equal(formatRelativeTime(ago(5 * 60 * 1000), NOW), '5m ago')
+    assert.equal(formatRelativeTime(ago(3 * 60 * 60 * 1000), NOW), '3h ago')
+    assert.equal(formatRelativeTime(ago(2 * 24 * 60 * 60 * 1000), NOW), '2d ago')
+})
+
+test('formatRelativeTime treats clock skew (future) as just now', () => {
+    assert.equal(formatRelativeTime(NOW + 5 * 1000, NOW), 'just now')
+})
+
+test('formatRelativeTime returns null for a missing or unparseable time', () => {
+    assert.equal(formatRelativeTime(NaN, NOW), null)
+    assert.equal(formatRelativeTime(Date.parse('not-a-date'), NOW), null)
+})
+
+test('sourceLabel reports a live GitHub count as "updated <rel> ago"', () => {
+    const label = sourceLabel(
+        {
+            stars: 1650,
+            forks: 259,
+            observedAt: new Date(ago(12 * 1000)).toISOString(),
+            source: 'github',
+            stale: false,
+        },
+        NOW
+    )
+    assert.equal(label, 'GitHub · updated 12s ago')
+})
+
+test('sourceLabel reports an unreachable-GitHub value as "last updated <rel>"', () => {
+    const label = sourceLabel(
+        {
+            stars: 1650,
+            forks: 259,
+            observedAt: new Date(ago(5 * 60 * 1000)).toISOString(),
+            source: 'stale',
+            stale: true,
+        },
+        NOW
+    )
+    assert.equal(label, 'GitHub · last updated 5m ago')
+})
+
+test('sourceLabel reports the committed snapshot as "snapshot from <rel>"', () => {
+    const label = sourceLabel(
+        {
+            stars: 1648,
+            forks: 258,
+            observedAt: new Date(ago(3 * 24 * 60 * 60 * 1000)).toISOString(),
+            source: 'snapshot',
+            stale: true,
+        },
+        NOW
+    )
+    assert.equal(label, 'GitHub · snapshot from 3d ago')
+})
+
+test('sourceLabel never prints NaN when the timestamp is missing', () => {
+    assert.equal(
+        sourceLabel({ source: 'github', stale: false }, NOW),
+        'GitHub · updated just now'
+    )
+    assert.equal(
+        sourceLabel({ source: 'stale', stale: true }, NOW),
+        'GitHub · last-known counts'
+    )
+    assert.equal(sourceLabel({ source: 'snapshot' }, NOW), 'GitHub · snapshot')
+})
+
+test('sourceLabel always begins with the honest "GitHub" attribution', () => {
+    for (const source of ['github', 'stale', 'snapshot']) {
+        const label = sourceLabel(
+            {
+                observedAt: new Date(ago(60 * 1000)).toISOString(),
+                source,
+                stale: source !== 'github',
+            },
+            NOW
+        )
+        assert.match(label, /^GitHub · /)
+    }
+})

--- a/utils/repositoryStatsView.js
+++ b/utils/repositoryStatsView.js
@@ -1,0 +1,44 @@
+// Pure presentation helpers for the footer's GitHub star/fork social proof.
+//
+// Kept framework-free (plain CommonJS, no React) so the honest relative-time
+// label logic is unit-testable with `node --test` and identical whether it
+// runs on the server, during hydration, or on each live client tick.
+
+const SECOND = 1000
+const MINUTE = 60 * SECOND
+const HOUR = 60 * MINUTE
+const DAY = 24 * HOUR
+
+// A short, honest "how long ago" string for a timestamp, relative to `now`.
+// Returns null when the timestamp is missing or unparseable so callers can
+// fall back to a non-temporal label instead of printing "NaN".
+function formatRelativeTime(observedAtMs, now = Date.now()) {
+    if (!Number.isFinite(observedAtMs)) return null
+    const diff = now - observedAtMs
+    // Clock skew or a just-issued timestamp both read as "just now".
+    if (diff < 10 * SECOND) return 'just now'
+    if (diff < MINUTE) return `${Math.floor(diff / SECOND)}s ago`
+    if (diff < HOUR) return `${Math.floor(diff / MINUTE)}m ago`
+    if (diff < DAY) return `${Math.floor(diff / HOUR)}h ago`
+    return `${Math.floor(diff / DAY)}d ago`
+}
+
+// Honest source label tied to the ACTUAL last successful observation time,
+// never a vague "refreshed recently". The three states mirror the server
+// loader's `source` field:
+//   - github : a live count observed this session (updated <rel> ago)
+//   - stale  : GitHub was unreachable on the last refresh; show when the last
+//              real count was observed (last updated <rel> ago)
+//   - snapshot: no live count yet; show the committed snapshot's age
+function sourceLabel(stats, now = Date.now()) {
+    const rel = formatRelativeTime(Date.parse(stats && stats.observedAt), now)
+    if (stats && stats.source === 'github' && !stats.stale) {
+        return rel ? `GitHub · updated ${rel}` : 'GitHub · updated just now'
+    }
+    if (stats && stats.source === 'stale') {
+        return rel ? `GitHub · last updated ${rel}` : 'GitHub · last-known counts'
+    }
+    return rel ? `GitHub · snapshot from ${rel}` : 'GitHub · snapshot'
+}
+
+module.exports = { formatRelativeTime, sourceLabel }


### PR DESCRIPTION
## Summary

The footer's GitHub star/fork widget showed a vague **"GitHub · refreshed recently"** label over what was effectively a build-time snapshot with a single fetch on mount. This makes it genuinely live-updating and replaces the vague label with an **honest relative timestamp tied to the actual last successful fetch**.

## SSE vs. polling: evaluation and choice

The founder suggested SSE. Assessed honestly, **SSE does not fit** here:

- **No server to stream from.** openadapt.ai is a static site deployed on Netlify (`@netlify/plugin-nextjs`, `publish = ".next"`). There is no long-lived process to hold open an `EventSource` connection; API routes run as short-lived serverless functions. Streaming would mean standing up (and paying for) separate always-on infra for a footer widget.
- **The data barely moves.** Stars/forks change over **hours**, not seconds. A push channel optimizes for sub-second freshness we do not need.
- **Cost/complexity all downside.** Persistent connections, reconnection/backoff logic, and per-connection server cost — to deliver a number that changes a few times a day.

**Chosen: client-side fetch on mount + a light, visibility-aware poll** against the existing same-origin `/api/repository-stats` route (already proxies + caches GitHub server-side, keeps `GITHUB_TOKEN` off the client). This is the fitting tool for a static site and reuses infrastructure that already exists.

## What changed

- **Live poll** every 90s **while the tab is visible**; **paused when hidden** (`visibilitychange`), with an **immediate refresh on return**. **Exponential backoff** to a 10-minute cap on any error/rate-limit — and also when the server reports a `stale`/`snapshot` value (GitHub unreachable), so a struggling upstream is not hammered.
- **Never blanks.** A failed/aborted fetch keeps the last good counts; the committed snapshot is the floor, so the widget is never empty or `0/0`.
- **Honest timestamp** replacing "refreshed recently", tied to the real `observedAt`:
  - live fetch → `GitHub · updated Ns ago` (ticks live)
  - GitHub unreachable → `GitHub · last updated Ns ago`
  - before first live fetch → `GitHub · snapshot from Nd ago`
- **Live tick without network**: recomputed locally every 1s, or **every 30s under `prefers-reduced-motion`** (no visible per-second counter). Tick also pauses while hidden.
- **Accessible + no layout shift**: semantic `<time dateTime=...>`, `suppressHydrationWarning` (the documented escape hatch for timestamps), no `aria-live` churn, single-line label so ticking text does not reflow siblings.

## Rate-limit handling

- Visitor browsers **still never call `api.github.com`** (guarded by `publicTruth.test.js`). The poll only hits the same-origin route.
- That route's response is **CDN- and server-cached** (`s-maxage=600` + a 10-minute in-function cache + optional server-side `GITHUB_TOKEN`), so many visitors polling every 90s **collapse onto cache** rather than onto GitHub. The client backoff further reduces requests whenever the upstream is unhealthy.

## Tests

- **New** `tests/repositoryStatsView.test.js`: unit-tests the relative-time buckets (just now / Ns / Nm / Nh / Nd), clock-skew, the three honest label states, and the missing-timestamp fallback (never prints `NaN`).
- **Cypress** updated to assert the new live `GitHub · updated ...` label and the never-blank `GitHub · snapshot` fallback when the endpoint 503s.
- `publicTruth.test.js` guard updated from the old comment string to the new keep-last-good invariant.
- `node --test`: **108 passing**. `next build`: compiles + lints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM