### PR TITLE
fix: one canonical substrate-maturity ladder + honest hosted (browser-only Beta) scope

### DIFF
--- a/components/Faq.js
+++ b/components/Faq.js
@@ -21,15 +21,15 @@ export const faqItems = [
     },
     {
         question: 'Is OpenAdapt free?',
-        answer: 'The engine is MIT-licensed and free to use or modify. Managed cloud execution across every substrate is available as a $500/month subscription, with the price and billing period confirmed again in Stripe Checkout. Customer-controlled deployments are scoped separately because the data boundary, verifier, and operating responsibilities differ.',
+        answer: 'The engine is MIT-licensed and free to use or modify. Managed cloud execution of approved browser workflows is available as a $500/month subscription (Beta), with the price and billing period confirmed again in Stripe Checkout. Desktop, RDP, and Citrix run self-hosted or through a customer-controlled deployment, which is scoped separately because the data boundary, verifier, and operating responsibilities differ.',
     },
     {
         question: 'Is managed hosted execution available?',
-        answer: 'Yes. The hosted subscription provides managed execution for approved workflows across every substrate, including run history, reports, usage, and governed workflow updates. Start the subscription from the pricing section, then qualify the workflow and its verification boundary during onboarding.',
+        answer: 'Yes, for approved browser workflows. The hosted subscription provides managed browser execution (Beta), including run history, reports, usage, and governed workflow updates. Desktop, RDP, and Citrix workflows run self-hosted or through a scoped customer-controlled deployment, not in the managed subscription. Start the subscription from the pricing section, then qualify the workflow and its verification boundary during onboarding.',
     },
     {
         question: 'What software does OpenAdapt work with?',
-        answer: 'OpenAdapt targets repeated workflows across browser applications, Windows UI Automation, native macOS, and remote desktop environments. Managed subscriptions cover approved workflows across every substrate. Private systems and regulated runtime data are delivered through a scoped customer-controlled deployment.',
+        answer: 'OpenAdapt targets repeated workflows across browser applications, Windows UI Automation, native macOS, and remote desktop environments. The managed subscription covers approved browser workflows today; desktop, RDP, and Citrix run self-hosted or through a scoped customer-controlled deployment. Private systems and regulated runtime data are delivered through a customer-controlled deployment.',
     },
 ]
 

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -16,7 +16,7 @@ const { monthlyRunCapLabel } = require('../lib/hostedOfferContract')
 
 const hostedStatusLabel =
     status.substrates.find((substrate) => substrate.name === 'Hosted Cloud')
-        ?.public_label || 'Supported'
+        ?.public_label || 'Beta'
 
 function Check() {
     return (
@@ -147,8 +147,9 @@ export default function Pricing({ hostedOffer = null }) {
                 <p className="mx-auto mt-3 max-w-2xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
                     Run the MIT-licensed engine yourself for free. Subscribe to
                     OpenAdapt Cloud, the managed control plane that runs approved
-                    workflows across every substrate. Or start a scoped paid
-                    pilot for regulated data and customer-controlled deployments.
+                    browser workflows today. Or start a scoped paid pilot for
+                    desktop, RDP, Citrix, regulated data, and customer-controlled
+                    deployments.
                 </p>
 
                 <div className="mt-10 grid items-start gap-6 md:grid-cols-3">
@@ -220,16 +221,17 @@ export default function Pricing({ hostedOffer = null }) {
                             </p>
                         )}
                         <p className="mt-3 text-sm leading-relaxed text-ink-2">
-                            The managed control plane for governed execution
-                            across every substrate: browser, Windows, macOS, RDP,
-                            and Citrix. Approved workflows run in the managed
-                            runner with run history, reporting, and governed
-                            updates. Onboarding is assisted: we qualify the first
-                            workflow with you.
+                            The managed control plane for governed execution of
+                            approved browser workflows (Beta). Approved workflows
+                            run in the managed runner with run history, reporting,
+                            and governed updates. Desktop, RDP, and Citrix run
+                            self-hosted or in a customer-controlled deployment, not
+                            in the managed subscription. Onboarding is assisted: we
+                            qualify the first workflow with you.
                         </p>
                         <FeatureList
                             items={[
-                                'Managed runner for approved workflows across every substrate',
+                                'Managed runner for approved browser workflows',
                                 'Deterministic healthy replay with zero model calls',
                                 'Run history, failure reports, usage, and governed updates',
                                 'Sanitized uploads admitted under declared policy',

--- a/components/ProductStatus.js
+++ b/components/ProductStatus.js
@@ -40,7 +40,7 @@ const boundaries = [
     },
     {
         title: 'Managed cloud execution',
-        detail: 'Operate approved workflows across every substrate through the managed control plane with run history, reports, usage, and governed updates.',
+        detail: 'Operate approved browser workflows through the managed control plane with run history, reports, usage, and governed updates. Desktop, RDP, and Citrix run self-hosted or in a customer-controlled deployment.',
         href: '/#pricing',
         link: 'See hosted options',
     },
@@ -142,8 +142,9 @@ export default function ProductStatus() {
                         One governed loop across every surface
                     </h3>
                     <p className="mt-3 max-w-3xl text-sm leading-relaxed text-ink-2">
-                        Every surface below runs the same governed loop. Each
-                        label is read from one{' '}
+                        Every surface below runs the same governed loop, and each
+                        carries a maturity label that says how broadly it has been
+                        exercised today. Each label is read from one{' '}
                         <a
                             href="/status.json"
                             target="_blank"
@@ -175,6 +176,19 @@ export default function ProductStatus() {
                             </li>
                         ))}
                     </ul>
+                    <dl className="mt-6 grid gap-x-6 gap-y-2 rounded-xl border border-hairline bg-panel p-5 text-sm leading-relaxed sm:grid-cols-2">
+                        <p className="col-span-full font-display text-xs font-semibold uppercase tracking-[0.14em] text-ink-3">
+                            What the labels mean
+                        </p>
+                        {Object.entries(status.tiers).map(([tier, meaning]) => (
+                            <div key={tier} className="flex gap-2">
+                                <dt className="flex-shrink-0 font-mono text-xs font-medium text-accent">
+                                    {tier}
+                                </dt>
+                                <dd className="text-ink-2">{meaning}</dd>
+                            </div>
+                        ))}
+                    </dl>
                     <p className="mt-5 font-mono text-xs text-ink-3">
                         Current components: launcher{' '}
                         <span className="text-ink-2">openadapt {status.versions.launcher}</span>{' '}

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -290,7 +290,7 @@ describe('public product truth', () => {
             cy.contains('Scoped paid pilot').should('be.visible')
             cy.get('[data-testid="hosted-status-label"]').should(
                 'contain.text',
-                'Supported'
+                'Beta'
             )
             cy.contains('Beta / public offer').should('not.exist')
             cy.contains('Offer unavailable').should('not.exist')

--- a/data/workflowCatalog.js
+++ b/data/workflowCatalog.js
@@ -8,16 +8,19 @@
 
 const FLOW_REPO = 'https://github.com/OpenAdaptAI/openadapt-flow'
 
-// Canonical substrate labels. OpenAdapt runs one governed loop across every
-// execution substrate, so each is first-class and supported. The three catalog
-// entries below happen to run through the browser substrate; the same governed
-// loop covers Windows UIA, native macOS, RDP, and Citrix.
+// Canonical substrate maturity labels, reconciled to public/status.json (the
+// single source of truth). The same governed loop covers every substrate; the
+// label says how broadly each has been exercised today. Beta = broadly
+// exercised (browser); Early access = validated on specific named tasks
+// (Windows UIA, native macOS, RDP); Exploratory = no validated real-environment
+// integration yet (Citrix / VDI). The three catalog entries below all run
+// through the browser substrate.
 export const SUBSTRATE_MATURITY = {
-    browser: 'Supported',
-    windows: 'Supported',
-    macos: 'Supported',
-    rdp: 'Supported',
-    citrix: 'Supported',
+    browser: 'Beta',
+    windows: 'Early access',
+    macos: 'Early access',
+    rdp: 'Early access',
+    citrix: 'Exploratory',
 }
 
 // Shared honesty envelope. Every catalog entry sets these explicitly so the

--- a/pages/pricing.js
+++ b/pages/pricing.js
@@ -17,13 +17,13 @@ export default function PricingPage({ hostedOffer }) {
                 <title>Pricing | OpenAdapt</title>
                 <meta
                     name="description"
-                    content="Launch OpenAdapt with the MIT engine, managed cloud execution across every substrate, or a scoped customer-controlled deployment."
+                    content="Launch OpenAdapt with the MIT engine, managed cloud execution for approved browser workflows (Beta), or a scoped customer-controlled deployment for desktop, RDP, and Citrix."
                 />
                 <link rel="canonical" href="https://openadapt.ai/pricing" />
                 <meta property="og:title" content="Pricing | OpenAdapt" />
                 <meta
                     property="og:description"
-                    content="OpenAdapt launch options: self-host the MIT engine, qualify managed cloud execution, or scope a regulated deployment."
+                    content="OpenAdapt launch options: self-host the MIT engine, subscribe to managed browser execution, or scope a customer-controlled deployment."
                 />
                 <meta property="og:url" content="https://openadapt.ai/pricing" />
             </Head>

--- a/pages/workflows.js
+++ b/pages/workflows.js
@@ -231,6 +231,20 @@ export default function WorkflowsPage() {
                             {SUBSTRATE_MATURITY.citrix}
                         </li>
                     </ul>
+                    <p className="mt-3 text-xs leading-relaxed text-ink-3">
+                        Labels reconcile to the canonical{' '}
+                        <a
+                            href="/status.json"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-accent underline"
+                        >
+                            status manifest
+                        </a>
+                        . Beta means broadly exercised; Early access means
+                        validated on specific named tasks; Exploratory means no
+                        validated real-environment integration yet.
+                    </p>
                 </div>
             </div>
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -50,10 +50,10 @@ Real, runnable workflow templates. Every template corresponds to something that 
 
 ## Commercial Status
 - The open-source browser engine is available now.
-- Managed cloud execution across every substrate is available as a $500/month subscription through verified Stripe Checkout and account onboarding.
+- Managed cloud execution of approved browser workflows (Beta) is available as a $500/month subscription through verified Stripe Checkout and account onboarding.
 - Credentials alone cannot expose the launch price or create Checkout. Web also refuses a configured Stripe offer that differs from the launch contract.
 - Customer-controlled regulated deployments are scoped to the actual substrate, runtime boundary, verifier, and operating responsibilities.
-- Hosted subscriptions cover managed execution across every substrate; customer-controlled regulated deployments and service terms are qualified separately for the workflow boundary.
+- Hosted subscriptions cover managed browser execution today; desktop, RDP, and Citrix run self-hosted or through a customer-controlled deployment, qualified separately for the workflow boundary.
 
 ## Hosted Data Boundary
 - Compiled bundles can contain screenshots, typed values, and literal identity evidence. Compilation does not make a bundle PHI-free.

--- a/public/status.json
+++ b/public/status.json
@@ -1,35 +1,41 @@
 {
-    "$comment": "Canonical machine-readable status for OpenAdapt. This file is the single source of truth: every public surface (website, docs, launcher README, PyPI metadata, in-product copy) reconciles its substrate labels and component versions to this manifest. Served at https://openadapt.ai/status.json and imported directly by the homepage so rendered labels cannot drift from it. OpenAdapt presents one governed product across every execution substrate; each substrate is first-class and supported.",
-    "generated_at": "2026-07-20",
+    "$comment": "Canonical machine-readable status for OpenAdapt. This file is the single source of truth: every public surface (website, docs, launcher README, masthead, PyPI metadata, in-product copy) reconciles its substrate labels and component versions to this manifest. Served at https://openadapt.ai/status.json and imported directly by the homepage so rendered labels cannot drift from it. OpenAdapt is one governed product across every execution substrate; each substrate carries a maturity tier from the canonical ladder defined in `tiers`. The tiers describe how broadly a substrate has been exercised today, not whether it is first-class in the product.",
+    "generated_at": "2026-07-21",
     "versions": {
         "launcher": "1.7.1",
         "flow": "1.19.0",
         "desktop": "0.6.2"
     },
+    "tiers": {
+        "Beta": "Works and is broadly exercised. Available today through the managed hosted product for browser workflows.",
+        "Early access": "Works and is validated on specific named tasks, but not yet broadly exercised. Real UI Automation, accessibility, and RDP backends run under the governed loop.",
+        "Exploratory": "No validated real-environment integration yet. Qualification begins inside a design partner's real environment.",
+        "Research": "Experimental and not yet part of the governed product."
+    },
     "substrates": [
         {
             "name": "Browser",
-            "public_label": "Supported",
+            "public_label": "Beta",
             "internal_tier": "reference",
-            "evidence_note": "Record, compile, and replay browser workflows end to end. Healthy runs make no model calls, and identity, effect, and policy coverage are enforced per bundle before anything executes."
+            "evidence_note": "Record, compile, and replay browser workflows end to end. Healthy runs make no model calls, and identity, effect, and policy coverage are enforced per bundle before anything executes. This is the reference loop that backs the managed hosted product."
         },
         {
             "name": "Windows / macOS / RDP",
-            "public_label": "Supported",
+            "public_label": "Early access",
             "internal_tier": "scoped-acceptance",
-            "evidence_note": "Operate native Windows, macOS, and RDP applications under the same governed loop: structured UI Automation and accessibility evidence, effect verification against an independent oracle, and fail-closed halting when verification does not pass."
+            "evidence_note": "Operate native Windows, macOS, and RDP applications under the same governed loop: structured UI Automation and accessibility evidence, effect verification against an independent oracle, and fail-closed halting when verification does not pass. Validated on specific named tasks and environments, and run self-hosted or in a customer-controlled deployment, not in the managed subscription."
         },
         {
             "name": "Citrix / VDI",
-            "public_label": "Supported",
+            "public_label": "Exploratory",
             "internal_tier": "remote-window",
-            "evidence_note": "Run the governed loop across Citrix and VDI environments with a pixel-and-evidence safety floor. Identity, effect, and policy checks and halt-on-uncertainty carry into remote application delivery."
+            "evidence_note": "Bringing the governed loop to Citrix and VDI remote application delivery, carrying identity, effect, and policy checks and halt-on-uncertainty into a pixel-and-evidence safety floor. No validated real-environment ICA/HDX integration yet; qualification begins inside a design partner's real Citrix or VDI environment."
         },
         {
             "name": "Hosted Cloud",
-            "public_label": "Supported",
+            "public_label": "Beta",
             "internal_tier": "managed-control-plane",
-            "evidence_note": "The managed control plane runs your approved workflows across every substrate with run history, reporting, usage, and governed updates, backed by live billing. Runtime data handling and customer-controlled boundaries are configured per deployment."
+            "evidence_note": "The managed control plane runs your approved browser workflows today, with run history, reporting, usage, and governed updates, backed by live billing. Desktop, RDP, and Citrix workflows run self-hosted or in a customer-controlled deployment, not in the managed subscription. Runtime data handling and customer-controlled boundaries are configured per deployment."
         }
     ]
 }

--- a/tests/statusManifest.test.js
+++ b/tests/statusManifest.test.js
@@ -10,16 +10,22 @@ const read = (relativePath) =>
 const manifest = JSON.parse(read('public/status.json'))
 
 // The canonical public substrate labels. These are the single source of truth
-// that the website, docs (openadapt-ops), launcher README, and PyPI metadata
-// all reconcile to. OpenAdapt presents one governed product across every
-// execution substrate, so every substrate carries the same first-class,
-// supported label.
+// that the website, docs (openadapt-ops), launcher README, masthead, and PyPI
+// metadata all reconcile to. Every substrate is first-class in the product; the
+// label is a maturity tier from the canonical ladder (manifest.tiers) that says
+// how broadly the substrate has been exercised today. "Scoped" is never a
+// public label — the ladder is Beta / Early access / Exploratory / Research.
 const CANONICAL_LABELS = {
-    Browser: 'Supported',
-    'Windows / macOS / RDP': 'Supported',
-    'Citrix / VDI': 'Supported',
-    'Hosted Cloud': 'Supported',
+    Browser: 'Beta',
+    'Windows / macOS / RDP': 'Early access',
+    'Citrix / VDI': 'Exploratory',
+    'Hosted Cloud': 'Beta',
 }
+
+// The canonical maturity ladder. Every public label must be one of these tiers,
+// and each tier must carry a plain-language definition so any surface that shows
+// the ladder can render a legend.
+const CANONICAL_TIERS = ['Beta', 'Early access', 'Exploratory', 'Research']
 
 // Component versions verified against PyPI on 2026-07-19.
 const CANONICAL_VERSIONS = {
@@ -28,19 +34,24 @@ const CANONICAL_VERSIONS = {
     desktop: '0.6.2',
 }
 
-test('status manifest presents every substrate as first-class and supported', () => {
+test('status manifest labels every substrate with a canonical maturity tier', () => {
     const byName = Object.fromEntries(
         manifest.substrates.map((s) => [s.name, s.public_label])
     )
     assert.deepEqual(byName, CANONICAL_LABELS)
 
-    // Target state: no substrate is ranked below another. Every substrate
-    // shares the same supported label — no Beta / Early access / Exploratory
-    // downgrade tiers.
-    const labels = new Set(manifest.substrates.map((s) => s.public_label))
-    assert.equal(labels.size, 1, 'all substrates share one uniform label')
-
+    // "Scoped" is the confusing label this ladder replaces — it must not appear
+    // as any public label.
     for (const substrate of manifest.substrates) {
+        assert.doesNotMatch(
+            substrate.public_label,
+            /scoped/i,
+            `${substrate.name} public_label must not use the ambiguous "scoped"`
+        )
+        assert.ok(
+            CANONICAL_TIERS.includes(substrate.public_label),
+            `${substrate.name} public_label must be a canonical tier`
+        )
         assert.ok(
             substrate.evidence_note && substrate.evidence_note.length > 40,
             `${substrate.name} must carry a capability note`
@@ -53,21 +64,58 @@ test('status manifest presents every substrate as first-class and supported', ()
     }
 })
 
+test('status manifest defines the canonical ladder with plain definitions', () => {
+    assert.ok(manifest.tiers && typeof manifest.tiers === 'object')
+    assert.deepEqual(Object.keys(manifest.tiers), CANONICAL_TIERS)
+    for (const tier of CANONICAL_TIERS) {
+        assert.ok(
+            typeof manifest.tiers[tier] === 'string' &&
+                manifest.tiers[tier].length > 20,
+            `tier ${tier} must carry a plain-language definition`
+        )
+    }
+    // Every label actually used must be defined in the ladder.
+    for (const substrate of manifest.substrates) {
+        assert.ok(
+            manifest.tiers[substrate.public_label],
+            `${substrate.public_label} must be defined in manifest.tiers`
+        )
+    }
+})
+
+test('hosted cloud scope is browser-only, matching the TOS and checkout gate', () => {
+    // The managed subscription is a browser-only Beta by the site's own
+    // machinery (lib/hostedOfferContract.js requires substrate=browser +
+    // lifecycle=beta; the TOS calls it a Beta browser launch service). The
+    // manifest note must not resell it as running across every substrate.
+    const hosted = manifest.substrates.find((s) => s.name === 'Hosted Cloud')
+    assert.equal(hosted.public_label, 'Beta')
+    assert.match(hosted.evidence_note, /browser workflows/i)
+    assert.doesNotMatch(hosted.evidence_note, /across every substrate/i)
+    assert.match(
+        hosted.evidence_note,
+        /self-hosted|customer-controlled/i,
+        'hosted note must route non-browser substrates to self-hosted / on-prem'
+    )
+})
+
 test('status manifest encodes the verified component versions', () => {
     assert.deepEqual(manifest.versions, CANONICAL_VERSIONS)
     assert.match(manifest.generated_at, /^\d{4}-\d{2}-\d{2}$/)
 })
 
-test('homepage substrate matrix renders labels and versions from the manifest', () => {
+test('homepage substrate matrix renders labels, tiers, and versions from the manifest', () => {
     // The rendered labels must come from the manifest, not hardcoded strings,
-    // so a version bump or label change in status.json is the only edit needed
-    // and the homepage can never disagree with the source of truth.
+    // so a label change in status.json is the only edit needed and the homepage
+    // can never disagree with the source of truth.
     const product = read('components/ProductStatus.js')
 
     assert.match(product, /import status from '\.\.\/public\/status\.json'/)
     assert.match(product, /status\.substrates\.map/)
     assert.match(product, /substrate\.public_label/)
     assert.match(product, /substrate\.evidence_note/)
+    // The tier legend is rendered from the manifest ladder.
+    assert.match(product, /status\.tiers/)
     assert.match(product, /status\.versions\.launcher/)
     assert.match(product, /status\.versions\.flow/)
     assert.match(product, /status\.versions\.desktop/)
@@ -78,7 +126,7 @@ test('homepage substrate matrix renders labels and versions from the manifest', 
     for (const label of Object.values(CANONICAL_LABELS)) {
         assert.doesNotMatch(
             product,
-            new RegExp(label.replace(/[.*+?^${}()|[\]\\—/]/g, '\\$&')),
+            new RegExp(`['"\\s]${label}['"\\s]`),
             `ProductStatus must read "${label}" from the manifest, not inline it`
         )
     }

--- a/tests/workflowCatalog.test.js
+++ b/tests/workflowCatalog.test.js
@@ -81,18 +81,32 @@ test('every catalog entry carries the required honesty fields', () => {
     }
 })
 
-test('every substrate carries the canonical first-class supported label', () => {
-    // Target state: no substrate is ranked below another. Every substrate
-    // shares one uniform, first-class label.
-    const labels = new Set(Object.values(SUBSTRATE_MATURITY))
-    assert.equal(labels.size, 1, 'all substrates share one uniform label')
-    assert.equal(SUBSTRATE_MATURITY.browser, 'Supported')
+test('every substrate carries a canonical maturity tier reconciled to status.json', () => {
+    // Labels reconcile to public/status.json (the single source of truth):
+    // Beta = broadly exercised (browser); Early access = validated on specific
+    // named tasks (Windows / macOS / RDP); Exploratory = no validated
+    // real-environment integration yet (Citrix). "Supported" and the ambiguous
+    // "scoped" are never used as public labels here.
+    const expected = {
+        browser: 'Beta',
+        windows: 'Early access',
+        macos: 'Early access',
+        rdp: 'Early access',
+        citrix: 'Exploratory',
+    }
+    // Field-by-field: SUBSTRATE_MATURITY comes from a vm sandbox, so its
+    // prototype is not reference-equal to a plain object literal here.
+    assert.deepEqual({ ...SUBSTRATE_MATURITY }, expected)
+    for (const label of Object.values(SUBSTRATE_MATURITY)) {
+        assert.doesNotMatch(label, /scoped|supported/i)
+    }
+    // The three catalog entries are all browser fixtures, so they carry Beta.
     for (const entry of CATALOG) {
         assert.equal(entry.substrate, 'browser', `${entry.id} substrate`)
         assert.equal(
             entry.maturity,
             SUBSTRATE_MATURITY.browser,
-            `${entry.id} maturity is the canonical substrate label`
+            `${entry.id} maturity is the canonical browser label`
         )
     }
 })


### PR DESCRIPTION
## Why

Two related honesty problems on OpenAdapt surfaces:

1. **Inconsistent maturity vocabulary.** The same maturity was labeled three ways: `status.json` (`Supported`), docs (`scoped`), masthead SVG (`SCOPED`). The founder asked: *"macOS/Windows/RDP say 'scoped' - what does this mean? why not beta? don't these work?"* They do work; the label just meant "validated on a scoped set, not broadly exercised" - but "scoped" is unclear.
2. **Hosted-scope overclaim (P0).** The managed subscription is browser-only Beta by the site's own machinery (`lib/hostedOfferContract.js` requires `substrate === 'browser'` + `lifecycle === 'beta'`; the TOS says "Managed browser execution is a Beta launch service"), yet 8+ surfaces sold it as running "across every substrate."

## The canonical ladder (now in `public/status.json` `tiers`)

| Tier | Meaning | Substrate |
|------|---------|-----------|
| **Beta** | Works and is broadly exercised | Browser, Hosted Cloud |
| **Early access** | Works, validated on specific named tasks, not yet broadly exercised | Windows / macOS / RDP (was "scoped"/"Supported") |
| **Exploratory** | No validated real-environment integration yet | Citrix / VDI (was "Supported" - wrong) |
| **Research** | Experimental, not yet part of the governed product | Linux |

`status.json` is the single source of truth. `ProductStatus.js` and `/workflows` render a **legend** from `status.tiers` so a reader knows what each tier means. `data/workflowCatalog.js` reconciled to the ladder.

## Hosted scope corrected (old -> new)

Every "managed runs across every substrate" claim scoped to the honest truth - the **managed subscription runs approved BROWSER workflows today; desktop/RDP/Citrix run self-hosted or in a customer-controlled deployment**:
- `components/Pricing.js` (intro copy, card paragraph, feature bullet, default label)
- `components/ProductStatus.js` (managed-cloud boundary card)
- `components/Faq.js` (x3 answers)
- `pages/pricing.js` (meta description + OG)
- `public/llms.txt` (x2)
- `public/status.json` Hosted Cloud note

The product/self-hosted **all-substrates story is unchanged** - only the HOSTED subscription stops implying it runs them.

## Tests / build

- Updated `tests/statusManifest.test.js` + `tests/workflowCatalog.test.js` to enforce the new ladder (they previously enforced the old uniform-"Supported" policy this PR corrects). Added a hosted-scope guard asserting the manifest note matches the TOS/checkout gate.
- Updated `cypress/e2e/basic.cy.js` hosted-status-label assertion (`Supported` -> `Beta`).
- **All 115 node tests pass**; `next build` green.
- Netlify deploy-preview check is a known pre-existing infra failure on all web PRs; use **build-and-e2e** as the gate.

Companion PR reconciles the masthead SVG (`openadapt` repo) `SCOPED` bands. openadapt-ops docs divergence flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)