### PR TITLE
refactor(home): keep maturity ledger off sales narrative

### DIFF
--- a/components/ProductStatus.js
+++ b/components/ProductStatus.js
@@ -1,7 +1,5 @@
 import Link from 'next/link'
 
-import status from '../public/status.json'
-
 const FLOW_URL = 'https://github.com/OpenAdaptAI/openadapt-flow'
 const LIMITS_URL = `${FLOW_URL}/blob/main/docs/LIMITS.md`
 const EVIDENCE_URL = `${FLOW_URL}/tree/main/benchmark`
@@ -131,70 +129,6 @@ export default function ProductStatus() {
                             </div>
                         ))}
                     </div>
-                </div>
-
-                <div
-                    id="interface-readiness"
-                    className="mt-8 rounded-2xl border border-hairline bg-ground p-5 md:p-7"
-                >
-                    <p className="eyebrow">Every interface, first-class</p>
-                    <h3 className="mt-2 max-w-2xl font-display text-xl font-semibold tracking-tight text-ink md:text-2xl">
-                        One governed loop across every surface
-                    </h3>
-                    <p className="mt-3 max-w-3xl text-sm leading-relaxed text-ink-2">
-                        Every surface below runs the same governed loop, and each
-                        carries a maturity label that says how broadly it has been
-                        exercised today. Each label is read from one{' '}
-                        <a
-                            href="/status.json"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-accent underline"
-                        >
-                            machine-readable status manifest
-                        </a>
-                        , so the website, docs, launcher, and packages stay in
-                        lockstep.
-                    </p>
-                    <ul className="mt-6 grid gap-4 md:grid-cols-2">
-                        {status.substrates.map((substrate) => (
-                            <li
-                                key={substrate.name}
-                                className="rounded-xl border border-hairline bg-panel p-5"
-                            >
-                                <div className="flex flex-wrap items-baseline justify-between gap-2">
-                                    <h4 className="font-display font-semibold text-ink">
-                                        {substrate.name}
-                                    </h4>
-                                    <span className="rounded-full border border-hairline px-2.5 py-0.5 font-mono text-xs font-medium text-accent">
-                                        {substrate.public_label}
-                                    </span>
-                                </div>
-                                <p className="mt-2 text-sm leading-relaxed text-ink-2">
-                                    {substrate.evidence_note}
-                                </p>
-                            </li>
-                        ))}
-                    </ul>
-                    <dl className="mt-6 grid gap-x-6 gap-y-2 rounded-xl border border-hairline bg-panel p-5 text-sm leading-relaxed sm:grid-cols-2">
-                        <p className="col-span-full font-display text-xs font-semibold uppercase tracking-[0.14em] text-ink-3">
-                            What the labels mean
-                        </p>
-                        {Object.entries(status.tiers).map(([tier, meaning]) => (
-                            <div key={tier} className="flex gap-2">
-                                <dt className="flex-shrink-0 font-mono text-xs font-medium text-accent">
-                                    {tier}
-                                </dt>
-                                <dd className="text-ink-2">{meaning}</dd>
-                            </div>
-                        ))}
-                    </dl>
-                    <p className="mt-5 font-mono text-xs text-ink-3">
-                        Current components: launcher{' '}
-                        <span className="text-ink-2">openadapt {status.versions.launcher}</span>{' '}
-                        · <span className="text-ink-2">openadapt-flow {status.versions.flow}</span>{' '}
-                        · <span className="text-ink-2">desktop {status.versions.desktop}</span>
-                    </p>
                 </div>
 
                 <div className="mt-8 rounded-2xl border border-hairline bg-ground p-5 md:p-7">

--- a/tests/statusManifest.test.js
+++ b/tests/statusManifest.test.js
@@ -104,30 +104,24 @@ test('status manifest encodes the verified component versions', () => {
     assert.match(manifest.generated_at, /^\d{4}-\d{2}-\d{2}$/)
 })
 
-test('homepage substrate matrix renders labels, tiers, and versions from the manifest', () => {
-    // The rendered labels must come from the manifest, not hardcoded strings,
-    // so a label change in status.json is the only edit needed and the homepage
-    // can never disagree with the source of truth.
+test('homepage presents capabilities without exposing the maturity ledger', () => {
+    // The sales page describes the target product capability. The public status
+    // manifest remains available to technical consumers, but transient maturity
+    // labels and component versions do not belong in the homepage narrative.
     const product = read('components/ProductStatus.js')
 
-    assert.match(product, /import status from '\.\.\/public\/status\.json'/)
-    assert.match(product, /status\.substrates\.map/)
-    assert.match(product, /substrate\.public_label/)
-    assert.match(product, /substrate\.evidence_note/)
-    // The tier legend is rendered from the manifest ladder.
-    assert.match(product, /status\.tiers/)
-    assert.match(product, /status\.versions\.launcher/)
-    assert.match(product, /status\.versions\.flow/)
-    assert.match(product, /status\.versions\.desktop/)
-    assert.match(product, /status\.json/)
+    assert.doesNotMatch(product, /public\/status\.json/)
+    assert.doesNotMatch(product, /status\.substrates|substrate\.public_label/)
+    assert.doesNotMatch(product, /status\.tiers|status\.versions/)
+    assert.match(product, /Web applications/)
+    assert.match(product, /Windows applications/)
+    assert.match(product, /RDP, Citrix & VDI/)
 
-    // The canonical label strings must not be hardcoded into the component —
-    // that would let them drift from the manifest.
     for (const label of Object.values(CANONICAL_LABELS)) {
         assert.doesNotMatch(
             product,
             new RegExp(`['"\\s]${label}['"\\s]`),
-            `ProductStatus must read "${label}" from the manifest, not inline it`
+            `ProductStatus must not render the temporary "${label}" label`
         )
     }
 })


### PR DESCRIPTION
## What changed

- removed the duplicate homepage maturity/version ledger
- kept the concise capability cards for web, Windows, RDP, Citrix, and VDI
- retained `public/status.json` as the technical lifecycle source without making it part of the sales narrative
- added a regression contract that prevents temporary lifecycle labels from returning to the homepage component

## Why

The previous redesign changed the section title but still exposed Beta, Early access, and Exploratory labels plus component versions in the middle of the landing page. That mixed an implementation ledger into the buyer journey and repeated the capability section immediately above it.

The homepage now presents the target product capability. Technical lifecycle evidence remains machine-readable and continues to be validated independently.

## Validation

- `npm test` — 115 passed
- production `next build` — passed
- `git diff --check` — passed
