### PR TITLE
fix(deps): patch nested PostCSS advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5891,34 +5891,6 @@
                 }
             }
         },
-        "node_modules/next/node_modules/postcss": {
-            "version": "8.4.31",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-            "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/postcss"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "nanoid": "^3.3.6",
-                "picocolors": "^1.0.0",
-                "source-map-js": "^1.0.2"
-            },
-            "engines": {
-                "node": "^10 || ^12 || >=14"
-            }
-        },
         "node_modules/node-exports-info": {
             "version": "1.6.2",
             "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.2.tgz",
@@ -6292,9 +6264,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.19",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-            "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+            "version": "8.5.21",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.21.tgz",
+            "integrity": "sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -6311,7 +6283,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.12",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -12056,21 +12028,9 @@
                 "@next/swc-win32-x64-msvc": "15.5.20",
                 "@swc/helpers": "0.5.15",
                 "caniuse-lite": "^1.0.30001579",
-                "postcss": "8.4.31",
+                "postcss": "^8.5.10",
                 "sharp": "^0.34.3",
                 "styled-jsx": "5.1.6"
-            },
-            "dependencies": {
-                "postcss": {
-                    "version": "8.4.31",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-                    "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-                    "requires": {
-                        "nanoid": "^3.3.6",
-                        "picocolors": "^1.0.0",
-                        "source-map-js": "^1.0.2"
-                    }
-                }
             }
         },
         "node-exports-info": {
@@ -12330,11 +12290,11 @@
             "dev": true
         },
         "postcss": {
-            "version": "8.5.19",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-            "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+            "version": "8.5.21",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.21.tgz",
+            "integrity": "sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==",
             "requires": {
-                "nanoid": "^3.3.12",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             }
@@ -13185,7 +13145,7 @@
                 "normalize-path": "^3.0.0",
                 "object-hash": "^3.0.0",
                 "picocolors": "^1.0.0",
-                "postcss": "^8.4.23",
+                "postcss": "^8.5.10",
                 "postcss-import": "^15.1.0",
                 "postcss-js": "^4.0.1",
                 "postcss-load-config": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
         "eslint-config-next": "^15.5.16",
         "postcss": "^8.5.10",
         "tailwindcss": "^3.4.1"
+    },
+    "overrides": {
+        "postcss": "$postcss"
     }
 }


### PR DESCRIPTION
## What changed

- force every PostCSS consumer, including Next's nested dependency, onto the site's declared patched PostCSS range
- regenerate the lockfile so the vulnerable nested 8.4.31 copy is removed and the patched version is deduplicated

## Root cause

The direct PostCSS dependency was already patched, but Next 15.5.20 pinned a separate nested PostCSS 8.4.31. GitHub Dependabot therefore continued to report GHSA-qx2v-qp2m-jg93 on main.

## Impact

The production dependency graph now resolves Next, Tailwind, Autoprefixer, and the site to one patched PostCSS version. No application code or public copy changes.

## Verification

- `npm audit`: 0 vulnerabilities
- `npm ls postcss`: every consumer resolves to patched PostCSS 8.5.21
- website unit suite: 124/124 passed
- Next production build: passed (31 pages)
- `git diff --check`: passed
