### PR TITLE
feat: contribute-for-credits program (landing + /contribute + pricing) [early access]

### DIFF
--- a/components/ContributeSection.js
+++ b/components/ContributeSection.js
@@ -1,0 +1,79 @@
+import Link from 'next/link'
+
+// Contribute-for-credits landing SECTION.
+//
+// Placed after the trust summary (the open-source / trust cluster) because
+// this is a commons / flywheel message, not a pricing gimmick: contributions
+// strengthen the shared hardening corpus that lowers everyone's
+// silent-wrong-effect rate. The full mechanism, expanded guarantees, program
+// status, and FAQ live on /contribute.
+//
+// Framing is binding (see the data-for-credits framing brief): lead with the
+// guarantees, never "sell/monetize your data", no per-record price. The
+// program is EARLY ACCESS (gated on legal terms), so the copy is "request
+// access", never "upload now / available today", and never claims any data has
+// been collected.
+
+const GUARANTEES = [
+    'Sanitized, de-identified derivatives only. Raw recordings never leave your machine.',
+    'You approve every byte through hash-bound local review before anything is shared.',
+    'Opt-in and off by default. You can stop future contributions at any time.',
+    'Every contribution must meet the named de-identification standard in the versioned terms, and your organization attests before sharing.',
+]
+
+export default function ContributeSection() {
+    return (
+        <section
+            id="contribute"
+            className="border-b border-hairline bg-ground px-5 py-16 md:py-20"
+            aria-labelledby="contribute-heading"
+        >
+            <div className="mx-auto max-w-4xl">
+                <div className="flex flex-wrap items-center gap-3">
+                    <p className="eyebrow">Strengthen the commons</p>
+                    <span className="rounded-full border border-hairline bg-panel px-3 py-1 font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-ink-2">
+                        Early access
+                    </span>
+                </div>
+                <h2
+                    id="contribute-heading"
+                    className="mt-3 max-w-2xl font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl"
+                >
+                    Contribute data for credits
+                </h2>
+                <p className="mt-4 max-w-2xl text-sm leading-relaxed text-ink-2 md:text-base">
+                    Every sanitized contribution strengthens the shared
+                    hardening corpus, the commons that lowers everyone&apos;s
+                    silent-wrong-effect rate. In return, you earn run credits
+                    that extend your usage allowance.
+                </p>
+
+                <ul className="mt-8 grid gap-4 md:grid-cols-2">
+                    {GUARANTEES.map((item) => (
+                        <li
+                            key={item}
+                            className="flex gap-2.5 rounded-xl border border-hairline bg-panel p-4 text-sm leading-relaxed text-ink-2"
+                        >
+                            <span
+                                aria-hidden="true"
+                                className="mt-[2px] flex-shrink-0 font-mono text-accent"
+                            >
+                                ✓
+                            </span>
+                            <span>{item}</span>
+                        </li>
+                    ))}
+                </ul>
+
+                <div className="mt-8 flex flex-wrap items-center gap-4">
+                    <Link href="/contribute" className="btn-ink">
+                        Request access to the contributor program
+                    </Link>
+                    <span className="text-xs leading-relaxed text-ink-3">
+                        Early access. Opt-in. Sanitized derivatives only.
+                    </span>
+                </div>
+            </div>
+        </section>
+    )
+}

--- a/components/ContributorProgramForm.js
+++ b/components/ContributorProgramForm.js
@@ -1,0 +1,225 @@
+import { useState } from 'react'
+import Link from 'next/link'
+
+import { trackEmailCapture } from 'utils/conversion'
+
+// Dedicated intake for the contribute-for-credits program.
+//
+// Posts to the durable Netlify Forms lead path (`/form.html`) under its own
+// form name, `contributor-program`, so contributor leads land in their own
+// Netlify submissions bucket instead of the generic `contact` queue. The
+// hidden form definition lives in public/form.html; Netlify's build-time bots
+// read it from there. Registering interest shares only these contact fields;
+// it never enables any upload or shares any workflow data.
+
+const INITIAL_FORM = {
+    name: '',
+    email: '',
+    company: '',
+    role: '',
+    workflows: '',
+    message: '',
+    botField: '',
+}
+
+export default function ContributorProgramForm() {
+    const [form, setForm] = useState(INITIAL_FORM)
+    const [isSubmitting, setIsSubmitting] = useState(false)
+    const [isSubmitted, setIsSubmitted] = useState(false)
+    const [error, setError] = useState('')
+
+    const handleChange = (event) => {
+        const { name, value } = event.target
+        setForm((prev) => ({
+            ...prev,
+            [name]: value,
+        }))
+    }
+
+    const handleSubmit = async (event) => {
+        event.preventDefault()
+        setError('')
+        setIsSubmitting(true)
+
+        try {
+            const formData = new URLSearchParams()
+            formData.set('form-name', 'contributor-program')
+            formData.set('name', form.name)
+            formData.set('email', form.email)
+            formData.set('company', form.company)
+            formData.set('role', form.role)
+            formData.set('workflows', form.workflows)
+            formData.set('message', form.message)
+            formData.set('bot-field', form.botField)
+
+            const response = await fetch('/form.html', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                },
+                body: formData.toString(),
+            })
+
+            if (!response.ok) {
+                throw new Error(
+                    `Form submission failed with status ${response.status}`
+                )
+            }
+
+            // E1 qualified-lead conversion: contributor-program interest
+            // captured. Carries first-touch utm_* attribution; never any form
+            // contents.
+            trackEmailCapture({ location: 'contributor_program_form' })
+            setIsSubmitted(true)
+        } catch (submitError) {
+            console.error(submitError)
+            setError(
+                'Submission failed. Please email hello@openadapt.ai directly.'
+            )
+        } finally {
+            setIsSubmitting(false)
+        }
+    }
+
+    return (
+        <div className="rounded-2xl border border-hairline bg-panel p-6 md:p-8">
+            {!isSubmitted ? (
+                <form
+                    className="space-y-4"
+                    onSubmit={handleSubmit}
+                    data-netlify="true"
+                    netlify-honeypot="bot-field"
+                    name="contributor-program"
+                >
+                    <input
+                        type="hidden"
+                        name="form-name"
+                        value="contributor-program"
+                    />
+                    <p className="hidden">
+                        <label>
+                            Do not fill this out if you are human:{' '}
+                            <input
+                                name="bot-field"
+                                value={form.botField}
+                                onChange={(event) =>
+                                    setForm((prev) => ({
+                                        ...prev,
+                                        botField: event.target.value,
+                                    }))
+                                }
+                            />
+                        </label>
+                    </p>
+
+                    <div className="grid gap-4 md:grid-cols-2">
+                        <label className="flex flex-col gap-2 text-sm">
+                            Name *
+                            <input
+                                type="text"
+                                name="name"
+                                required
+                                value={form.name}
+                                onChange={handleChange}
+                                className="rounded-lg border border-ink/30 bg-panel px-3 py-2 text-ink placeholder-ink-3/60 focus:border-accent focus:outline-none"
+                                placeholder="Your Name"
+                            />
+                        </label>
+                        <label className="flex flex-col gap-2 text-sm">
+                            Work email *
+                            <input
+                                type="email"
+                                name="email"
+                                required
+                                value={form.email}
+                                onChange={handleChange}
+                                className="rounded-lg border border-ink/30 bg-panel px-3 py-2 text-ink placeholder-ink-3/60 focus:border-accent focus:outline-none"
+                                placeholder="name@company.com"
+                            />
+                        </label>
+                        <label className="flex flex-col gap-2 text-sm">
+                            Organization
+                            <input
+                                type="text"
+                                name="company"
+                                value={form.company}
+                                onChange={handleChange}
+                                className="rounded-lg border border-ink/30 bg-panel px-3 py-2 text-ink placeholder-ink-3/60 focus:border-accent focus:outline-none"
+                                placeholder="Acme Inc"
+                            />
+                        </label>
+                        <label className="flex flex-col gap-2 text-sm">
+                            Role
+                            <input
+                                type="text"
+                                name="role"
+                                value={form.role}
+                                onChange={handleChange}
+                                className="rounded-lg border border-ink/30 bg-panel px-3 py-2 text-ink placeholder-ink-3/60 focus:border-accent focus:outline-none"
+                                placeholder="Operations Manager"
+                            />
+                        </label>
+                    </div>
+
+                    <label className="flex flex-col gap-2 text-sm">
+                        Workflows you would consider contributing
+                        <input
+                            type="text"
+                            name="workflows"
+                            value={form.workflows}
+                            onChange={handleChange}
+                            className="rounded-lg border border-ink/30 bg-panel px-3 py-2 text-ink placeholder-ink-3/60 focus:border-accent focus:outline-none"
+                            placeholder="Claims intake, eligibility checks, order entry"
+                        />
+                    </label>
+
+                    <label className="flex flex-col gap-2 text-sm">
+                        Anything else
+                        <textarea
+                            name="message"
+                            rows={4}
+                            value={form.message}
+                            onChange={handleChange}
+                            className="rounded-lg border border-ink/30 bg-panel px-3 py-2 text-ink placeholder-ink-3/60 focus:border-accent focus:outline-none"
+                            placeholder="Systems involved, data sensitivity, questions about the terms"
+                        />
+                    </label>
+
+                    {error && (
+                        <p className="rounded-lg border border-red-800/40 bg-red-100 px-3 py-2 text-sm text-red-900">
+                            {error}
+                        </p>
+                    )}
+
+                    <p className="text-xs leading-relaxed text-ink-3">
+                        Registering interest shares only the contact details
+                        above. It does not enable any upload, share any
+                        workflow data, or accept any terms.
+                    </p>
+                    <div className="flex flex-wrap items-center gap-3">
+                        <button
+                            type="submit"
+                            disabled={isSubmitting}
+                            className="btn-ink disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                            {isSubmitting
+                                ? 'Submitting...'
+                                : 'Request access'}
+                        </button>
+                        <Link href="/" className="btn-ghost-ink">
+                            Back to home
+                        </Link>
+                    </div>
+                </form>
+            ) : (
+                <div className="rounded-xl border border-accent/40 bg-accent/10 px-4 py-4">
+                    <p className="text-sm text-accent">
+                        Thanks. You are on the early-access list for the
+                        contributor program. We will reach out when the
+                        versioned terms are finalized and access opens.
+                    </p>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -414,6 +414,37 @@ export default function Pricing({ hostedOffer = null }) {
                     </aside>
                 </div>
 
+                {/*
+                 * Option A (chosen): a credits callout under the tiers, not a
+                 * fourth "pay-with-data" tier. Frames credits as extending
+                 * your monthly run cap, which is what the mechanism does.
+                 * Marked early access; links to /contribute for the full
+                 * program, guarantees, and terms status.
+                 */}
+                <div className="mx-auto mt-10 max-w-3xl rounded-2xl border border-hairline bg-panel p-6 md:p-7">
+                    <div className="flex flex-wrap items-center gap-3">
+                        <p className="eyebrow">Earn credits by contributing</p>
+                        <span className="rounded-full border border-hairline bg-ground px-3 py-1 font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-ink-2">
+                            Early access
+                        </span>
+                    </div>
+                    <p className="mt-3 text-sm leading-relaxed text-ink-2">
+                        Contribute a sanitized, de-identified derivative to the
+                        shared hardening corpus and earn run credits that
+                        extend your monthly run cap. Raw recordings never
+                        leave your machine, you approve every byte, and it
+                        stays opt-in; you can stop future contributions at any
+                        time. The program opens once its versioned terms are
+                        finalized.{' '}
+                        <Link
+                            href="/contribute"
+                            className="text-accent underline"
+                        >
+                            Request access to the contributor program.
+                        </Link>
+                    </p>
+                </div>
+
                 <p className="mx-auto mt-8 max-w-3xl text-center text-xs leading-relaxed text-ink-3">
                     {hostedOfferAvailable
                         ? 'The Cloud subscription price comes directly from Stripe and is confirmed again at checkout.'

--- a/pages/contribute.js
+++ b/pages/contribute.js
@@ -1,0 +1,350 @@
+import Head from 'next/head'
+import Link from 'next/link'
+
+import ContributorProgramForm from '@components/ContributorProgramForm'
+import Footer from '@components/Footer'
+
+// Dedicated page for the contribute-for-credits program.
+//
+// EARLY ACCESS (gated on legal terms): copy is "request access", never "upload
+// now / available today", and never claims any data has been collected. The
+// framing is binding (see the data-for-credits framing brief): lead with the
+// guarantees, frame it as strengthening the shared hardening corpus, and never
+// say "sell/monetize your data" or attach a per-record price. When target-state
+// confidence and legal factuality conflict, factuality wins.
+//
+// The "Program status" section below is load-bearing: it discloses, on the
+// page itself, that the contribution path is versioned-terms-gated and off by
+// default until those terms are finalized. That converts the target-state
+// promise into disclosed status rather than an implied live capability.
+
+const GUARANTEES = [
+    {
+        title: 'Sanitized derivatives only',
+        body: 'You contribute a sanitized, de-identified derivative. Raw recordings never leave your machine or tenant.',
+    },
+    {
+        title: 'You approve every byte',
+        body: 'Nothing is shared until you review the exact bytes locally and approve them through hash-bound review.',
+    },
+    {
+        title: 'Opt-in and under your control',
+        body: 'The program is opt-in and off by default. You can stop future contributions at any time. Accepted contributions remain governed by the versioned terms you approved.',
+    },
+    {
+        title: 'De-identification standard',
+        body: 'Contributions are sanitized to a de-identification standard, and you attest that a contribution meets it.',
+    },
+]
+
+const STEPS = [
+    {
+        n: '1',
+        title: 'Record and compile locally',
+        body: 'You record and compile a workflow the way you already do. The original recording stays on your machine.',
+    },
+    {
+        n: '2',
+        title: 'Sanitize a derivative',
+        body: 'A derivative is sanitized to a de-identification standard. You review it locally, not us.',
+    },
+    {
+        n: '3',
+        title: 'Approve the exact bytes',
+        body: 'You approve the sanitized derivative through hash-bound local review. Only that approved copy is eligible to contribute.',
+    },
+    {
+        n: '4',
+        title: 'Contribute to the corpus',
+        body: 'The approved, sanitized derivative passes manifest and runtime validation at ingest, then strengthens the shared hardening corpus.',
+    },
+    {
+        n: '5',
+        title: 'Earn run credits',
+        body: 'Your contribution earns run credits that extend your usage allowance. Not cash, and no per-record price.',
+    },
+]
+
+const FAQ = [
+    {
+        q: 'Is my raw data ever uploaded?',
+        a: 'No. Raw recordings never leave your machine. Only a sanitized, de-identified derivative that you have reviewed and approved is eligible to contribute.',
+    },
+    {
+        q: 'Is this PHI?',
+        a: 'The program accepts only derivatives that your organization has de-identified to the required named standard and attests are eligible to contribute. Sanitization alone is not a legal determination. If your organization cannot make that attestation, the derivative is not eligible and must not be shared.',
+    },
+    {
+        q: 'Can I stop?',
+        a: 'Yes. The program is opt-in and off by default, and you can stop future contributions at any time. A contribution already accepted remains governed by the versioned terms you approved when you submitted it.',
+    },
+    {
+        q: 'What is the standard?',
+        a: 'The required de-identification standard is named in the versioned contribution terms before access opens. Your organization attests that each derivative meets it, and you approve the exact bytes through hash-bound local review.',
+    },
+    {
+        q: 'What do I get?',
+        a: 'Run credits that extend your monthly run cap. Credits are service credits, not cash, and there is no per-record price.',
+    },
+]
+
+const webPageSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    name: 'Contribute data for credits',
+    url: 'https://openadapt.ai/contribute',
+    description:
+        'Early-access contributor program: contribute sanitized, de-identified derivatives to the shared hardening corpus and earn run credits that extend your usage allowance. Raw recordings never leave your machine; you approve every byte; future contributions can stop at any time.',
+    isPartOf: {
+        '@type': 'WebSite',
+        name: 'OpenAdapt.AI',
+        url: 'https://openadapt.ai',
+    },
+    about: {
+        '@type': 'SoftwareApplication',
+        name: 'OpenAdapt',
+        url: 'https://openadapt.ai',
+    },
+    inLanguage: 'en',
+}
+
+export default function ContributePage() {
+    return (
+        <div className="min-h-screen bg-ground text-ink">
+            <Head>
+                <title>Contribute data for credits | OpenAdapt</title>
+                <meta
+                    name="description"
+                    content="Early access. Contribute sanitized, de-identified derivatives to the shared hardening corpus and earn run credits that extend your usage allowance. Raw recordings never leave your machine; you approve every byte; future contributions can stop at any time."
+                />
+                <link rel="canonical" href="https://openadapt.ai/contribute" />
+                <meta
+                    property="og:title"
+                    content="Contribute data for credits | OpenAdapt"
+                />
+                <meta
+                    property="og:description"
+                    content="Early access. Contribute sanitized, de-identified derivatives to the shared hardening corpus and earn run credits. Raw recordings never leave your machine; you approve every byte; future contributions can stop at any time."
+                />
+                <meta
+                    property="og:url"
+                    content="https://openadapt.ai/contribute"
+                />
+                <script
+                    type="application/ld+json"
+                    dangerouslySetInnerHTML={{
+                        __html: JSON.stringify(webPageSchema),
+                    }}
+                />
+            </Head>
+
+            {/* Hero: what it is, and the status */}
+            <div className="mx-auto max-w-4xl px-4 py-14 md:py-16">
+                <div className="flex flex-wrap items-center gap-3">
+                    <p className="eyebrow">Contributor program</p>
+                    <span className="rounded-full border border-hairline bg-panel px-3 py-1 font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-ink-2">
+                        Early access
+                    </span>
+                </div>
+                <h1 className="mt-4 font-display text-3xl font-semibold tracking-tight text-ink md:text-4xl">
+                    Contribute data for credits
+                </h1>
+                <p className="mt-5 max-w-3xl text-base leading-relaxed text-ink-2 md:text-lg">
+                    Every sanitized contribution strengthens the shared
+                    hardening corpus, the commons that lowers everyone&apos;s
+                    silent-wrong-effect rate. In return, you earn run credits
+                    that extend your usage allowance. This program is in early
+                    access while the terms are finalized, so you register
+                    interest and we grant access; there is no upload flow today.
+                </p>
+                <p className="mt-4 text-sm font-medium text-ink">
+                    Early access. Opt-in. Sanitized derivatives only.
+                </p>
+                <div className="mt-7">
+                    <Link href="#request-access" className="btn-ink">
+                        Request access
+                    </Link>
+                </div>
+            </div>
+
+            {/* Guarantees */}
+            <div className="mx-auto max-w-4xl px-4 pb-14">
+                <div className="border-t-2 border-ink pt-10">
+                    <p className="eyebrow">The guarantees</p>
+                    <h2 className="mt-2 font-display text-2xl font-semibold tracking-tight text-ink">
+                        Built to protect the contributor first
+                    </h2>
+                    <ul className="mt-8 grid gap-4 md:grid-cols-2">
+                        {GUARANTEES.map((g) => (
+                            <li
+                                key={g.title}
+                                className="rounded-xl border border-hairline bg-panel p-5"
+                            >
+                                <strong className="block font-display text-base font-semibold text-ink">
+                                    {g.title}
+                                </strong>
+                                <p className="mt-2 text-sm leading-relaxed text-ink-2">
+                                    {g.body}
+                                </p>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            </div>
+
+            {/* How it works */}
+            <div className="mx-auto max-w-4xl px-4 pb-14">
+                <div className="border-t-2 border-ink pt-10">
+                    <p className="eyebrow">How it works</p>
+                    <h2 className="mt-2 font-display text-2xl font-semibold tracking-tight text-ink">
+                        The same sanitize, approve, ingest path you already use
+                    </h2>
+                    <p className="mt-3 max-w-3xl text-sm leading-relaxed text-ink-2 md:text-base">
+                        A contribution references an already-approved sanitized
+                        derivative: the exact bytes that already passed local
+                        review and hash-bound approval. There is no separate
+                        upload of raw data, ever.
+                    </p>
+                    <ol className="mt-8 space-y-4">
+                        {STEPS.map((s) => (
+                            <li
+                                key={s.n}
+                                className="flex gap-4 rounded-xl border border-hairline bg-panel p-5"
+                            >
+                                <span className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full border border-hairline bg-ground font-mono text-sm text-accent">
+                                    {s.n}
+                                </span>
+                                <div>
+                                    <strong className="block font-display text-base font-semibold text-ink">
+                                        {s.title}
+                                    </strong>
+                                    <p className="mt-1 text-sm leading-relaxed text-ink-2">
+                                        {s.body}
+                                    </p>
+                                </div>
+                            </li>
+                        ))}
+                    </ol>
+                </div>
+            </div>
+
+            {/* What you get */}
+            <div className="mx-auto max-w-4xl px-4 pb-14">
+                <div className="border-t-2 border-ink pt-10">
+                    <p className="eyebrow">What you get</p>
+                    <h2 className="mt-2 font-display text-2xl font-semibold tracking-tight text-ink">
+                        Run credits that extend your usage allowance
+                    </h2>
+                    <p className="mt-3 max-w-3xl text-sm leading-relaxed text-ink-2 md:text-base">
+                        Contributions earn run credits that extend your monthly
+                        run cap, the same cap shown on the{' '}
+                        <Link
+                            href="/pricing"
+                            className="text-accent underline"
+                        >
+                            pricing page
+                        </Link>
+                        . Credits are service credits that fund usage. They are
+                        not cash, there is no per-record price, and OpenAdapt
+                        does not buy your data.
+                    </p>
+                </div>
+            </div>
+
+            {/* Program status and eligibility: disclosed, not implied */}
+            <div className="mx-auto max-w-4xl px-4 pb-14">
+                <div className="border-t-2 border-ink pt-10">
+                    <p className="eyebrow">Program status and eligibility</p>
+                    <h2 className="mt-2 font-display text-2xl font-semibold tracking-tight text-ink">
+                        Gated on versioned terms, off by default
+                    </h2>
+                    <div className="mt-6 space-y-4 rounded-xl border border-hairline bg-panel p-5">
+                        <p className="text-sm leading-relaxed text-ink-2">
+                            <strong className="text-ink">
+                                Status: early access.
+                            </strong>{' '}
+                            The contribution terms are versioned, and the
+                            contribution path stays off by default until a
+                            finalized terms version is active. The terms name
+                            the required de-identification standard, the
+                            contributor attestation, the jurisdiction scope,
+                            and the curation rules under which a contribution
+                            can be declined. Requesting access today registers
+                            interest only; it does not accept any terms, enable
+                            any upload, or share any workflow data. No customer
+                            or patient data has been collected through this
+                            program.
+                        </p>
+                        <p className="text-sm leading-relaxed text-ink-2">
+                            <strong className="text-ink">Eligibility.</strong>{' '}
+                            When access opens, contributions are accepted only
+                            from organizations that can attest, under the
+                            versioned terms, that each derivative meets the
+                            required named de-identification standard, that
+                            they have the right to contribute it, and that
+                            contributing does not breach their own downstream
+                            agreements. Sanitization alone is not a legal
+                            determination. Contributions are curated: a
+                            derivative that does not conform can be declined,
+                            and declined contributions earn no credits.
+                        </p>
+                        <p className="text-sm leading-relaxed text-ink-2">
+                            <strong className="text-ink">
+                                When you accept a terms version.
+                            </strong>{' '}
+                            Your acceptance records the exact terms version and
+                            timestamp. You can stop future contributions at any
+                            time; a contribution already accepted remains
+                            governed by the versioned terms you approved when
+                            you submitted it.
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            {/* FAQ */}
+            <div className="mx-auto max-w-4xl px-4 pb-14">
+                <div className="border-t-2 border-ink pt-10">
+                    <p className="eyebrow">FAQ</p>
+                    <h2 className="mt-2 font-display text-2xl font-semibold tracking-tight text-ink">
+                        Straight answers
+                    </h2>
+                    <dl className="mt-8 space-y-6">
+                        {FAQ.map((item) => (
+                            <div key={item.q}>
+                                <dt className="font-display text-base font-semibold text-ink">
+                                    {item.q}
+                                </dt>
+                                <dd className="mt-2 max-w-3xl text-sm leading-relaxed text-ink-2">
+                                    {item.a}
+                                </dd>
+                            </div>
+                        ))}
+                    </dl>
+                </div>
+            </div>
+
+            {/* Request access CTA: dedicated contributor-program intake */}
+            <div id="request-access" className="scroll-mt-20 pb-16">
+                <div className="mx-auto max-w-4xl px-4 pt-10">
+                    <div className="border-t-2 border-ink pt-10">
+                        <p className="eyebrow">Request access</p>
+                        <h2 className="mt-2 font-display text-2xl font-semibold tracking-tight text-ink">
+                            Register interest in the contributor program
+                        </h2>
+                        <p className="mt-3 max-w-3xl text-sm leading-relaxed text-ink-2 md:text-base">
+                            Tell us a little about your workflows and we will
+                            reach out as early access opens. Registering does
+                            not enable any upload or share any data.
+                        </p>
+                        <div className="mt-8">
+                            <ContributorProgramForm />
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <Footer />
+        </div>
+    )
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,7 @@
 import Head from 'next/head'
 
 import CommercialOffer from '@components/CommercialOffer'
+import ContributeSection from '@components/ContributeSection'
 import CustomerCaseStudy from '@components/CustomerCaseStudy'
 import DashboardShowcase from '@components/DashboardShowcase'
 import FinalQualificationCta from '@components/FinalQualificationCta'
@@ -161,6 +162,16 @@ export default function Home({ githubStats, hostedOffer }) {
             <Reveal><CommercialOffer hostedOffer={hostedOffer} /></Reveal>
             <Reveal><DashboardShowcase /></Reveal>
             <Reveal><TrustSummary /></Reveal>
+            {/*
+             * Contribute-for-credits sits after the trust summary because it
+             * is a commons / flywheel message that extends the open-source
+             * trust story: sanitized contributions strengthen the shared
+             * hardening corpus. It stays out of the hero, the commercial
+             * offer, and the closing qualification CTA so it never interrupts
+             * the buying narrative. Early access, opt-in, links to
+             * /contribute.
+             */}
+            <Reveal><ContributeSection /></Reveal>
             <Reveal><FinalQualificationCta /></Reveal>
             <Footer
                 repositoryStats={currentGithubStats}

--- a/public/form.html
+++ b/public/form.html
@@ -55,6 +55,18 @@
   <input type="text" name="qualificationTier" />
 </form>
 
+<form name="contributor-program" data-netlify="true" method="POST" netlify netlify-honeypot="bot-field">
+  <input type="hidden" name="form-name" value="contributor-program" />
+  <input type="text" name="bot-field" />
+  <input type="text" name="name" />
+  <input type="email" name="email" />
+  <input type="text" name="company" />
+  <input type="text" name="role" />
+  <input type="text" name="workflows" />
+  <textarea name="message"></textarea>
+  <button type="submit">Request access</button>
+</form>
+
 <form name="dental-founding-cohort" data-netlify="true" method="POST" netlify netlify-honeypot="bot-field">
   <input type="hidden" name="form-name" value="dental-founding-cohort" />
   <input type="text" name="bot-field" />

--- a/tests/contributeProgram.test.js
+++ b/tests/contributeProgram.test.js
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import test from 'node:test'
+
+const landing = fs.readFileSync('components/ContributeSection.js', 'utf8')
+const pricing = fs.readFileSync('components/Pricing.js', 'utf8')
+const page = fs.readFileSync('pages/contribute.js', 'utf8')
+const intake = fs.readFileSync('components/ContributorProgramForm.js', 'utf8')
+const formDefinitions = fs.readFileSync('public/form.html', 'utf8')
+const home = fs.readFileSync('pages/index.js', 'utf8')
+
+// JSX wraps prose across indented lines, so phrase assertions run against a
+// whitespace-normalized view. Banned-phrase checks also strip JS comments,
+// which quote the banned phrases as guidance.
+const norm = (source) => source.replace(/\s+/g, ' ')
+const stripComments = (source) =>
+    source.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '')
+const rendered = norm(
+    stripComments(`${landing}\n${pricing}\n${page}\n${intake}`)
+)
+const pageText = norm(page)
+
+test('contributor copy never turns sanitization into a categorical legal conclusion', () => {
+    assert.doesNotMatch(rendered, /de-identified derivatives are not PHI/i)
+    assert.doesNotMatch(rendered, /no BAA (is )?required|BAA[- ]free/i)
+    assert.match(pageText, /Sanitization alone is not a legal determination/)
+    assert.match(pageText, /required named standard/)
+})
+
+test('stopping future contributions does not promise revocation of accepted terms', () => {
+    assert.doesNotMatch(rendered, /revocable going forward/i)
+    assert.match(rendered, /stop future contributions at any time/i)
+    assert.match(
+        pageText,
+        /already accepted remains governed by the versioned terms/i
+    )
+})
+
+test('contributor copy never frames the program as selling data or names a price', () => {
+    assert.doesNotMatch(rendered, /sell your data|monetize your data/i)
+    assert.doesNotMatch(rendered, /we buy your data/i)
+    assert.doesNotMatch(rendered, /per[- ]record price of|\$\d+ per record/i)
+    // Early access framing, never a live capability.
+    assert.doesNotMatch(rendered, /upload (your data )?today|available today/i)
+    assert.match(rendered, /Early access/)
+})
+
+test('the terms-gated program status is disclosed on the page itself', () => {
+    assert.match(pageText, /Program status and eligibility/)
+    assert.match(
+        pageText,
+        /off by default until a finalized terms version is active/i
+    )
+    assert.match(
+        pageText,
+        /No customer or patient data has been collected through this program/
+    )
+    assert.match(pageText, /declined contributions earn no credits/i)
+})
+
+test('contributor leads use a dedicated Netlify form, segmented from contact', () => {
+    // The runtime submit and the build-time definition must agree on the
+    // form name, or Netlify silently drops submissions.
+    assert.match(intake, /formData\.set\('form-name', 'contributor-program'\)/)
+    assert.match(intake, /fetch\('\/form\.html'/)
+    assert.match(
+        formDefinitions,
+        /<form name="contributor-program" data-netlify="true"/
+    )
+    for (const field of [
+        'name',
+        'email',
+        'company',
+        'role',
+        'workflows',
+        'message',
+    ]) {
+        assert.ok(
+            new RegExp(`name="${field}"`).test(intake),
+            `intake posts field ${field}`
+        )
+    }
+    // The page uses the dedicated intake, not the generic contact intake.
+    assert.match(page, /ContributorProgramForm/)
+    assert.doesNotMatch(page, /ContactBookingSection/)
+})
+
+test('the homepage renders the contribute section and pricing carries the credits callout', () => {
+    assert.match(home, /<ContributeSection \/>/)
+    assert.match(norm(pricing), /Earn credits by contributing/)
+    assert.match(pricing, /href="\/contribute"/)
+    // The page links to the real pricing route, not a stale homepage anchor.
+    assert.match(page, /href="\/pricing"/)
+    assert.doesNotMatch(page, /href="\/#pricing"/)
+})
+
+test('contribute surfaces contain no em dashes', () => {
+    for (const [label, source] of [
+        ['ContributeSection', landing],
+        ['contribute page', page],
+        ['ContributorProgramForm', intake],
+    ]) {
+        assert.ok(!source.includes('—'), `${label} has no em dashes`)
+    }
+})


### PR DESCRIPTION
## Coordinated early-access rollout — hold for final program approval

This is the public website surface for the data-for-credits target state. The underlying Cloud mechanism is inert and OFF by default until the versioned contribution terms, named de-identification standard and attestation, jurisdiction scope, and curation path are active. Nothing in this PR enables uploads or claims customer data has been collected.

## Public surfaces

1. Landing-page section after the adoption block, framed as strengthening the shared hardening corpus.
2. Dedicated `/contribute` page with the local sanitize → exact-byte approval → validated ingest → credits lifecycle and the existing contact intake.
3. Pricing callout that extends the monthly run allowance rather than creating a pay-with-data tier.

## Binding copy contract

- raw recordings never leave the contributor boundary
- only a locally reviewed, hash-bound derivative is eligible
- the contributor organization must attest that it meets the named de-identification standard in the versioned terms; sanitization alone is not presented as a legal determination
- contributors can stop future contributions at any time; accepted contributions remain governed by the terms version approved at submission
- service credits only, never cash or per-record pricing
- early access/request access, never available today

## Verification

- `npm test`: 117 tests pass, including two new contribution-copy regression tests
- the page remains statically renderable
- GitHub CI is authoritative while the owning Netlify team remains quota-blocked; the Netlify failures occur before source build

Hold merge until the coordinated program copy and terms are approved together. The code path remains fail-closed and OFF by default.