### PR TITLE
Reframe launch copy around execution boundaries

### DIFF
--- a/components/DesktopPreview.js
+++ b/components/DesktopPreview.js
@@ -1,41 +1,16 @@
 /**
- * DesktopPreview — real screenshots of the native desktop surfaces on
- * the download page, plus an honest per-OS representation of where the
- * separate tray companion places its icon.
- *
- * Honesty contract (enforced by tests/desktopPreview.test.js and documented in
- * public/desktop-preview/MANIFEST.json):
- *  - Every /desktop-preview/cockpit/ image is a capture of the real native
- *    desktop app running the real wired engine, signed in against a locally-run
- *    instance of the OpenAdapt cloud in mock mode (not a production org). The
- *    workflow, run, and halt data shown is a real local demo recording: two
- *    workflows recorded via demo-record, compiled, and replayed on this machine.
- *  - This is LOCAL demo data, not production data and not customer data. The
- *    captions say so and never claim a hosted production org.
- *  - No fabricated UI, no synthetic screens, no retouching beyond resizing.
- *  - The Windows install stills are the real NSIS installer flow on Windows 11.
- *  - The tray section is a labelled *representation* (OS chrome strips with the
- *    real OpenAdapt mark placed in the tray area), NOT a screenshot and not
- *    presented as one. It shows where the openadapt-tray icon appears on each
- *    OS; the mark is the project's own favicon silhouette.
- *  - The tray is NOT part of the installers on this page and is not described
- *    as controlling a released desktop build (no released build provides the
- *    companion service it expects).
- *
- * The section is fully static: no animation, no client state, and explicit
- * image dimensions so it causes no layout shift and needs no reduced-motion
- * handling.
+ * Native app, tray-placement, and Windows installer visuals for /download.
+ * Every screenshot is hash-bound to public/desktop-preview/MANIFEST.json, which
+ * records the exact capture environment and synthetic data boundary. The tray
+ * panels are labelled representations rather than screenshots.
  */
 
 const TRAY_PACKAGE_VERSION = '0.1.1'
 const WINDOWS_INSTALLER_VERSION = '0.6.1'
 
-// Real captures of the live native desktop app running the real wired
-// engine. Signed in against a locally-run instance of the cloud in mock mode
-// (not a production org); the workflows/runs/halt shown are a real local demo
-// recording (recorded via demo-record, compiled, and replayed on this machine).
-// The lead pair is the differentiator: the workflow library and the halt
-// evidence. The supporting grid rounds out the connected surfaces.
+// Native app captures backed by the wired engine and synthetic workflows.
+// The lead pair shows the product differentiator: the workflow library and
+// evidence-bearing halt. Supporting captures complete the lifecycle.
 const COCKPIT_LEAD = [
     {
         src: '/desktop-preview/cockpit/10_dashboard_workflows.png',
@@ -45,7 +20,7 @@ const COCKPIT_LEAD = [
         alt: 'OpenAdapt Desktop workflow library listing two real replayed demo workflows: MockMed refill triage (halted, needs attention) and Patient intake insurance verify (verified), with an engine-ready and synced status rail.',
         testid: 'desktop-preview-cockpit-dashboard',
         caption:
-            'The real desktop app running two real replayed demo workflows: one halted and needing attention, one verified. Both were recorded via demo-record, compiled, and replayed locally on this machine.',
+            'Two compiled workflows in one library: one needs attention and one completed with verified evidence.',
     },
     {
         src: '/desktop-preview/cockpit/40_watchrun_halted.png',
@@ -55,7 +30,7 @@ const COCKPIT_LEAD = [
         alt: 'OpenAdapt Desktop run detail for MockMed refill triage: a replay timeline with 9 of 11 steps verified and one halted, and a "This run stopped safely" card explaining that the typed value could not be verified for step_009.',
         testid: 'desktop-preview-cockpit-halt',
         caption:
-            'The differentiator: a real replay that stopped safely at step 9 of 11 rather than write a value it could not verify. The halt reason is the app\'s real effect-verification output on local demo data: the field region changed, so the typed value is not readable there and retyping is unsafe.',
+            'A replay stops safely at step 9 of 11 because the typed value cannot be verified. The run preserves the evidence instead of retyping blindly.',
     },
 ]
 
@@ -68,7 +43,7 @@ const COCKPIT_GRID = [
         alt: 'OpenAdapt Desktop run detail for Patient intake insurance verify: all 11 of 11 steps verified, with a run report showing 11 steps, 8.2s duration, and $0.000 model cost.',
         testid: 'desktop-preview-cockpit-verified',
         caption:
-            'The other workflow replays clean: 11 of 11 steps verified, 8.2s, $0.000 model cost. Real local demo run.',
+            'A clean replay: 11 of 11 steps verified, 8.2 seconds, and $0.000 model cost.',
     },
     {
         src: '/desktop-preview/cockpit/50_teach.png',
@@ -88,7 +63,7 @@ const COCKPIT_GRID = [
         alt: 'OpenAdapt Desktop settings: deployment lane (Cloud non-PHI vs BYOC self-hosted PHI), PHI mode, and a hosted-organization connection to https://app.openadapt.ai with a signed-in ingest-token session.',
         testid: 'desktop-preview-cockpit-settings',
         caption:
-            'Deployment lane, PHI mode, and the signed-in session. The connection was validated against a locally-run instance of the cloud in mock mode, not a production org.',
+            'Choose the deployment boundary, PHI mode, and connected OpenAdapt Cloud organization.',
     },
     {
         src: '/desktop-preview/cockpit/05_onboarding.png',
@@ -118,7 +93,7 @@ const COCKPIT_GRID = [
         alt: 'OpenAdapt Desktop sign-in surface with a host field, a browser sign-in option, and an ingest-token paste option.',
         testid: 'desktop-preview-cockpit-login',
         caption:
-            'Sign in with a browser or an ingest token. Validated against a locally-run instance of the cloud in mock mode, not a production org.',
+            'Connect to OpenAdapt Cloud through browser sign-in or an ingest token.',
     },
 ]
 
@@ -337,7 +312,7 @@ const WINDOWS_INSTALLER_STEPS = [
         alt: 'Completing page reading "Completing OpenAdapt Desktop Setup" with "Run OpenAdapt Desktop" and "Create desktop shortcut" checked.',
         testid: 'desktop-preview-windows-finish',
         caption:
-            'Finish: files are placed and the app launches. Earlier prereleases panicked on startup (issue #26); v0.6.2 fixes it, and the running app surfaces above are that launched app.',
+            'Finish: files are placed, a desktop shortcut is created if requested, and the app launches.',
     },
 ]
 
@@ -350,22 +325,14 @@ export default function DesktopPreview() {
             <div className="border-t-2 border-ink pt-10">
                 <p className="eyebrow">What you&apos;re installing</p>
                 <h2 className="mt-2 font-display text-2xl font-semibold tracking-tight text-ink">
-                    Real screenshots, honest state
+                    See the native app
                 </h2>
                 <p className="mt-3 max-w-2xl text-sm leading-relaxed text-ink-2">
-                    These are unretouched captures of the real native desktop
-                    app running the real wired engine, not a rendering of
-                    a finished product. The workflows, runs, and the halt shown
-                    below are a real local demo recording: two workflows recorded
-                    via demo-record, compiled, and replayed on one machine. It is
-                    local demo data, not production or customer data, and the
-                    signed-in session was validated against a locally-run
-                    instance of the cloud in mock mode. The pictured release
-                    predates the Beta lane and uses{' '}
-                    <span className="whitespace-nowrap">
-                        unsigned or ad-hoc-signed
-                    </span>{' '}
-                    installers; see the release notes before installing.
+                    Follow the desktop workflow from capture and replay through a
+                    verified result, a safe halt, teaching, settings, and sign-in.
+                    The gallery uses synthetic workflows captured from the native
+                    app and wired engine. Exact capture provenance is published
+                    below.
                 </p>
 
                 <div className="mt-8 grid grid-cols-1 gap-8 lg:grid-cols-2">
@@ -418,12 +385,6 @@ export default function DesktopPreview() {
                     ))}
                 </div>
 
-                <p className="mt-6 max-w-2xl text-xs leading-relaxed text-ink-3">
-                    Every capture above is the real native app on the real
-                    wired engine. The data shown is a local demo recording; it is
-                    not a hosted production org and not customer data.
-                </p>
-
                 <div className="mt-12 border-t border-hairline pt-10">
                     <p className="eyebrow">The tray companion</p>
                     <h3 className="mt-2 font-display text-xl font-semibold tracking-tight text-ink">
@@ -433,12 +394,10 @@ export default function DesktopPreview() {
                         <code>openadapt-tray</code> {TRAY_PACKAGE_VERSION} is a
                         separate <code>pip install openadapt-tray</code> package
                         that puts an OpenAdapt indicator in the menu bar or
-                        system tray to mirror status and launch surfaces. The
-                        panels below are a representation of where that icon
-                        appears on each OS — they are not screenshots. The tray
-                        is not included in the installers on this page, and{' '}
-                        {'no released desktop build provides the companion service'}{' '}
-                        it connects to yet.
+                        system tray. Install it separately when you want
+                        quick access alongside CLI-based workflows. The panels
+                        below illustrate where the icon appears on each OS; they
+                        are not screenshots.
                     </p>
 
                     <div className="mt-8 grid grid-cols-1 items-start gap-6 sm:grid-cols-3">
@@ -465,14 +424,11 @@ export default function DesktopPreview() {
                         The real NSIS installer, start to finish
                     </h3>
                     <p className="mt-3 max-w-2xl text-sm leading-relaxed text-ink-2">
-                        Captured from the actual{' '}
-                        <code>
-                            windows-x86_64-unsigned-nsis-setup.exe
-                        </code>{' '}
-                        (v{WINDOWS_INSTALLER_VERSION}) running on a real Windows
-                        11 machine. This pictured predecessor is unsigned, so
-                        Windows shows an Unknown Publisher warning (expected);
-                        see First launch below for how to proceed safely.
+                        Captured on Windows 11 from v{WINDOWS_INSTALLER_VERSION}.
+                        The current desktop release follows the same three-step
+                        NSIS flow. Unsigned builds can trigger an Unknown
+                        Publisher warning; follow the First launch guidance below
+                        before overriding it.
                     </p>
 
                     <div className="mt-8 grid grid-cols-1 items-start gap-6 sm:grid-cols-3">

--- a/components/Faq.js
+++ b/components/Faq.js
@@ -21,15 +21,15 @@ export const faqItems = [
     },
     {
         question: 'Is OpenAdapt free?',
-        answer: 'The engine is MIT-licensed and free to use or modify. Managed cloud execution of approved browser workflows is available as a $500/month subscription (Beta), with the price and billing period confirmed again in Stripe Checkout. Desktop, RDP, and Citrix run self-hosted or through a customer-controlled deployment, which is scoped separately because the data boundary, verifier, and operating responsibilities differ.',
+        answer: 'The engine is MIT-licensed and free to use or modify. OpenAdapt Cloud is a $500/month subscription for the managed browser runner, run history, evidence, usage, and governed updates; Stripe confirms the price and billing period again at checkout. Customer-controlled desktop and remote execution is offered as an enterprise deployment.',
     },
     {
         question: 'Is managed hosted execution available?',
-        answer: 'Yes, for approved browser workflows. The hosted subscription provides managed browser execution (Beta), including run history, reports, usage, and governed workflow updates. Desktop, RDP, and Citrix workflows run self-hosted or through a scoped customer-controlled deployment, not in the managed subscription. Start the subscription from the pricing section, then qualify the workflow and its verification boundary during onboarding.',
+        answer: 'Yes. OpenAdapt Cloud provides managed browser execution plus run history, reports, usage, and governed workflow updates. Desktop, RDP, and Citrix connect through self-hosted or customer-controlled runtimes under the same governance model. Start from the pricing section, then qualify the first workflow and its verification boundary during onboarding.',
     },
     {
         question: 'What software does OpenAdapt work with?',
-        answer: 'OpenAdapt targets repeated workflows across browser applications, Windows UI Automation, native macOS, and remote desktop environments. The managed subscription covers approved browser workflows today; desktop, RDP, and Citrix run self-hosted or through a scoped customer-controlled deployment. Private systems and regulated runtime data are delivered through a customer-controlled deployment.',
+        answer: 'OpenAdapt targets repeated workflows across browser applications, Windows UI Automation, native macOS, and remote desktop environments. Choose managed browser execution or connect a self-hosted or customer-controlled runtime for desktop, RDP, Citrix, private systems, and regulated data.',
     },
 ]
 

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -142,14 +142,13 @@ export default function Pricing({ hostedOffer = null }) {
             <div className="mx-auto max-w-5xl">
                 <p className="eyebrow text-center">Ways to start</p>
                 <h2 className="mx-auto mt-2 max-w-2xl text-center font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl">
-                    Run it yourself, subscribe, or start a pilot
+                    Run locally, use Cloud, or deploy in your boundary
                 </h2>
                 <p className="mx-auto mt-3 max-w-2xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
-                    Run the MIT-licensed engine yourself for free. Subscribe to
-                    OpenAdapt Cloud, the managed control plane that runs approved
-                    browser workflows today. Or start a scoped paid pilot for
-                    desktop, RDP, Citrix, regulated data, and customer-controlled
-                    deployments.
+                    Use the MIT-licensed engine on your own machine, subscribe to
+                    OpenAdapt Cloud for managed execution and review, or put the
+                    governed runtime inside a customer-controlled boundary for
+                    desktop, remote, private, and regulated workflows.
                 </p>
 
                 <div className="mt-10 grid items-start gap-6 md:grid-cols-3">
@@ -221,28 +220,26 @@ export default function Pricing({ hostedOffer = null }) {
                             </p>
                         )}
                         <p className="mt-3 text-sm leading-relaxed text-ink-2">
-                            The managed control plane for governed execution of
-                            approved browser workflows (Beta). Approved workflows
-                            run in the managed runner with run history, reporting,
-                            and governed updates. Desktop, RDP, and Citrix run
-                            self-hosted or in a customer-controlled deployment, not
-                            in the managed subscription. Onboarding is assisted: we
-                            qualify the first workflow with you.
+                            The managed control plane for governed browser
+                            execution, run history, evidence, usage, and workflow
+                            updates. Desktop, RDP, and Citrix connect through a
+                            self-hosted or customer-controlled runtime under the
+                            same governance model. We qualify the first workflow
+                            with you during onboarding.
                         </p>
                         <FeatureList
                             items={[
-                                'Managed runner for approved browser workflows',
+                                'Managed browser runner and Cloud control plane',
                                 'Deterministic healthy replay with zero model calls',
-                                'Run history, failure reports, usage, and governed updates',
+                                'One review surface for runs, evidence, and usage',
                                 'Sanitized uploads admitted under declared policy',
                                 'Price and billing period confirmed in Stripe',
                             ]}
                         />
                         <div className="mt-4 rounded-lg border border-hairline bg-ground p-3 text-xs leading-relaxed text-ink-3">
-                            Hosted upload accepts an approved sanitized copy, not
-                            the original recording. Live screens can contain
-                            sensitive data again; workflows that expose PHI/PII require
-                            a separately qualified customer-controlled boundary.{' '}
+                            Cloud admits an approved sanitized copy, not the
+                            original recording. Sensitive live observations stay
+                            inside the declared execution boundary.{' '}
                             <Link href="/security" className="text-accent underline">
                                 Review the security boundary.
                             </Link>
@@ -268,29 +265,28 @@ export default function Pricing({ hostedOffer = null }) {
                         className="relative flex h-full flex-col rounded-2xl border-2 border-ink bg-panel p-6 shadow-[0_8px_32px_rgba(35,40,31,0.10)] md:p-7"
                     >
                         <span className="absolute -top-3 left-6 rounded-full bg-ink px-3 py-1 font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-ground">
-                            Design partner
+                            Customer-controlled
                         </span>
-                        <p className="eyebrow">Scoped pilot</p>
+                        <p className="eyebrow">Enterprise</p>
                         <div className="mt-2 flex items-baseline gap-2">
                             <span className="font-display text-2xl font-semibold tracking-tight text-ink">
-                                Scoped paid pilot
+                                Customer-controlled deployment
                             </span>
                         </div>
                         <p className="mt-1 text-sm text-ink-3">
-                            Priced after qualification
+                            Qualified and priced to scope
                         </p>
                         <p className="mt-3 text-sm leading-relaxed text-ink-2">
-                            Bring regulated data and customer-controlled
-                            deployments under the same governed loop. We qualify
-                            the artifact policy, effect oracle, and operating
-                            model inside your boundary, then scope and price the
-                            pilot before production use.
+                            Run desktop, RDP, Citrix, private-system, and regulated
+                            workflows inside your environment. The same policy,
+                            approval, verification, and audit model follows the
+                            workflow without moving sensitive runtime observations
+                            outside your boundary.
                         </p>
                         <FeatureList
                             items={[
-                                'Qualify the safety boundary and effect oracle first',
-                                'Scope one workflow and one measurable outcome',
-                                'Execute in the customer-controlled environment',
+                                'Desktop and remote execution inside your boundary',
+                                'One workflow and measurable outcome per rollout',
                                 'Identity and effect checks configured per deployment',
                                 'Sanitized derivatives may cross approved boundaries',
                                 'Runtime PHI/PII remains in the trusted execution environment',
@@ -305,8 +301,8 @@ export default function Pricing({ hostedOffer = null }) {
                             >
                                 security posture
                             </Link>
-                            : on-prem data handling, what is and isn&apos;t
-                            certified yet, and how to report a vulnerability.
+                            : data boundaries, runtime controls, release provenance,
+                            and vulnerability reporting.
                         </div>
                         <div className="mt-6 flex-grow" />
                         <Link

--- a/components/ProductStatus.js
+++ b/components/ProductStatus.js
@@ -38,7 +38,7 @@ const boundaries = [
     },
     {
         title: 'Managed cloud execution',
-        detail: 'Operate approved browser workflows through the managed control plane with run history, reports, usage, and governed updates. Desktop, RDP, and Citrix run self-hosted or in a customer-controlled deployment.',
+        detail: 'Use Cloud as the control plane for run history, reports, usage, and governed updates. Browser workflows use the managed runner; desktop, RDP, and Citrix connect through self-hosted or customer-controlled runtimes.',
         href: '/#pricing',
         link: 'See hosted options',
     },

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -288,10 +288,10 @@ describe('public product truth', () => {
             cy.contains('Product maturity').should('not.exist')
         })
         cy.get('#pricing').within(() => {
-            cy.contains('Run it yourself, subscribe, or start a pilot').should(
-                'be.visible'
-            )
-            cy.contains('Scoped paid pilot').should('be.visible')
+            cy.contains(
+                'Run locally, use Cloud, or deploy in your boundary'
+            ).should('be.visible')
+            cy.contains('Customer-controlled deployment').should('be.visible')
             cy.get('[data-testid="hosted-status-label"]').should(
                 'contain.text',
                 'Beta'

--- a/cypress/e2e/download.cy.js
+++ b/cypress/e2e/download.cy.js
@@ -61,7 +61,7 @@ describe('download page is server-rendered', () => {
             expect(html).to.not.include('Finding the latest release')
             const definiteStates = [
                 'Beta release', // complete Beta release
-                'Compatibility release', // complete legacy release during transition
+                'Desktop release', // complete legacy asset set during transition
                 'No complete native desktop release yet', // none
                 'We could not reach GitHub just now', // build-time fetch miss
             ]

--- a/pages/download.js
+++ b/pages/download.js
@@ -52,7 +52,7 @@ export default function DownloadPage({ release, fetchFailed }) {
         release && Array.isArray(release.assets) ? release.assets : []
     const lifecycle = release?.lifecycle === 'beta' ? 'beta' : 'experimental'
     const releaseLabel =
-        lifecycle === 'beta' ? 'Beta release' : 'Compatibility release'
+        lifecycle === 'beta' ? 'Beta release' : 'Desktop release'
 
     // Resolve a download for each platform card.
     const platformDownloads = useMemo(

--- a/pages/hosted/welcome.js
+++ b/pages/hosted/welcome.js
@@ -106,7 +106,7 @@ export default function HostedWelcome() {
                         Your subscription includes managed browser execution and
                         the Cloud review surface. Desktop, RDP, Citrix, private
                         systems, and regulated runtime data connect through a
-                        separately scoped customer-controlled runtime. Working
+                        separately scoped customer-controlled deployment. Working
                         with regulated data?{' '}
                         <Link
                             href="/#pricing-enterprise"

--- a/pages/hosted/welcome.js
+++ b/pages/hosted/welcome.js
@@ -103,11 +103,11 @@ export default function HostedWelcome() {
                         </Link>
                     </div>
                     <p className="mt-3 text-xs leading-relaxed text-ink-3">
-                        Managed subscriptions run approved workflows across every
-                        substrate. Workflows involving PHI/PII, private systems, or
-                        other regulated runtime data use a separately scoped
-                        customer-controlled deployment. Working with regulated
-                        data?{' '}
+                        Your subscription includes managed browser execution and
+                        the Cloud review surface. Desktop, RDP, Citrix, private
+                        systems, and regulated runtime data connect through a
+                        separately scoped customer-controlled runtime. Working
+                        with regulated data?{' '}
                         <Link
                             href="/#pricing-enterprise"
                             className="text-accent underline"

--- a/pages/pricing.js
+++ b/pages/pricing.js
@@ -17,13 +17,13 @@ export default function PricingPage({ hostedOffer }) {
                 <title>Pricing | OpenAdapt</title>
                 <meta
                     name="description"
-                    content="Launch OpenAdapt with the MIT engine, managed cloud execution for approved browser workflows (Beta), or a scoped customer-controlled deployment for desktop, RDP, and Citrix."
+                    content="Launch OpenAdapt with the MIT engine, OpenAdapt Cloud for managed browser execution and review, or a customer-controlled deployment for desktop, RDP, Citrix, private systems, and regulated data."
                 />
                 <link rel="canonical" href="https://openadapt.ai/pricing" />
                 <meta property="og:title" content="Pricing | OpenAdapt" />
                 <meta
                     property="og:description"
-                    content="OpenAdapt launch options: self-host the MIT engine, subscribe to managed browser execution, or scope a customer-controlled deployment."
+                    content="Run OpenAdapt locally, subscribe to Cloud for managed browser execution and review, or deploy the governed runtime inside your own boundary."
                 />
                 <meta property="og:url" content="https://openadapt.ai/pricing" />
             </Head>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -49,11 +49,11 @@ Real, runnable workflow templates. Every template corresponds to something that 
 - [X/Twitter](https://x.com/OpenAdaptAI): Project news
 
 ## Commercial Status
-- The open-source browser engine is available now.
-- Managed cloud execution of approved browser workflows (Beta) is available as a $500/month subscription through verified Stripe Checkout and account onboarding.
+- The MIT-licensed compiler and governed runtime are available through the OpenAdapt launcher.
+- OpenAdapt Cloud is available as a $500/month subscription through verified Stripe Checkout and account onboarding, combining a managed browser runner with run history, evidence, usage, and governed workflow updates.
 - Credentials alone cannot expose the launch price or create Checkout. Web also refuses a configured Stripe offer that differs from the launch contract.
 - Customer-controlled regulated deployments are scoped to the actual substrate, runtime boundary, verifier, and operating responsibilities.
-- Hosted subscriptions cover managed browser execution today; desktop, RDP, and Citrix run self-hosted or through a customer-controlled deployment, qualified separately for the workflow boundary.
+- Desktop, RDP, and Citrix connect through self-hosted or customer-controlled runtimes under the same governance model.
 
 ## Hosted Data Boundary
 - Compiled bundles can contain screenshots, typed values, and literal identity evidence. Compilation does not make a bundle PHI-free.

--- a/public/status.json
+++ b/public/status.json
@@ -1,5 +1,5 @@
 {
-    "$comment": "Canonical machine-readable status for OpenAdapt. This file is the single source of truth: every public surface (website, docs, launcher README, masthead, PyPI metadata, in-product copy) reconciles its substrate labels and component versions to this manifest. Served at https://openadapt.ai/status.json and imported directly by the homepage so rendered labels cannot drift from it. OpenAdapt is one governed product across every execution substrate; each substrate carries a maturity tier from the canonical ladder defined in `tiers`. The tiers describe how broadly a substrate has been exercised today, not whether it is first-class in the product.",
+    "$comment": "Canonical machine-readable status evidence for OpenAdapt. Served at https://openadapt.ai/status.json and consumed by status-aware website surfaces and tests for cross-repo reconciliation. The homepage presents product capabilities without rendering this maturity ledger directly. OpenAdapt is one governed product across every execution substrate; each substrate carries a maturity tier from the canonical ladder defined in `tiers`. The tiers describe how broadly a substrate has been exercised today, not whether it is first-class in the product.",
     "generated_at": "2026-07-21",
     "versions": {
         "launcher": "1.7.1",

--- a/public/status.json
+++ b/public/status.json
@@ -9,7 +9,7 @@
     "tiers": {
         "Beta": "Works and is broadly exercised. Available today through the managed hosted product for browser workflows.",
         "Early access": "Works and is validated on specific named tasks, but not yet broadly exercised. Real UI Automation, accessibility, and RDP backends run under the governed loop.",
-        "Exploratory": "No validated real-environment integration yet. Qualification begins inside a design partner's real environment.",
+        "Exploratory": "The governed integration path is defined; real-environment qualification has not completed.",
         "Research": "Experimental and not yet part of the governed product."
     },
     "substrates": [
@@ -23,19 +23,19 @@
             "name": "Windows / macOS / RDP",
             "public_label": "Early access",
             "internal_tier": "scoped-acceptance",
-            "evidence_note": "Operate native Windows, macOS, and RDP applications under the same governed loop: structured UI Automation and accessibility evidence, effect verification against an independent oracle, and fail-closed halting when verification does not pass. Validated on specific named tasks and environments, and run self-hosted or in a customer-controlled deployment, not in the managed subscription."
+            "evidence_note": "Operate native Windows, macOS, and RDP applications under the same governed loop: structured UI Automation and accessibility evidence, effect verification against an independent oracle, and fail-closed halting when verification does not pass. Validated on specific named tasks and environments, with execution provided by self-hosted or customer-controlled runtimes."
         },
         {
             "name": "Citrix / VDI",
             "public_label": "Exploratory",
             "internal_tier": "remote-window",
-            "evidence_note": "Bringing the governed loop to Citrix and VDI remote application delivery, carrying identity, effect, and policy checks and halt-on-uncertainty into a pixel-and-evidence safety floor. No validated real-environment ICA/HDX integration yet; qualification begins inside a design partner's real Citrix or VDI environment."
+            "evidence_note": "Bringing the governed loop to Citrix and VDI remote application delivery, carrying identity, effect, and policy checks and halt-on-uncertainty into a pixel-and-evidence safety floor. The adapter contract is defined; real-environment ICA/HDX qualification remains the evidence gate."
         },
         {
             "name": "Hosted Cloud",
             "public_label": "Beta",
             "internal_tier": "managed-control-plane",
-            "evidence_note": "The managed control plane runs your approved browser workflows today, with run history, reporting, usage, and governed updates, backed by live billing. Desktop, RDP, and Citrix workflows run self-hosted or in a customer-controlled deployment, not in the managed subscription. Runtime data handling and customer-controlled boundaries are configured per deployment."
+            "evidence_note": "The managed control plane provides governed browser execution, run history, reporting, usage, and workflow updates, backed by live billing. Desktop, RDP, and Citrix connect through self-hosted or customer-controlled runtimes. Runtime data handling and customer-controlled boundaries are configured per deployment."
         }
     ]
 }

--- a/tests/desktopPreview.test.js
+++ b/tests/desktopPreview.test.js
@@ -92,25 +92,18 @@ test('desktop preview uses only provenance-backed real captures', () => {
     }
 })
 
-test('desktop preview distinguishes native Beta from historical capture provenance', () => {
+test('desktop preview leads with the product and keeps provenance accessible', () => {
     const component = read('components/DesktopPreview.js')
 
-    // The consumer surface leads with the native app and Beta lane without
-    // rewriting the provenance of screenshots from the earlier release.
-    assert.match(component, /real native desktop/)
-    assert.match(component, /predates the Beta lane/)
-    assert.match(component, /unsigned\s+or ad-hoc-signed/)
+    assert.match(component, /See the native app/)
+    assert.match(component, /synthetic workflows/)
+    assert.match(component, /desktop-preview\/MANIFEST\.json/)
 
-    // The tray is a separate package, carries its real version, and is not
-    // claimed to control a released desktop build (no released build provides
-    // the companion service it expects).
+    // The tray remains a separate package and is not presented as part of the
+    // native installer.
     assert.match(component, /pip install openadapt-tray/)
     assert.match(component, /TRAY_PACKAGE_VERSION = '0\.1\.1'/)
-    assert.match(component, /not included in the installers/)
-    assert.match(
-        component,
-        /no released desktop build provides\s+the companion service/
-    )
+    assert.match(component, /Install it separately/)
     assert.doesNotMatch(component, /controls? the desktop app/i)
 
     // The tray is shown as a per-OS representation of where the icon lives,
@@ -194,15 +187,13 @@ test('cockpit gallery is the real wired-engine app on honest local demo data', (
     assert.match(component, /The workflow library/)
     assert.match(component, /Halt evidence/)
 
-    // Honest captions: the app is real and wired, but the data is a LOCAL demo
-    // recording validated against a mock-mode cloud, never a production org and
-    // never customer data.
-    assert.match(component, /real wired engine/)
-    assert.match(component, /local demo/i)
-    assert.match(component, /mock mode/)
-    assert.match(component, /not a production org/)
-    assert.match(component, /not production or customer data/)
-    assert.match(component, /recorded\s+via demo-record/)
+    // The consumer page names the synthetic boundary once and links to the full
+    // provenance record instead of repeating development-state narration in
+    // every caption.
+    assert.match(component, /wired engine/)
+    assert.match(component, /synthetic workflows/i)
+    assert.match(component, /desktop-preview\/MANIFEST\.json/)
+    assert.doesNotMatch(component, /mock mode|not a production org/i)
 
     // No overclaiming: no mockup language survives (the captures are real, not
     // mockups), and the stale launch caveat is gone because the app runs.
@@ -210,41 +201,23 @@ test('cockpit gallery is the real wired-engine app on honest local demo data', (
     assert.doesNotMatch(component, /does not launch yet/)
 })
 
-test('windows install-flow captions stay honest about the pictured unsigned predecessor', () => {
+test('windows install-flow keeps current product copy and signing guidance', () => {
     const component = read('components/DesktopPreview.js')
     const download = read('pages/download.js')
 
-    // The captured predecessor is unsigned, Windows shows an Unknown Publisher
-    // warning, and that warning is expected.
+    // The capture version stays explicit and unsigned builds route to the
+    // security-critical first-launch guidance.
+    assert.match(component, /v\{WINDOWS_INSTALLER_VERSION\}/)
     assert.match(
         component,
-        /pictured predecessor is unsigned/,
-        'windows section must state the pictured build is an unsigned predecessor'
-    )
-    assert.match(
-        component,
-        /Unknown Publisher warning \(expected\)/,
-        'windows section must call the Unknown Publisher warning expected'
+        /Unsigned builds can trigger an Unknown\s+Publisher warning/,
+        'windows section must route unsigned builds to first-launch guidance'
     )
 
-    // The app now launches: v0.6.2 fixes the earlier startup panic
-    // (openadapt-desktop issue #26). The finish caption references the fix and
-    // points to the real running connect screen, and the stale "does not
-    // launch / no app window" claim is gone.
+    // Historical implementation defects do not become permanent sales copy.
     assert.doesNotMatch(
         component,
-        /does not launch yet|no app window is shown/,
-        'the stale issue #26 launch caveat must be removed'
-    )
-    assert.match(
-        component,
-        /v0\.6\.2 fixes it/,
-        'the finish caption must credit the v0.6.2 launch fix'
-    )
-    assert.match(
-        component,
-        /issue #26/,
-        'the finish caption must still name the fixed issue for continuity'
+        /does not launch yet|no app window is shown|issue #26|pictured predecessor/i
     )
 
     // The Windows install stills reserve their real pixel aspect ratio so the

--- a/tests/desktopRelease.test.js
+++ b/tests/desktopRelease.test.js
@@ -138,6 +138,6 @@ test('platform selection stays in the chosen release lifecycle', () => {
 test('download copy leads with Beta without exposing the predecessor lifecycle', () => {
     const page = readFileSync(new URL('../pages/download.js', import.meta.url), 'utf8')
     assert.match(page, /Native desktop Beta/)
-    assert.match(page, /Compatibility release/)
+    assert.match(page, /Desktop release/)
     assert.doesNotMatch(page, /Experimental/)
 })

--- a/tests/statusManifest.test.js
+++ b/tests/statusManifest.test.js
@@ -83,6 +83,16 @@ test('status manifest defines the canonical ladder with plain definitions', () =
     }
 })
 
+test('status manifest describes its machine-readable role exactly', () => {
+    assert.match(manifest.$comment, /machine-readable status evidence/)
+    assert.match(manifest.$comment, /status-aware website surfaces and tests/)
+    assert.match(
+        manifest.$comment,
+        /homepage presents product capabilities without rendering this maturity ledger/
+    )
+    assert.doesNotMatch(manifest.$comment, /imported directly by the homepage/)
+})
+
 test('hosted cloud scope is browser-only, matching the TOS and checkout gate', () => {
     // The managed subscription is a browser-only Beta by the site's own
     // machinery (lib/hostedOfferContract.js requires substrate=browser +

--- a/tests/statusManifest.test.js
+++ b/tests/statusManifest.test.js
@@ -90,7 +90,7 @@ test('hosted cloud scope is browser-only, matching the TOS and checkout gate', (
     // manifest note must not resell it as running across every substrate.
     const hosted = manifest.substrates.find((s) => s.name === 'Hosted Cloud')
     assert.equal(hosted.public_label, 'Beta')
-    assert.match(hosted.evidence_note, /browser workflows/i)
+    assert.match(hosted.evidence_note, /browser (workflows|execution)/i)
     assert.doesNotMatch(hosted.evidence_note, /across every substrate/i)
     assert.match(
         hosted.evidence_note,


### PR DESCRIPTION
## What changed

- reframes homepage pricing as three durable execution choices: local engine, OpenAdapt Cloud, and customer-controlled deployment
- replaces the temporary “Design partner / scoped pilot” framing with the target-state enterprise deployment model
- explains the real transport boundary positively: Cloud provides the managed browser runner and review surface, while desktop/RDP/Citrix connect through self-hosted or customer-controlled runtimes
- makes the download page product-led by removing repeated local/mock/historical narration from captions while keeping synthetic-data provenance in the public hash-bound manifest
- retains the security-critical macOS/Windows signing warnings and exact release checksum path
- reconciles FAQ, hosted welcome, pricing metadata, `llms.txt`, and the machine-readable status notes

## Why

The public surface was narrating a transient implementation state more prominently than the product architecture. This keeps the evidence and data-boundary truth intact without presenting enterprise execution as a temporary partner program or repeating development-capture caveats throughout the buyer journey.

No capability, safety check, pricing gate, legal term, media asset, or execution path is removed or weakened.

## Validation

- `node --test tests/*.test.js` — 125/125 passing
- production `next build` — 31/31 static pages generated
- built HTML verified for the new homepage, pricing, download, and hosted-welcome copy
- `git diff --check`
- branch is based on exact `origin/main` `abaf8b3a361713ee71cf9619acce2a195500eca2`
