### PR TITLE
fix: enforce Desktop Beta release integrity

### DIFF
--- a/cypress/e2e/download.cy.js
+++ b/cypress/e2e/download.cy.js
@@ -62,7 +62,7 @@ describe('download page is server-rendered', () => {
             const definiteStates = [
                 'Beta release', // complete Beta release
                 'Compatibility release', // complete legacy release during transition
-                'No public desktop installer yet', // none
+                'No complete native desktop release yet', // none
                 'We could not reach GitHub just now', // build-time fetch miss
             ]
             expect(

--- a/tests/desktopRelease.test.js
+++ b/tests/desktopRelease.test.js
@@ -74,6 +74,22 @@ test('keeps complete legacy Experimental sets discoverable during transition', (
     assert.equal(desktopReleaseLifecycle(candidate), 'experimental')
 })
 
+test('binds every Beta asset version to the release tag', () => {
+    const candidate = release('Beta', '0.8.0', '2026-07-21T12:00:00Z')
+    candidate.tag_name = 'desktop-v0.9.0'
+    assert.equal(isCompleteDesktopRelease(candidate), false)
+})
+
+test('binds every legacy asset version to the release tag', () => {
+    const candidate = release(
+        'Experimental',
+        '0.6.2',
+        '2026-07-20T12:00:00Z'
+    )
+    candidate.tag_name = 'desktop-v0.6.3'
+    assert.equal(isCompleteDesktopRelease(candidate), false)
+})
+
 test('never assembles a complete release by mixing lifecycle asset families', () => {
     const candidate = release('Beta', '0.7.0', '2026-07-21T12:00:00Z')
     const missing = candidate.assets.findIndex((asset) =>
@@ -94,6 +110,16 @@ test('selects the newest complete release and preserves Experimental fallback', 
     const beta = release('Beta', '0.7.0', '2026-07-21T12:00:00Z')
     assert.equal(selectDesktopRelease([legacy, beta]), beta)
     assert.equal(selectDesktopRelease([legacy]), legacy)
+})
+
+test('a complete Beta remains primary when a legacy release is newer', () => {
+    const beta = release('Beta', '0.7.0', '2026-07-21T12:00:00Z')
+    const laterLegacy = release(
+        'Experimental',
+        '0.6.3',
+        '2026-07-22T12:00:00Z'
+    )
+    assert.equal(selectDesktopRelease([laterLegacy, beta]), beta)
 })
 
 test('platform selection stays in the chosen release lifecycle', () => {

--- a/utils/desktopRelease.js
+++ b/utils/desktopRelease.js
@@ -8,6 +8,10 @@ const RELEASE_PREFIXES = {
     beta: /^OpenAdapt-Desktop-Beta-/i,
     experimental: /^OpenAdapt-Desktop-Experimental-/i,
 }
+const RELEASE_ASSET_FAMILIES = {
+    beta: 'Beta',
+    experimental: 'Experimental',
+}
 const RELEASE_LIFECYCLES = ['beta', 'experimental']
 
 function lifecycleForAsset(name) {
@@ -64,12 +68,12 @@ export const DESKTOP_PLATFORMS = [
 ]
 
 const REQUIRED_ASSETS = [
-    /-macos-arm64-(?:adhoc|developer-id-notarized)\.dmg$/i,
-    /-macos-x86_64-(?:adhoc|developer-id-notarized)\.dmg$/i,
-    /-windows-x86_64-(?:unsigned|authenticode)\.msi$/i,
-    /-windows-x86_64-(?:unsigned|authenticode)-nsis-setup\.exe$/i,
-    /-linux-x86_64-unsigned\.AppImage$/i,
-    /-linux-x86_64-unsigned\.deb$/i,
+    /^-macos-arm64-(?:adhoc|developer-id-notarized)\.dmg$/i,
+    /^-macos-x86_64-(?:adhoc|developer-id-notarized)\.dmg$/i,
+    /^-windows-x86_64-(?:unsigned|authenticode)\.msi$/i,
+    /^-windows-x86_64-(?:unsigned|authenticode)-nsis-setup\.exe$/i,
+    /^-linux-x86_64-unsigned\.AppImage$/i,
+    /^-linux-x86_64-unsigned\.deb$/i,
 ]
 
 // Beta releases add one machine-readable provenance record for every platform
@@ -77,10 +81,10 @@ const REQUIRED_ASSETS = [
 // discoverable during the transition, but a new Beta set is never accepted
 // without all four metadata records and the checksum manifest.
 const BETA_PROVENANCE_ASSETS = [
-    /-macos-arm64-(?:adhoc|developer-id-notarized)-metadata\.json$/i,
-    /-macos-x86_64-(?:adhoc|developer-id-notarized)-metadata\.json$/i,
-    /-windows-x86_64-(?:unsigned|authenticode)-metadata\.json$/i,
-    /-linux-x86_64-unsigned-metadata\.json$/i,
+    /^-macos-arm64-(?:adhoc|developer-id-notarized)-metadata\.json$/i,
+    /^-macos-x86_64-(?:adhoc|developer-id-notarized)-metadata\.json$/i,
+    /^-windows-x86_64-(?:unsigned|authenticode)-metadata\.json$/i,
+    /^-linux-x86_64-unsigned-metadata\.json$/i,
 ]
 
 function hasDownloadUrl(asset) {
@@ -110,7 +114,6 @@ export function assetForPlatform(assets, platform, preferredLifecycle = null) {
 }
 
 function isCompleteDesktopReleaseForLifecycle(release, lifecycle) {
-    const prefix = RELEASE_PREFIXES[lifecycle]
     if (
         !release ||
         release.draft ||
@@ -121,6 +124,8 @@ function isCompleteDesktopReleaseForLifecycle(release, lifecycle) {
         return false
     }
 
+    const version = release.tag_name.slice('desktop-v'.length)
+    const expectedPrefix = `OpenAdapt-Desktop-${RELEASE_ASSET_FAMILIES[lifecycle]}-v${version}-`
     const assets = release.assets.filter(hasDownloadUrl)
     const hasChecksums = assets.some((asset) => asset.name === 'SHA256SUMS')
     const required =
@@ -130,7 +135,13 @@ function isCompleteDesktopReleaseForLifecycle(release, lifecycle) {
     return (
         hasChecksums &&
         required.every((pattern) =>
-            assets.some((asset) => prefix.test(asset.name) && pattern.test(asset.name))
+            assets.some(
+                (asset) =>
+                    asset.name.startsWith(expectedPrefix) &&
+                    pattern.test(
+                        asset.name.slice(expectedPrefix.length - 1)
+                    )
+            )
         )
     )
 }
@@ -152,11 +163,20 @@ export function selectDesktopRelease(releases) {
     const complete = releases.filter(isCompleteDesktopRelease)
     if (complete.length === 0) return null
 
+    // Once a complete Beta exists, legacy Experimental compatibility releases
+    // can never become primary again—even if one is published later. This
+    // makes the lifecycle transition monotonic while retaining the newest
+    // complete Experimental release as a fallback before Beta is available.
+    const beta = complete.filter(
+        (release) => desktopReleaseLifecycle(release) === 'beta'
+    )
+    const candidates = beta.length > 0 ? beta : complete
+
     // The GitHub endpoint is normally newest-first, but select by publication
     // metadata so a stable release interleaved in the response or a changed
     // API ordering cannot make the download page advertise an older desktop
     // prerelease.
-    return complete.reduce((latest, candidate) => {
+    return candidates.reduce((latest, candidate) => {
         const latestTime = Date.parse(
             latest.published_at || latest.created_at || ''
         )
@@ -166,13 +186,6 @@ export function selectDesktopRelease(releases) {
         if (
             Number.isFinite(candidateTime) &&
             (!Number.isFinite(latestTime) || candidateTime > latestTime)
-        ) {
-            return candidate
-        }
-        if (
-            candidateTime === latestTime &&
-            desktopReleaseLifecycle(candidate) === 'beta' &&
-            desktopReleaseLifecycle(latest) !== 'beta'
         ) {
             return candidate
         }


### PR DESCRIPTION
## Summary

- make complete Desktop Beta releases permanently outrank legacy compatibility releases
- bind every required installer and Beta provenance asset to the exact desktop release tag version
- align the server-rendered empty-state Cypress contract with the target-state page copy

## Verification

- `npm test` — 124/124 pass
- `npm run build` — pass
- `npx cypress run --spec cypress/e2e/download.cy.js --browser chrome` — 10/10 pass

Fix-forward for the release-integrity edge cases identified immediately after #266 merged. This does not publish a Desktop release or mutate deployment configuration.
