### PR TITLE
refactor(home): tighten the landing to one narrative arc

### DIFF
--- a/components/CompiledProgramSection.module.css
+++ b/components/CompiledProgramSection.module.css
@@ -1,5 +1,5 @@
 .section {
-    padding: 76px 20px 80px;
+    padding: 96px 20px 112px;
     border-top: 2px solid var(--rule);
     background: var(--paper);
     scroll-margin-top: 72px;

--- a/components/DashboardShowcase.module.css
+++ b/components/DashboardShowcase.module.css
@@ -1,5 +1,5 @@
 .section {
-    padding: 76px 20px 80px;
+    padding: 96px 20px 112px;
     border-top: 2px solid var(--rule);
     background: var(--panel);
     scroll-margin-top: 72px;
@@ -306,7 +306,7 @@
 
 @media (max-width: 620px) {
     .section {
-        padding: 56px 16px 62px;
+        padding: 72px 16px 80px;
     }
 
     .summary {

--- a/components/HowItWorks.module.css
+++ b/components/HowItWorks.module.css
@@ -1,7 +1,7 @@
 .section {
     background: var(--ground);
     border-top: 2px solid var(--rule);
-    padding: 72px 20px 80px;
+    padding: 96px 20px 112px;
     scroll-margin-top: 24px;
 }
 
@@ -291,7 +291,7 @@
 
 @media (max-width: 640px) {
     .section {
-        padding: 52px 16px 60px;
+        padding: 72px 16px 80px;
     }
 
     .copy {

--- a/components/HowItWorksCondensed.js
+++ b/components/HowItWorksCondensed.js
@@ -28,7 +28,7 @@ export default function HowItWorksCondensed() {
     return (
         <section
             id="how-it-works"
-            className="border-b border-hairline bg-ground px-5 py-14 md:py-16"
+            className="border-b border-hairline bg-ground px-5 py-20 md:py-28"
         >
             <div className="mx-auto max-w-5xl">
                 <p className="eyebrow text-center">How it works</p>

--- a/components/InstallStats.module.css
+++ b/components/InstallStats.module.css
@@ -5,7 +5,7 @@
     background: var(--ground);
     border-top: 1px solid var(--hairline);
     border-bottom: 1px solid var(--hairline);
-    padding: 2.75rem 1.5rem;
+    padding: 6rem 1.5rem;
 }
 
 .inner {
@@ -103,7 +103,7 @@
 
 @media (max-width: 560px) {
     .section {
-        padding: 2.25rem 1rem;
+        padding: 4rem 1rem;
     }
 
     .chartPlaceholder {

--- a/components/NavHeader.js
+++ b/components/NavHeader.js
@@ -29,6 +29,7 @@ const SOLUTIONS_LINKS = [
 ]
 
 const PRODUCT_LINKS = [
+    { label: 'How it works', href: '/how-it-works' },
     { label: 'How it runs', href: '/#product-status' },
     { label: 'Workflows', href: '/workflows' },
     { label: 'Safety', href: '/safety' },

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -137,7 +137,7 @@ export default function Pricing({ hostedOffer = null }) {
     return (
         <section
             id="pricing"
-            className="border-t-2 border-ink bg-ground px-5 py-16 md:py-20"
+            className="border-t border-hairline bg-ground px-5 py-20 md:py-28"
         >
             <div className="mx-auto max-w-5xl">
                 <p className="eyebrow text-center">Ways to start</p>

--- a/components/ProductStatus.js
+++ b/components/ProductStatus.js
@@ -71,7 +71,7 @@ export default function ProductStatus() {
     return (
         <section
             id="product-status"
-            className="border-b border-hairline bg-panel px-5 py-14 md:py-16"
+            className="border-b border-hairline bg-panel px-5 py-20 md:py-28"
         >
             <div className="mx-auto max-w-5xl">
                 <p className="eyebrow text-center">From demonstration to operation</p>

--- a/components/Qualification.js
+++ b/components/Qualification.js
@@ -20,7 +20,7 @@ export default function Qualification() {
     return (
         <section
             id="qualification"
-            className="border-b border-hairline bg-panel px-5 py-14 md:py-16"
+            className="border-b border-hairline bg-panel px-5 py-20 md:py-28"
         >
             <div className="mx-auto max-w-5xl">
                 <p className="eyebrow text-center">The right fit</p>

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -256,10 +256,14 @@ describe('public product truth', () => {
     })
 
     it('explains the governed workflow and execution choices', () => {
-        cy.contains('What “repair” means, and where it stops').should(
-            'be.visible'
+        // The deep "what repair means, and where it stops" explanation now
+        // lives on /how-it-works (see the dedicated test below); the homepage
+        // links to it via a compact teaser instead of stacking the deep dive.
+        cy.contains('a', 'See how it works').should(
+            'have.attr',
+            'href',
+            '/how-it-works'
         )
-        cy.contains('Unsupported drift').should('be.visible')
         cy.get('#product-status').within(() => {
             cy.contains('One governed workflow, end to end').should(
                 'be.visible'
@@ -315,6 +319,23 @@ describe('public product truth', () => {
                 cy.contains('Start hosted subscription').should('not.exist')
             }
         })
+    })
+
+    it('keeps the drift-outcome deep dive on the how-it-works page', () => {
+        // The compiled-program and drift-outcome deep dives moved off the
+        // landing to /how-it-works. Assert they still exist there so the
+        // "what repair means, and where it stops" honesty coverage travels
+        // with the content instead of being deleted.
+        cy.visit('/how-it-works')
+        cy.contains('What “repair” means, and where it stops').should(
+            'be.visible'
+        )
+        cy.contains('Unsupported drift').should('be.visible')
+        cy.contains('Deterministic re-resolution').should('be.visible')
+        cy.contains('Refuse instead of improvise').should('be.visible')
+        cy.contains('See what a demonstration compiled into').should(
+            'be.visible'
+        )
     })
 
     it('renders the Stripe Product run allowance without a website fallback', () => {

--- a/pages/how-it-works.js
+++ b/pages/how-it-works.js
@@ -1,0 +1,129 @@
+import Head from 'next/head'
+import Link from 'next/link'
+
+import CompiledProgramSection from '@components/CompiledProgramSection'
+import DriftOutcomes from '@components/DriftOutcomes'
+import Footer from '@components/Footer'
+import HowItWorksCondensed from '@components/HowItWorksCondensed'
+import Reveal from '@components/Reveal'
+
+// Concepts / method page. The homepage keeps one clear narrative arc, so the
+// deeper "what a demonstration compiles into" and "what repair means, and where
+// it stops" explanations live here, one click from the homepage's condensed
+// three-step model. Nothing was deleted in the homepage cleanup: this page is
+// where the compiled-program deep dive and the drift-outcome ladder now live.
+
+const howToSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'HowTo',
+    name: 'How OpenAdapt compiles and governs a repeated GUI workflow',
+    description:
+        'Demonstrate a bounded, repeated task once. OpenAdapt compiles the trace into a deterministic, locally executable program, replays it with zero per-run model calls, and resolves, repairs, or halts under interface drift.',
+    step: [
+        {
+            '@type': 'HowToStep',
+            name: 'Record and compile',
+            text: 'Demonstrate one bounded, repeated task. OpenAdapt compiles the trace into a reviewable, parameterized program.',
+        },
+        {
+            '@type': 'HowToStep',
+            name: 'Replay deterministically',
+            text: 'Healthy runs execute the compiled steps locally with zero model calls.',
+        },
+        {
+            '@type': 'HowToStep',
+            name: 'Resolve, repair, or halt',
+            text: 'When the interface drifts, deterministic evidence re-finds the target, an optional model proposes a governed repair, or verification halts and keeps a run report.',
+        },
+    ],
+}
+
+export default function HowItWorksPage() {
+    return (
+        <div className="bg-ground text-ink">
+            <Head>
+                <title>How it works | OpenAdapt</title>
+                <meta
+                    name="description"
+                    content="How OpenAdapt turns one recorded demonstration into a deterministic, locally executable program, and how it resolves, repairs, or halts under interface drift."
+                />
+                <link
+                    rel="canonical"
+                    href="https://openadapt.ai/how-it-works"
+                />
+                <meta property="og:title" content="How it works | OpenAdapt" />
+                <meta
+                    property="og:description"
+                    content="From a recorded demonstration to a reviewable program, deterministic replay, and governed repair under drift."
+                />
+                <meta
+                    property="og:url"
+                    content="https://openadapt.ai/how-it-works"
+                />
+                <script
+                    type="application/ld+json"
+                    dangerouslySetInnerHTML={{
+                        __html: JSON.stringify(howToSchema),
+                    }}
+                />
+            </Head>
+
+            <header className="border-b border-hairline bg-panel px-5 py-20 md:py-28">
+                <div className="mx-auto max-w-3xl text-center">
+                    <p className="eyebrow">The method</p>
+                    <h1 className="mx-auto mt-3 max-w-2xl font-display text-3xl font-semibold tracking-tight text-ink md:text-4xl">
+                        Compile once, govern every repair
+                    </h1>
+                    <p className="mx-auto mt-4 max-w-2xl text-base leading-relaxed text-ink-2">
+                        Record a bounded, repeated task once. OpenAdapt compiles
+                        the trace into a deterministic local program, replays it
+                        with zero per-run model cost, and resolves, repairs, or
+                        halts under interface drift. Here is what each step
+                        produces and where the loop deliberately stops.
+                    </p>
+                    <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+                        <Link className="btn-ink" href="/#book">
+                            Evaluate a workflow
+                        </Link>
+                        <Link className="btn-ghost-ink" href="/research">
+                            Read the technical paper
+                        </Link>
+                    </div>
+                </div>
+            </header>
+
+            <Reveal>
+                <HowItWorksCondensed />
+            </Reveal>
+            <Reveal>
+                <CompiledProgramSection />
+            </Reveal>
+            <Reveal>
+                <DriftOutcomes />
+            </Reveal>
+
+            <section className="border-b border-hairline bg-panel px-5 py-20 md:py-28">
+                <div className="mx-auto max-w-3xl text-center">
+                    <p className="eyebrow">See it running</p>
+                    <h2 className="mx-auto mt-3 max-w-2xl font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl">
+                        Watch the same loop on a real reference workflow
+                    </h2>
+                    <p className="mx-auto mt-4 max-w-2xl text-sm leading-relaxed text-ink-2 md:text-base">
+                        Each reference is a bounded, synthetic fixture with its
+                        own honest evidence and caveats.
+                    </p>
+                    <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+                        <Link className="btn-ink" href="/#references">
+                            See reference workflows
+                        </Link>
+                        <Link className="btn-ghost-ink" href="/compare">
+                            Compare with RPA and agents
+                        </Link>
+                    </div>
+                </div>
+            </section>
+
+            <Footer />
+        </div>
+    )
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,11 +3,9 @@ import Head from 'next/head'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 
-import CompiledProgramSection from '@components/CompiledProgramSection'
 import ContactBookingSection from '@components/ContactBookingSection'
 import DashboardShowcase from '@components/DashboardShowcase'
 import Developers from '@components/Developers'
-import DriftOutcomes from '@components/DriftOutcomes'
 import EmailForm from '@components/EmailForm'
 import Footer from '@components/Footer'
 import HomeReferenceWorkflow from '@components/HomeReferenceWorkflow'
@@ -206,6 +204,26 @@ export default function Home({ githubStats, buildWarnings, hostedOffer, installS
             <Reveal>
                 <HowItWorksCondensed />
             </Reveal>
+            {/*
+             * The deep concept explanations — what a demonstration compiles
+             * into (CompiledProgramSection) and what "repair" means and where it
+             * stops (DriftOutcomes) — now live on /how-it-works so the landing
+             * keeps one clear arc. This compact teaser links there instead of
+             * stacking both deep-dives inline.
+             */}
+            <div className="border-b border-hairline bg-ground px-5 pb-16 md:pb-20">
+                <p className="mx-auto max-w-2xl text-center text-sm leading-relaxed text-ink-2">
+                    Want the full method — what a demonstration compiles into,
+                    and exactly where repair stops?{' '}
+                    <Link
+                        href="/how-it-works"
+                        className="font-medium text-accent hover:underline"
+                    >
+                        See how it works
+                    </Link>
+                    .
+                </p>
+            </div>
             <Reveal>
                 <HomeReferenceWorkflow
                     vertical={vertical}
@@ -214,7 +232,7 @@ export default function Home({ githubStats, buildWarnings, hostedOffer, installS
             </Reveal>
             <section
                 id="references"
-                className="border-b border-hairline bg-panel px-5 py-10"
+                className="border-b border-hairline bg-panel px-5 py-16 md:py-20"
             >
                 <div className="mx-auto max-w-5xl text-center">
                     <p className="eyebrow">More reference workflows</p>
@@ -282,12 +300,6 @@ export default function Home({ githubStats, buildWarnings, hostedOffer, installS
              */}
             <Reveal>
                 <DashboardShowcase />
-            </Reveal>
-            <Reveal>
-                <CompiledProgramSection />
-            </Reveal>
-            <Reveal>
-                <DriftOutcomes />
             </Reveal>
             <Reveal>
                 <ProductStatus />


### PR DESCRIPTION
## Why

The landing page stacked ~12 full-bleed sections. The content is mostly good, but with that many equally-weighted sections no section had one job and the vertical rhythm felt "all over the place." This is subjective visual/IA work — **renders below**; expect the founder to iterate.

**Scope note:** this PR owns **structure, layout, whitespace, section rhythm, and information architecture** only. It deliberately does **not** rewrite the in-component marketing copy that other agents are concurrently editing (hosted/maturity labels, proof-hedge phrasing). Edits are confined to section composition/order, section wrapper spacing, and the destination page moved content lands on.

## New narrative arc (kept on the landing)

1. **Hero** (MastHead)
2. **How it works** — 3-step condensed model, now with a compact teaser link to the full method
3. **Proof** — reference workflow demo + reference chips, OpenAdapt Cloud (real screenshots), interfaces/end-to-end (ProductStatus)
4. **Fit** — Qualification ("UI-only last mile")
5. **Start** — Pricing + Book a call
6. **Open source & adoption** — Developers/InstallSection + PyPI adoption chart

## Keep vs. move decisions

| Section | Decision | Rationale |
|---|---|---|
| Hero, How-it-works, Reference workflow + chips, Cloud showcase, ProductStatus, Qualification, Pricing, Book, Developers/Install, Adoption | **Keep** | Each is a distinct beat in the one arc; several are also test/anchor-load-bearing (`#cloud-product`, `#product-status`, `#book`, `#open-source`, `#pricing`, `#references`) |
| **CompiledProgramSection** ("what a demonstration compiles into") | **Move → `/how-it-works`** | Deep concept explainer; belongs on a concepts page, not stacked on the landing |
| **DriftOutcomes** ("what 'repair' means, and where it stops") | **Move → `/how-it-works`** | Same — the drift-outcome ladder is a deep dive |

Content is **moved, not deleted.** The new `/how-it-works` page composes: page hero → condensed 3-step → compiled-program deep dive → drift-outcome ladder → "see it running" CTA. It's linked from the landing (compact teaser) and from the **Product** nav dropdown.

### Why not move more?
Pricing, ProductStatus (substrate ladder), the reference chips, the Cloud showcase, and the adoption chart are each guarded by tests that assert their presence/anchors on the landing (`installStats`, `statusManifest`, `dashboardShowcase`, `homeVerticalSync`, `publicTruth`) and/or are primary-CTA/proof beats. Moving them would either break honesty guards or gut the at-a-glance pitch, so they stay.

## Whitespace / hierarchy changes

- **One vertical spacing scale** across every major section: `py-20 md:py-28` for the Tailwind sections and `96px / 112px` for the CSS-module sections (previously a jumble of `py-10`, `py-14 md:py-16`, `py-16 md:py-20`, `72–80px`). Consistent breathing room = clear section boundaries.
- Softened the harsh **2px ink divider** above Pricing to a hairline so it stops competing with the section content.
- Removed two stacked deep-dive sections so each remaining beat has one focal point.

## Density result (full-page render heights)

| | Before | After | Δ |
|---|---|---|---|
| Landing desktop | 29,928px | 27,218px | **−9%** |
| Landing mobile | 47,238px | 40,682px | **−14%** |

Shorter **and** more generously spaced (the win comes from removing sections, not cramming).

## SEO / at-a-glance tradeoff

Moving the compiled-program and drift-outcome copy off the landing removes those keywords from `/`. Mitigations: both now live on a crawlable `/how-it-works` page with its own `HowTo` JSON-LD, canonical, and OG tags; the landing links to it (teaser + nav); and the homepage's own JSON-LD/`llms.txt` still carry the governed-compiler/repair language. Net: the landing trades a little raw keyword density for a much clearer scent + a dedicated concept page that can rank on its own.

## Theme / responsive / a11y

- Single "paper/ink + accent-green" theme is preserved (the site has **no dark mode** in code — no `prefers-color-scheme`/`data-theme` override exists — so renders are light-only by design, not an omission).
- No horizontal overflow at 390px (full-page mobile capture is exactly 780px wide = 390×2 DPR).
- New page reuses existing accessible components + `.eyebrow`/`btn-ink` primitives.

## Tests

- `node --test` — **113/113 pass** (honesty guards `publicTruth` + `statusManifest` untouched and green).
- Cypress e2e — **36/36 pass**. `basic.cy.js` had asserted the moved DriftOutcomes heading on the landing; updated to assert the homepage **teaser link** plus a **new test** that the deep-dive truths still render on `/how-it-works` (coverage travels with the content).
- `next build` clean; `/how-it-works` prerenders static.
- The Netlify deploy-preview check is a known pre-existing infra fail — gate on **build-and-e2e**.

## Renders (desktop + mobile, before/after)

Rendered to `/private/tmp/claude-501/landing-redesign/renders/` for review:
- `01-landing-BEFORE-desktop.png`, `02-landing-BEFORE-mobile.png`
- `03-landing-AFTER-desktop.png`, `04-landing-AFTER-mobile.png`
- `05-howitworks-AFTER-desktop.png`, `06-howitworks-AFTER-mobile.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)