### PR TITLE
chore(netlify): re-enable PR deploy previews on Personal

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,11 +11,12 @@
 [[plugins]]
   package = "@netlify/plugin-nextjs"
 
-# PR deploy previews build and deploy on Netlify. The site is now on the
-# Pro/Personal plan (25,000 build-min/mo), so the Free-plan quota that forced
-# us to skip preview builds in #261 no longer applies. Deploy previews give
-# reviewers a live, rendered URL per PR, which the GitHub Actions
-# `build-and-e2e` job (headless `next build` + Cypress) cannot.
+# PR deploy previews build and deploy on Netlify. The intended paid tier is
+# Personal; Deploy Previews do not require Pro. Once Personal is active on the
+# team that owns this site, the Free-plan quota that forced us to skip preview
+# builds in #261 no longer applies. Deploy previews give reviewers a live,
+# rendered URL per PR, which the GitHub Actions `build-and-e2e` job (headless
+# `next build` + Cypress) cannot.
 #
 # `ignore` runs before each build: exit 0 cancels the build, non-zero proceeds.
 # The production context has no `ignore`, so pushes to main always build and

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,16 +11,16 @@
 [[plugins]]
   package = "@netlify/plugin-nextjs"
 
-# Preview and branch builds are skipped to protect the production build-minute
-# budget. `ignore` runs before each build: exit 0 cancels the build, non-zero
-# proceeds. Deploy-preview (PR) and branch-deploy contexts are already covered
-# by the GitHub Actions `build-and-e2e` job (real `next build` + Cypress
-# browser contract), so rebuilding them on Netlify only spends minutes that the
-# production context needs. The production context has no `ignore`, so pushes to
-# main always build and deploy.
-[context.deploy-preview]
-  ignore = "exit 0"
-
+# PR deploy previews build and deploy on Netlify. The site is now on the
+# Pro/Personal plan (25,000 build-min/mo), so the Free-plan quota that forced
+# us to skip preview builds in #261 no longer applies. Deploy previews give
+# reviewers a live, rendered URL per PR, which the GitHub Actions
+# `build-and-e2e` job (headless `next build` + Cypress) cannot.
+#
+# `ignore` runs before each build: exit 0 cancels the build, non-zero proceeds.
+# The production context has no `ignore`, so pushes to main always build and
+# deploy. Branch-deploy stays skipped: per-branch deploys are lower value than
+# PR previews and would still spend minutes with no reviewer attached.
 [context.branch-deploy]
   ignore = "exit 0"
 


### PR DESCRIPTION
## What\n\nRemove the deploy-preview skip from netlify.toml so every pull request gets a live rendered Netlify preview again. Branch deploys stay skipped and production builds are unchanged.\n\n## Current provider state\n\nVerified through the authenticated Netlify API on 2026-07-21: the exact owning team is now on Personal and no longer reports an exceeded-usage state. Pro is not required.\n\n## Verification\n\n- Rebased onto current website main at b3ca75c\n- Local website suite: 124/124 passed\n- GitHub CI and the refreshed Netlify preview are the merge gates\n- No production deployment or production configuration changes are made by this PR