### PR TITLE
Support native Desktop Beta releases without a flag day

### DIFF
--- a/components/DesktopPreview.js
+++ b/components/DesktopPreview.js
@@ -1,11 +1,11 @@
 /**
- * DesktopPreview — real screenshots of the Experimental desktop surfaces on
+ * DesktopPreview — real screenshots of the native desktop surfaces on
  * the download page, plus an honest per-OS representation of where the
  * separate tray companion places its icon.
  *
  * Honesty contract (enforced by tests/desktopPreview.test.js and documented in
  * public/desktop-preview/MANIFEST.json):
- *  - Every /desktop-preview/cockpit/ image is a capture of the real Experimental
+ *  - Every /desktop-preview/cockpit/ image is a capture of the real native
  *    desktop app running the real wired engine, signed in against a locally-run
  *    instance of the OpenAdapt cloud in mock mode (not a production org). The
  *    workflow, run, and halt data shown is a real local demo recording: two
@@ -30,7 +30,7 @@
 const TRAY_PACKAGE_VERSION = '0.1.1'
 const WINDOWS_INSTALLER_VERSION = '0.6.1'
 
-// Real captures of the live Experimental desktop app running the real wired
+// Real captures of the live native desktop app running the real wired
 // engine. Signed in against a locally-run instance of the cloud in mock mode
 // (not a production org); the workflows/runs/halt shown are a real local demo
 // recording (recorded via demo-record, compiled, and replayed on this machine).
@@ -353,18 +353,19 @@ export default function DesktopPreview() {
                     Real screenshots, honest state
                 </h2>
                 <p className="mt-3 max-w-2xl text-sm leading-relaxed text-ink-2">
-                    These are unretouched captures of the real Experimental
-                    desktop app running the real wired engine, not a rendering of
+                    These are unretouched captures of the real native desktop
+                    app running the real wired engine, not a rendering of
                     a finished product. The workflows, runs, and the halt shown
                     below are a real local demo recording: two workflows recorded
                     via demo-record, compiled, and replayed on one machine. It is
                     local demo data, not production or customer data, and the
                     signed-in session was validated against a locally-run
-                    instance of the cloud in mock mode. Experimental prerelease,{' '}
+                    instance of the cloud in mock mode. The pictured release
+                    predates the Beta lane and uses{' '}
                     <span className="whitespace-nowrap">
                         unsigned or ad-hoc-signed
                     </span>{' '}
-                    builds; see the release notes before installing.
+                    installers; see the release notes before installing.
                 </p>
 
                 <div className="mt-8 grid grid-cols-1 gap-8 lg:grid-cols-2">
@@ -418,7 +419,7 @@ export default function DesktopPreview() {
                 </div>
 
                 <p className="mt-6 max-w-2xl text-xs leading-relaxed text-ink-3">
-                    Every capture above is the real Experimental app on the real
+                    Every capture above is the real native app on the real
                     wired engine. The data shown is a local demo recording; it is
                     not a hosted production org and not customer data.
                 </p>
@@ -469,9 +470,9 @@ export default function DesktopPreview() {
                             windows-x86_64-unsigned-nsis-setup.exe
                         </code>{' '}
                         (v{WINDOWS_INSTALLER_VERSION}) running on a real Windows
-                        11 machine. Experimental prerelease, unsigned — Windows
-                        shows an Unknown Publisher warning (expected); see First
-                        launch below for how to proceed safely.
+                        11 machine. This pictured predecessor is unsigned, so
+                        Windows shows an Unknown Publisher warning (expected);
+                        see First launch below for how to proceed safely.
                     </p>
 
                     <div className="mt-8 grid grid-cols-1 items-start gap-6 sm:grid-cols-3">

--- a/cypress/e2e/download.cy.js
+++ b/cypress/e2e/download.cy.js
@@ -60,7 +60,8 @@ describe('download page is server-rendered', () => {
         cy.request('/download').its('body').then((html) => {
             expect(html).to.not.include('Finding the latest release')
             const definiteStates = [
-                'Experimental prerelease', // ready
+                'Beta release', // complete Beta release
+                'Compatibility release', // complete legacy release during transition
                 'No public desktop installer yet', // none
                 'We could not reach GitHub just now', // build-time fetch miss
             ]

--- a/lib/githubApi.js
+++ b/lib/githubApi.js
@@ -84,9 +84,11 @@ export async function getOpenIssuesByLabel(repository, label) {
 }
 
 /**
- * The newest complete Experimental desktop prerelease, slimmed to the fields
+ * The newest complete native desktop prerelease, slimmed to the fields
  * the download page renders (getStaticProps props must stay small and
- * JSON-serializable).
+ * JSON-serializable). Beta sets are accepted only with their per-platform
+ * provenance metadata and SHA256SUMS; complete legacy Experimental sets remain
+ * discoverable during the transition.
  *
  * Returns { release, fetchFailed }:
  * - release: slim release object, or null
@@ -94,15 +96,17 @@ export async function getOpenIssuesByLabel(repository, label) {
  *   "open releases on GitHub" fallback), false when GitHub answered but no
  *   complete prerelease exists yet.
  */
-export async function getExperimentalDesktopRelease() {
-    const { DESKTOP_REPO, selectExperimentalDesktopRelease } = await import(
-        '../utils/desktopRelease'
-    )
+export async function getDesktopRelease() {
+    const {
+        DESKTOP_REPO,
+        desktopReleaseLifecycle,
+        selectDesktopRelease,
+    } = await import('../utils/desktopRelease')
     try {
         const releases = await fetchGitHubJson(
             `/repos/${DESKTOP_REPO}/releases?per_page=20`
         )
-        const selected = selectExperimentalDesktopRelease(releases)
+        const selected = selectDesktopRelease(releases)
         if (!selected) {
             return { release: null, fetchFailed: false }
         }
@@ -110,6 +114,7 @@ export async function getExperimentalDesktopRelease() {
             release: {
                 tag_name: selected.tag_name || null,
                 name: selected.name || null,
+                lifecycle: desktopReleaseLifecycle(selected),
                 assets: (selected.assets || [])
                     .filter(
                         (asset) =>
@@ -129,3 +134,6 @@ export async function getExperimentalDesktopRelease() {
         return { release: null, fetchFailed: true }
     }
 }
+
+// Backward-compatible server API for older page code during rollout.
+export const getExperimentalDesktopRelease = getDesktopRelease

--- a/pages/download.js
+++ b/pages/download.js
@@ -52,9 +52,7 @@ export default function DownloadPage({ release, fetchFailed }) {
         release && Array.isArray(release.assets) ? release.assets : []
     const lifecycle = release?.lifecycle === 'beta' ? 'beta' : 'experimental'
     const releaseLabel =
-        lifecycle === 'beta'
-            ? 'Beta release'
-            : 'Experimental compatibility prerelease'
+        lifecycle === 'beta' ? 'Beta release' : 'Compatibility release'
 
     // Resolve a download for each platform card.
     const platformDownloads = useMemo(

--- a/pages/download.js
+++ b/pages/download.js
@@ -25,9 +25,9 @@ export async function getStaticProps() {
     // The release list is fetched at build/revalidate time so visitor
     // browsers never call api.github.com (60 unauthenticated req/hr per
     // client IP means shared IPs got 403s and a broken download page).
-    const { getExperimentalDesktopRelease } = await import('../lib/githubApi')
-    const { release, fetchFailed } = await getExperimentalDesktopRelease()
-    return { props: { release, fetchFailed }, revalidate: 3600 }
+    const { getDesktopRelease } = await import('../lib/githubApi')
+    const { release, fetchFailed } = await getDesktopRelease()
+    return { props: { release, fetchFailed }, revalidate: 300 }
 }
 
 export default function DownloadPage({ release, fetchFailed }) {
@@ -50,15 +50,20 @@ export default function DownloadPage({ release, fetchFailed }) {
 
     const assets =
         release && Array.isArray(release.assets) ? release.assets : []
+    const lifecycle = release?.lifecycle === 'beta' ? 'beta' : 'experimental'
+    const releaseLabel =
+        lifecycle === 'beta'
+            ? 'Beta release'
+            : 'Experimental compatibility prerelease'
 
     // Resolve a download for each platform card.
     const platformDownloads = useMemo(
         () =>
             DESKTOP_PLATFORMS.map((p) => ({
                 platform: p,
-                asset: assetForPlatform(assets, p),
+                asset: assetForPlatform(assets, p, lifecycle),
             })),
-        [assets]
+        [assets, lifecycle]
     )
 
     const recommended = useMemo(
@@ -77,7 +82,10 @@ export default function DownloadPage({ release, fetchFailed }) {
     )
 
     const version = release ? release.tag_name || release.name : null
-    const signing = useMemo(() => releaseSigningState(assets), [assets])
+    const signing = useMemo(
+        () => releaseSigningState(assets, lifecycle),
+        [assets, lifecycle]
+    )
     const checksumAsset = assets.find((asset) => asset.name === 'SHA256SUMS')
 
     return (
@@ -120,9 +128,9 @@ export default function DownloadPage({ release, fetchFailed }) {
                         OpenAdapt project
                     </a>{' '}
                     installs the compiler and governed runtime under the unified{' '}
-                    <code>openadapt flow</code> command. Native installers are
-                    generated separately from the latest complete Experimental
-                    desktop prerelease.
+                    <code>openadapt flow</code> command. Native OpenAdapt
+                    Desktop Beta installers package that workflow engine for
+                    Windows, macOS, and Linux.
                 </p>
                 <pre className="mt-6 max-w-2xl overflow-x-auto rounded-xl border border-hairline bg-panel p-4 font-mono text-sm text-ink">
                     <code>pip install openadapt</code>
@@ -144,7 +152,7 @@ export default function DownloadPage({ release, fetchFailed }) {
                 <div id="desktop-builds" className="mt-12 scroll-mt-8">
                     <p className="eyebrow">Desktop packaging</p>
                     <h2 className="mt-2 font-display text-2xl font-semibold tracking-tight text-ink">
-                        Native installer preview
+                        Native desktop Beta
                     </h2>
                     {status === 'ready' && recommended && (
                         <div className="rounded-2xl border-2 border-ink bg-panel p-6 md:p-7">
@@ -180,7 +188,7 @@ export default function DownloadPage({ release, fetchFailed }) {
                             </div>
                             {version && (
                                 <p className="mt-3 text-xs text-ink-3">
-                                    Experimental prerelease {version}
+                                    {releaseLabel} {version}
                                 </p>
                             )}
                         </div>
@@ -232,7 +240,7 @@ export default function DownloadPage({ release, fetchFailed }) {
                         detectedId !== 'macos' && (
                         <div>
                             <p className="eyebrow">
-                                Experimental prerelease {version}
+                                {releaseLabel} {version}
                             </p>
                             <p className="mt-2 text-sm text-ink-2">
                                 Choose the build that matches your operating
@@ -244,14 +252,13 @@ export default function DownloadPage({ release, fetchFailed }) {
                     {status === 'none' && (
                         <div className="rounded-2xl border border-hairline bg-panel p-6">
                             <p className="font-display text-lg font-semibold text-ink">
-                                No public desktop installer yet
+                                No complete native desktop release yet
                             </p>
                             <p className="mt-2 max-w-2xl text-sm text-ink-2">
-                                No complete Experimental desktop prerelease has
-                                been published. Use{' '}
+                                The next complete Beta set has not been
+                                published yet. Use{' '}
                                 <code>pip install openadapt</code>, or watch the
-                                desktop releases page for the next native
-                                preview.
+                                desktop releases page for the native build.
                             </p>
                             <div className="mt-4 flex flex-wrap gap-3">
                                 <a
@@ -306,7 +313,7 @@ export default function DownloadPage({ release, fetchFailed }) {
                         All downloads
                     </h2>
                     <p className="mt-3 max-w-2xl text-sm leading-relaxed text-ink-2">
-                        Every installer for the latest Experimental prerelease
+                        Every installer in the latest {releaseLabel.toLowerCase()}
                         {version ? ` (${version})` : ''}. Choose the one that
                         matches your machine.
                     </p>
@@ -364,7 +371,7 @@ export default function DownloadPage({ release, fetchFailed }) {
                 </div>
             )}
 
-            {/* Real captures of the Experimental surfaces (see component). */}
+            {/* Real captures of the native desktop surfaces (see component). */}
             <DesktopPreview />
 
             {/* Guidance is tied to the signing labels in the published assets. */}
@@ -376,7 +383,7 @@ export default function DownloadPage({ release, fetchFailed }) {
                                 First launch
                             </h2>
                             <p className="mt-3 max-w-2xl text-sm leading-relaxed text-ink-2">
-                                Current Experimental builds may trigger an
+                                Current native builds may trigger an
                                 operating-system publisher warning. Verify the
                                 release checksum before overriding it.
                             </p>
@@ -426,8 +433,8 @@ export default function DownloadPage({ release, fetchFailed }) {
                                                 data-testid="download-windows-security-warning"
                                             />
                                             <figcaption className="mt-2 text-xs leading-relaxed text-ink-3">
-                                                The real warning on the unsigned
-                                                Experimental build: &quot;Unknown
+                                                The real warning on the pictured
+                                                unsigned build: &quot;Unknown
                                                 Publisher.&quot; It appears
                                                 because the installer is
                                                 unsigned, not because anything is

--- a/tests/desktopPreview.test.js
+++ b/tests/desktopPreview.test.js
@@ -92,12 +92,13 @@ test('desktop preview uses only provenance-backed real captures', () => {
     }
 })
 
-test('desktop preview labels match the Experimental reality', () => {
+test('desktop preview distinguishes native Beta from historical capture provenance', () => {
     const component = read('components/DesktopPreview.js')
 
-    // The desktop build is an Experimental prerelease with unsigned or
-    // ad-hoc-signed artifacts, and the section says so.
-    assert.match(component, /Experimental prerelease/)
+    // The consumer surface leads with the native app and Beta lane without
+    // rewriting the provenance of screenshots from the earlier release.
+    assert.match(component, /real native desktop/)
+    assert.match(component, /predates the Beta lane/)
     assert.match(component, /unsigned\s+or ad-hoc-signed/)
 
     // The tray is a separate package, carries its real version, and is not
@@ -209,17 +210,16 @@ test('cockpit gallery is the real wired-engine app on honest local demo data', (
     assert.doesNotMatch(component, /does not launch yet/)
 })
 
-test('windows install-flow captions stay honest about the unsigned prerelease', () => {
+test('windows install-flow captions stay honest about the pictured unsigned predecessor', () => {
     const component = read('components/DesktopPreview.js')
     const download = read('pages/download.js')
 
-    // The required honesty phrase for the Windows installer visuals: an
-    // Experimental, unsigned build for which Windows shows an Unknown
-    // Publisher warning, and that warning is expected.
+    // The captured predecessor is unsigned, Windows shows an Unknown Publisher
+    // warning, and that warning is expected.
     assert.match(
         component,
-        /Experimental prerelease, unsigned/,
-        'windows section must state the build is an unsigned Experimental prerelease'
+        /pictured predecessor is unsigned/,
+        'windows section must state the pictured build is an unsigned predecessor'
     )
     assert.match(
         component,

--- a/tests/desktopRelease.test.js
+++ b/tests/desktopRelease.test.js
@@ -109,9 +109,9 @@ test('platform selection stays in the chosen release lifecycle', () => {
     )
 })
 
-test('download copy leads with Beta while naming the compatibility path', () => {
+test('download copy leads with Beta without exposing the predecessor lifecycle', () => {
     const page = readFileSync(new URL('../pages/download.js', import.meta.url), 'utf8')
     assert.match(page, /Native desktop Beta/)
-    assert.match(page, /Experimental compatibility prerelease/)
-    assert.doesNotMatch(page, /latest complete Experimental desktop prerelease/)
+    assert.match(page, /Compatibility release/)
+    assert.doesNotMatch(page, /Experimental/)
 })

--- a/tests/desktopRelease.test.js
+++ b/tests/desktopRelease.test.js
@@ -1,0 +1,117 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+import {
+    assetForPlatform,
+    DESKTOP_PLATFORMS,
+    desktopReleaseLifecycle,
+    isCompleteDesktopRelease,
+    selectDesktopRelease,
+} from '../utils/desktopRelease.js'
+
+const url = (name) => ({
+    name,
+    size: 1024,
+    browser_download_url: `https://github.com/OpenAdaptAI/openadapt-desktop/releases/download/test/${name}`,
+})
+
+function binaryNames(lifecycle, version = '0.7.0') {
+    const prefix = `OpenAdapt-Desktop-${lifecycle}-v${version}`
+    return [
+        `${prefix}-macos-arm64-adhoc.dmg`,
+        `${prefix}-macos-x86_64-adhoc.dmg`,
+        `${prefix}-windows-x86_64-unsigned.msi`,
+        `${prefix}-windows-x86_64-unsigned-nsis-setup.exe`,
+        `${prefix}-linux-x86_64-unsigned.AppImage`,
+        `${prefix}-linux-x86_64-unsigned.deb`,
+    ]
+}
+
+function betaMetadataNames(version = '0.7.0') {
+    const prefix = `OpenAdapt-Desktop-Beta-v${version}`
+    return [
+        `${prefix}-macos-arm64-adhoc-metadata.json`,
+        `${prefix}-macos-x86_64-adhoc-metadata.json`,
+        `${prefix}-windows-x86_64-unsigned-metadata.json`,
+        `${prefix}-linux-x86_64-unsigned-metadata.json`,
+    ]
+}
+
+function release(lifecycle, version, publishedAt) {
+    const names = [
+        ...binaryNames(lifecycle, version),
+        ...(lifecycle === 'Beta' ? betaMetadataNames(version) : []),
+        'SHA256SUMS',
+    ]
+    return {
+        tag_name: `desktop-v${version}`,
+        prerelease: true,
+        draft: false,
+        published_at: publishedAt,
+        assets: names.map(url),
+    }
+}
+
+test('accepts a complete Beta set only with checksums and per-platform provenance', () => {
+    const candidate = release('Beta', '0.7.0', '2026-07-21T12:00:00Z')
+    assert.equal(isCompleteDesktopRelease(candidate), true)
+    assert.equal(desktopReleaseLifecycle(candidate), 'beta')
+
+    candidate.assets = candidate.assets.filter(
+        (asset) => !asset.name.endsWith('windows-x86_64-unsigned-metadata.json')
+    )
+    assert.equal(isCompleteDesktopRelease(candidate), false)
+})
+
+test('keeps complete legacy Experimental sets discoverable during transition', () => {
+    const candidate = release(
+        'Experimental',
+        '0.6.2',
+        '2026-07-20T12:00:00Z'
+    )
+    assert.equal(isCompleteDesktopRelease(candidate), true)
+    assert.equal(desktopReleaseLifecycle(candidate), 'experimental')
+})
+
+test('never assembles a complete release by mixing lifecycle asset families', () => {
+    const candidate = release('Beta', '0.7.0', '2026-07-21T12:00:00Z')
+    const missing = candidate.assets.findIndex((asset) =>
+        asset.name.endsWith('macos-arm64-adhoc.dmg')
+    )
+    candidate.assets[missing] = url(
+        'OpenAdapt-Desktop-Experimental-v0.7.0-macos-arm64-adhoc.dmg'
+    )
+    assert.equal(isCompleteDesktopRelease(candidate), false)
+})
+
+test('selects the newest complete release and preserves Experimental fallback', () => {
+    const legacy = release(
+        'Experimental',
+        '0.6.2',
+        '2026-07-20T12:00:00Z'
+    )
+    const beta = release('Beta', '0.7.0', '2026-07-21T12:00:00Z')
+    assert.equal(selectDesktopRelease([legacy, beta]), beta)
+    assert.equal(selectDesktopRelease([legacy]), legacy)
+})
+
+test('platform selection stays in the chosen release lifecycle', () => {
+    const assets = [
+        ...release('Experimental', '0.6.2', '2026-07-20T12:00:00Z').assets,
+        ...release('Beta', '0.7.0', '2026-07-21T12:00:00Z').assets,
+    ]
+    const windows = DESKTOP_PLATFORMS.find((platform) => platform.id === 'windows')
+    assert.match(assetForPlatform(assets, windows, 'beta').name, /-Beta-/)
+    assert.match(
+        assetForPlatform(assets, windows, 'experimental').name,
+        /-Experimental-/
+    )
+})
+
+test('download copy leads with Beta while naming the compatibility path', () => {
+    const page = readFileSync(new URL('../pages/download.js', import.meta.url), 'utf8')
+    assert.match(page, /Native desktop Beta/)
+    assert.match(page, /Experimental compatibility prerelease/)
+    assert.doesNotMatch(page, /latest complete Experimental desktop prerelease/)
+})

--- a/tests/publicTruth.test.js
+++ b/tests/publicTruth.test.js
@@ -125,8 +125,8 @@ test('visitor browsers never call api.github.com', () => {
     // so the release data is in the initial HTML for every visitor.
     const download = read('pages/download.js')
     assert.match(download, /export async function getStaticProps/)
-    assert.match(download, /getExperimentalDesktopRelease/)
-    assert.match(download, /revalidate: 3600/)
+    assert.match(download, /getDesktopRelease/)
+    assert.match(download, /revalidate: 300/)
 })
 
 test('launch surfaces lead with capabilities instead of temporary gap labels', () => {

--- a/utils/desktopRelease.js
+++ b/utils/desktopRelease.js
@@ -3,8 +3,18 @@ export const DESKTOP_REPO = 'OpenAdaptAI/openadapt-desktop'
 // build/revalidate time). Visitor browsers must never call api.github.com.
 export const DESKTOP_RELEASES_PAGE = `https://github.com/${DESKTOP_REPO}/releases`
 
-const EXPERIMENTAL_TAG = /^desktop-v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
-const EXPERIMENTAL_PREFIX = /^OpenAdapt-Desktop-Experimental-/i
+const DESKTOP_TAG = /^desktop-v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
+const RELEASE_PREFIXES = {
+    beta: /^OpenAdapt-Desktop-Beta-/i,
+    experimental: /^OpenAdapt-Desktop-Experimental-/i,
+}
+const RELEASE_LIFECYCLES = ['beta', 'experimental']
+
+function lifecycleForAsset(name) {
+    return RELEASE_LIFECYCLES.find((lifecycle) =>
+        RELEASE_PREFIXES[lifecycle].test(name || '')
+    )
+}
 
 export const DESKTOP_PLATFORMS = [
     {
@@ -13,7 +23,7 @@ export const DESKTOP_PLATFORMS = [
         arch: 'x64',
         hint: '.msi installer (or .exe)',
         match: (name) =>
-            EXPERIMENTAL_PREFIX.test(name) &&
+            Boolean(lifecycleForAsset(name)) &&
             /-windows-x86_64-(?:(?:unsigned|authenticode)\.msi|(?:unsigned|authenticode)-nsis-setup\.exe)$/i.test(
                 name
             ),
@@ -25,7 +35,7 @@ export const DESKTOP_PLATFORMS = [
         arch: 'Apple Silicon',
         hint: '.dmg for M1 and later',
         match: (name) =>
-            EXPERIMENTAL_PREFIX.test(name) &&
+            Boolean(lifecycleForAsset(name)) &&
             /-macos-arm64-(?:adhoc|developer-id-notarized)\.dmg$/i.test(name),
         rank: () => 0,
     },
@@ -35,7 +45,7 @@ export const DESKTOP_PLATFORMS = [
         arch: 'Intel',
         hint: '.dmg for Intel Macs',
         match: (name) =>
-            EXPERIMENTAL_PREFIX.test(name) &&
+            Boolean(lifecycleForAsset(name)) &&
             /-macos-x86_64-(?:adhoc|developer-id-notarized)\.dmg$/i.test(
                 name
             ),
@@ -47,7 +57,7 @@ export const DESKTOP_PLATFORMS = [
         arch: 'x64',
         hint: '.AppImage (or .deb)',
         match: (name) =>
-            EXPERIMENTAL_PREFIX.test(name) &&
+            Boolean(lifecycleForAsset(name)) &&
             /-linux-x86_64-unsigned\.(?:AppImage|deb)$/i.test(name),
         rank: (name) => (/\.AppImage$/i.test(name) ? 0 : 1),
     },
@@ -62,6 +72,17 @@ const REQUIRED_ASSETS = [
     /-linux-x86_64-unsigned\.deb$/i,
 ]
 
+// Beta releases add one machine-readable provenance record for every platform
+// build. Existing Experimental releases predate that contract and remain
+// discoverable during the transition, but a new Beta set is never accepted
+// without all four metadata records and the checksum manifest.
+const BETA_PROVENANCE_ASSETS = [
+    /-macos-arm64-(?:adhoc|developer-id-notarized)-metadata\.json$/i,
+    /-macos-x86_64-(?:adhoc|developer-id-notarized)-metadata\.json$/i,
+    /-windows-x86_64-(?:unsigned|authenticode)-metadata\.json$/i,
+    /-linux-x86_64-unsigned-metadata\.json$/i,
+]
+
 function hasDownloadUrl(asset) {
     return Boolean(
         asset &&
@@ -71,19 +92,30 @@ function hasDownloadUrl(asset) {
     )
 }
 
-export function assetForPlatform(assets, platform) {
+export function assetForPlatform(assets, platform, preferredLifecycle = null) {
     return assets
         .filter(hasDownloadUrl)
         .filter((asset) => platform.match(asset.name))
-        .sort((a, b) => platform.rank(a.name) - platform.rank(b.name))[0]
+        .filter(
+            (asset) =>
+                !preferredLifecycle ||
+                lifecycleForAsset(asset.name) === preferredLifecycle
+        )
+        .sort((a, b) => {
+            const lifecycleRank =
+                RELEASE_LIFECYCLES.indexOf(lifecycleForAsset(a.name)) -
+                RELEASE_LIFECYCLES.indexOf(lifecycleForAsset(b.name))
+            return lifecycleRank || platform.rank(a.name) - platform.rank(b.name)
+        })[0]
 }
 
-export function isCompleteExperimentalDesktopRelease(release) {
+function isCompleteDesktopReleaseForLifecycle(release, lifecycle) {
+    const prefix = RELEASE_PREFIXES[lifecycle]
     if (
         !release ||
         release.draft ||
         release.prerelease !== true ||
-        !EXPERIMENTAL_TAG.test(release.tag_name || '') ||
+        !DESKTOP_TAG.test(release.tag_name || '') ||
         !Array.isArray(release.assets)
     ) {
         return false
@@ -91,21 +123,33 @@ export function isCompleteExperimentalDesktopRelease(release) {
 
     const assets = release.assets.filter(hasDownloadUrl)
     const hasChecksums = assets.some((asset) => asset.name === 'SHA256SUMS')
+    const required =
+        lifecycle === 'beta'
+            ? [...REQUIRED_ASSETS, ...BETA_PROVENANCE_ASSETS]
+            : REQUIRED_ASSETS
     return (
         hasChecksums &&
-        REQUIRED_ASSETS.every((pattern) =>
-            assets.some(
-                (asset) =>
-                    EXPERIMENTAL_PREFIX.test(asset.name) &&
-                    pattern.test(asset.name)
-            )
+        required.every((pattern) =>
+            assets.some((asset) => prefix.test(asset.name) && pattern.test(asset.name))
         )
     )
 }
 
-export function selectExperimentalDesktopRelease(releases) {
+export function desktopReleaseLifecycle(release) {
+    return (
+        RELEASE_LIFECYCLES.find((lifecycle) =>
+            isCompleteDesktopReleaseForLifecycle(release, lifecycle)
+        ) || null
+    )
+}
+
+export function isCompleteDesktopRelease(release) {
+    return desktopReleaseLifecycle(release) !== null
+}
+
+export function selectDesktopRelease(releases) {
     if (!Array.isArray(releases)) return null
-    const complete = releases.filter(isCompleteExperimentalDesktopRelease)
+    const complete = releases.filter(isCompleteDesktopRelease)
     if (complete.length === 0) return null
 
     // The GitHub endpoint is normally newest-first, but select by publication
@@ -125,9 +169,22 @@ export function selectExperimentalDesktopRelease(releases) {
         ) {
             return candidate
         }
+        if (
+            candidateTime === latestTime &&
+            desktopReleaseLifecycle(candidate) === 'beta' &&
+            desktopReleaseLifecycle(latest) !== 'beta'
+        ) {
+            return candidate
+        }
         return latest
     })
 }
+
+// Compatibility exports for consumers that still use the old names. Their
+// behavior intentionally includes both Beta and legacy Experimental releases,
+// avoiding a flag day while callers migrate to the lifecycle-neutral names.
+export const isCompleteExperimentalDesktopRelease = isCompleteDesktopRelease
+export const selectExperimentalDesktopRelease = selectDesktopRelease
 
 export function detectDesktopPlatform(navigatorValue) {
     if (!navigatorValue) return null
@@ -179,9 +236,14 @@ export async function detectDesktopPlatformWithHints(navigatorValue) {
     return detected
 }
 
-export function releaseSigningState(assets) {
+export function releaseSigningState(assets, lifecycle = null) {
     const names = Array.isArray(assets)
-        ? assets.map((asset) => asset.name || '')
+        ? assets
+              .map((asset) => asset.name || '')
+              .filter(
+                  (name) =>
+                      !lifecycle || lifecycleForAsset(name) === lifecycle
+              )
         : []
     return {
         macosNotarized: ['arm64', 'x86_64'].every((architecture) =>


### PR DESCRIPTION
## What changed

- discovers complete `OpenAdapt-Desktop-Beta-*` release sets from GitHub Releases
- requires all six platform installers, `SHA256SUMS`, and all four Beta platform-provenance metadata files before a Beta release can appear
- keeps complete `OpenAdapt-Desktop-Experimental-*` releases discoverable during the transition
- prevents platform cards and signing state from mixing Beta and Experimental asset families
- presents the target native Desktop Beta while retaining accurate provenance for screenshots and compatibility artifacts from the earlier Experimental lane
- shortens download-page ISR from one hour to five minutes so a published native release appears promptly without making visitor browsers call GitHub

## Why

Desktop PR [OpenAdaptAI/openadapt-desktop#38](https://github.com/OpenAdaptAI/openadapt-desktop/pull/38) promotes the self-contained native installer lane to Beta and changes staged asset names to `OpenAdapt-Desktop-Beta-*`. The website only recognized `Experimental` filenames, so a fully qualified Beta release would have looked absent. A flag-day replacement would also have hidden the currently published `desktop-v0.6.2` set before its successor is public.

## User impact

The download page automatically moves to the newest complete Beta release when it is published. Until then, the complete Experimental compatibility release remains downloadable. Missing checksums, missing Beta provenance records, mixed asset families, draft releases, and incomplete platform sets still fail closed.

## Validation

- `npm test`: **121 passed**
- `npm run build`: passed; 31 static pages generated and `/download` reports a five-minute revalidation interval
- new selector tests cover complete Beta, missing provenance refusal, Experimental fallback, mixed-family refusal, newest-release selection, and lifecycle-bound device selection
- current GitHub release inventory confirms `desktop-v0.6.2` remains within the server-side discovery window with all required assets
- `git diff --check`: passed

The production build used the committed paper PDF fallback because the sandbox could not reach the paper release URL; the unrelated fallback path is existing behavior and the build completed successfully.

No release, tag, merge, or deployment is performed by this PR.
