### PR TITLE
fix: frame effect verification as an enhancement, not a requirement

### DIFF
--- a/components/AudiencePaths.js
+++ b/components/AudiencePaths.js
@@ -15,7 +15,7 @@ const paths = [
     {
         audience: 'Automation & operations',
         title: 'Launch a managed workflow',
-        body: 'Bring one repeated GUI workflow, its operating boundary, and an independent success oracle. OpenAdapt compiles the demonstrated last mile and keeps its run evidence, review, and repair lifecycle connected.',
+        body: 'Bring one repeated GUI workflow and its operating boundary. Add an independent success oracle where you have one and OpenAdapt verifies the effect end to end; without one it still runs, halting instead of guessing. It compiles the demonstrated last mile and keeps run evidence, review, and repair connected.',
         primary: { label: 'Evaluate a workflow', href: '#book' },
         secondary: { label: 'Review the benchmark', href: '/compare' },
     },

--- a/components/IndustriesGrid.js
+++ b/components/IndustriesGrid.js
@@ -14,7 +14,7 @@ export default function IndustriesGrid({
             title: 'Automation teams & BPO operators',
             href: '#book',
             descriptions:
-                'High-volume repeated operations with structured inputs, established business logic, and a UI-only last-mile gap that can be checked against an independent effect source of truth.',
+                'High-volume repeated operations with structured inputs, established business logic, and a UI-only last-mile gap. Where an independent effect source of truth is available the write is verified end to end; where it is not, the run halts instead of guessing.',
             logo: '/images/noun-finance.svg',
             example: {
                 label: 'Insurance claims reference',
@@ -25,7 +25,7 @@ export default function IndustriesGrid({
             title: 'RCM & vertical-software vendors',
             href: '#book',
             descriptions:
-                'Products with supported APIs for the core path and a bounded UI-only step at the edge, where volume and a separate system of record make verification practical.',
+                'Products with supported APIs for the core path and a bounded UI-only step at the edge, where volume justifies compiling it and a separate system of record, when present, makes the write verifiable end to end.',
             logo: '/images/noun-healthcare.svg',
             example: {
                 label: 'Healthcare workflow reference',
@@ -36,7 +36,7 @@ export default function IndustriesGrid({
             title: 'Regulated enterprise operations',
             href: '#book',
             descriptions:
-                'Governed teams that already know the inputs and rules, repeat the task at material volume, and can verify the external effect independently of the GUI run.',
+                'Governed teams that already know the inputs and rules and repeat the task at material volume. Where the external effect can be verified independently of the GUI run OpenAdapt confirms it end to end; where it cannot, it halts for review.',
             logo: '/images/noun-law.svg',
             example: {
                 label: 'Lending operations reference',
@@ -47,11 +47,11 @@ export default function IndustriesGrid({
 
     const industryMessages = {
         'Automation teams & BPO operators':
-            "I'm evaluating a high-volume workflow with a UI-only last-mile gap and an independent effect source of truth.",
+            "I'm evaluating a high-volume workflow with a UI-only last-mile gap (independent effect source of truth optional).",
         'RCM & vertical-software vendors':
             "I'm evaluating a bounded UI step that remains after using supported APIs.",
         'Regulated enterprise operations':
-            "I'm evaluating a governed repeated workflow with structured inputs and an independent effect source of truth.",
+            "I'm evaluating a governed repeated workflow with structured inputs (independent effect source of truth optional).",
     }
 
     const getDataFromTitle = (title) => {

--- a/components/Qualification.js
+++ b/components/Qualification.js
@@ -1,17 +1,19 @@
 import Link from 'next/link'
 
 // Buyer qualification lifted from the /compare "start with the right category"
-// guidance: OpenAdapt is for the repeated, consequential UI-only last mile that
-// can be checked against an independent source of truth. We lead with fit, then
-// affirm that when work fits that shape OpenAdapt runs it across every interface
-// (browser, Windows, macOS, RDP, Citrix) under one governed loop, with the full
-// /compare breakdown one click away.
+// guidance: OpenAdapt is for the repeated, consequential UI-only last mile.
+// Where an independent source of truth exists it verifies the effect end to
+// end; where one does not, it halts for a human or an AI instead of trusting
+// the screen. The oracle is an enhancement, never a gate on using the product.
+// We lead with fit, then affirm that when work fits that shape OpenAdapt runs
+// it across every interface (browser, Windows, macOS, RDP, Citrix) under one
+// governed loop, with the full /compare breakdown one click away.
 
 const fits = [
     'The work repeats and the business intent stays stable.',
     'A wrong action matters, so a run has to be verified or halted.',
     "There's no practical API for the last mile, so it's UI-only.",
-    'An independent oracle (REST, SQL, export) can confirm the effect.',
+    'Optional: a system of record (SQL, REST, FHIR, or a file) can confirm the write out of band from the screen. With one, OpenAdapt verifies the effect end to end; without one, it halts instead of guessing.',
 ]
 
 export default function Qualification() {
@@ -27,8 +29,9 @@ export default function Qualification() {
                 </h2>
                 <p className="mx-auto mt-3 max-w-2xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
                     OpenAdapt is deliberately narrow: repeated, high-stakes GUI
-                    work that has no real API and can be checked against an
-                    independent source of truth.
+                    work with no practical API. When the result can be checked
+                    against a system of record, OpenAdapt verifies it end to
+                    end; otherwise it halts instead of guessing.
                 </p>
                 <article className="mx-auto mt-8 max-w-2xl rounded-2xl border border-hairline bg-ground p-6 md:p-7">
                     <h3 className="font-display text-lg font-semibold tracking-tight text-ink">

--- a/pages/workflows.js
+++ b/pages/workflows.js
@@ -240,9 +240,9 @@ export default function WorkflowsPage() {
                     </h2>
                     <p className="mx-auto mt-3 max-w-2xl text-sm text-ink-2 md:text-base">
                         These references show the method: record once, compile,
-                        and verify against an independent source of truth. The
-                        next entry can be yours — on your application, under your
-                        policy and identity contract.
+                        and, where a system of record is available, verify the
+                        effect against it. The next entry can be yours, on your
+                        application, under your policy and identity contract.
                     </p>
                     <div className="mt-5 flex flex-wrap justify-center gap-3">
                         <Link href="/#book" className="btn-ink">


### PR DESCRIPTION
## Problem

The homepage fit/qualification copy framed an **independent source of truth** as a **prerequisite** for using OpenAdapt:

> OpenAdapt is deliberately narrow: repeated, high-stakes GUI work that has no real API **and can be checked against an independent source of truth.**

That reads as an AND-gate and disqualifies exactly the UI-only last-mile users we most want. It is **not** a requirement.

## The truth this copy now reflects

- **Independent source of truth** = the application's own backend queried out of band from the screen (a SQL query, a REST/FHIR read, or a file check). Not the screen, not a computer-use agent.
- **When available:** OpenAdapt verifies the effect end to end (confirms the record actually persisted). Strongest tier.
- **When not available:** OpenAdapt still works. It relies on the identity gates plus halt-don't-guess (it halts for a human or an AI rather than trusting the screen).

So the oracle is a capability-when-available, not a gate.

## Changes (requirement -> capability-when-available)

- `components/Qualification.js` - masthead subline, the "When OpenAdapt fits" oracle bullet, and the section comment.
- `components/IndustriesGrid.js` - the three buyer-card descriptions and the two prefilled inquiry messages.
- `components/AudiencePaths.js` - the "Automation & operations" path body.
- `pages/workflows.js` - the reference-catalog CTA method line (also removed a pre-existing em dash in the same paragraph).

Kept the effect-verification differentiator and the exact strings the honesty guards and Cypress specs assert. No em dashes.

## Verification

- `node --test tests/*.test.js` -> 100/100 pass (incl. the `publicTruth` buyer-fit guard).
- `next build` -> green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM