### PR TITLE
fix: refresh desktop downloads with API headroom

### DIFF
--- a/pages/download.js
+++ b/pages/download.js
@@ -27,7 +27,7 @@ export async function getStaticProps() {
     // client IP means shared IPs got 403s and a broken download page).
     const { getDesktopRelease } = await import('../lib/githubApi')
     const { release, fetchFailed } = await getDesktopRelease()
-    return { props: { release, fetchFailed }, revalidate: 60 }
+    return { props: { release, fetchFailed }, revalidate: 180 }
 }
 
 export default function DownloadPage({ release, fetchFailed }) {

--- a/pages/download.js
+++ b/pages/download.js
@@ -27,7 +27,7 @@ export async function getStaticProps() {
     // client IP means shared IPs got 403s and a broken download page).
     const { getDesktopRelease } = await import('../lib/githubApi')
     const { release, fetchFailed } = await getDesktopRelease()
-    return { props: { release, fetchFailed }, revalidate: 300 }
+    return { props: { release, fetchFailed }, revalidate: 60 }
 }
 
 export default function DownloadPage({ release, fetchFailed }) {

--- a/tests/desktopRelease.test.js
+++ b/tests/desktopRelease.test.js
@@ -112,6 +112,27 @@ test('selects the newest complete release and preserves Experimental fallback', 
     assert.equal(selectDesktopRelease([legacy]), legacy)
 })
 
+test('selects desktop-v0.9.0 over desktop-v0.6.2 with package releases interleaved', () => {
+    const legacy = release(
+        'Experimental',
+        '0.6.2',
+        '2026-07-19T17:28:56Z'
+    )
+    const packageOnly = {
+        tag_name: 'v0.9.0',
+        prerelease: false,
+        draft: false,
+        published_at: '2026-07-24T02:34:42Z',
+        assets: [url('openadapt_desktop-0.9.0-py3-none-any.whl')],
+    }
+    const current = release('Beta', '0.9.0', '2026-07-24T02:52:30Z')
+
+    assert.equal(
+        selectDesktopRelease([packageOnly, legacy, current]),
+        current
+    )
+})
+
 test('a complete Beta remains primary when a legacy release is newer', () => {
     const beta = release('Beta', '0.7.0', '2026-07-21T12:00:00Z')
     const laterLegacy = release(

--- a/tests/desktopRelease.test.js
+++ b/tests/desktopRelease.test.js
@@ -112,7 +112,7 @@ test('selects the newest complete release and preserves Experimental fallback', 
     assert.equal(selectDesktopRelease([legacy]), legacy)
 })
 
-test('selects desktop-v0.9.0 over desktop-v0.6.2 with package releases interleaved', () => {
+test('selects desktop-v0.9.0 over desktop-v0.6.2 with package and runtime releases interleaved', () => {
     const legacy = release(
         'Experimental',
         '0.6.2',
@@ -125,10 +125,22 @@ test('selects desktop-v0.9.0 over desktop-v0.6.2 with package releases interleav
         published_at: '2026-07-24T02:34:42Z',
         assets: [url('openadapt_desktop-0.9.0-py3-none-any.whl')],
     }
+    const ffmpegRuntime = {
+        tag_name: 'ffmpeg-runtime-v8.1.2-r1',
+        prerelease: true,
+        draft: false,
+        published_at: '2026-07-24T00:30:34Z',
+        assets: [url('ffmpeg-8.1.2-source.tar.xz')],
+    }
     const current = release('Beta', '0.9.0', '2026-07-24T02:52:30Z')
 
     assert.equal(
-        selectDesktopRelease([packageOnly, legacy, current]),
+        selectDesktopRelease([
+            packageOnly,
+            ffmpegRuntime,
+            legacy,
+            current,
+        ]),
         current
     )
 })

--- a/tests/publicTruth.test.js
+++ b/tests/publicTruth.test.js
@@ -126,7 +126,7 @@ test('visitor browsers never call api.github.com', () => {
     const download = read('pages/download.js')
     assert.match(download, /export async function getStaticProps/)
     assert.match(download, /getDesktopRelease/)
-    assert.match(download, /revalidate: 300/)
+    assert.match(download, /revalidate: 60/)
 })
 
 test('launch surfaces lead with capabilities instead of temporary gap labels', () => {

--- a/tests/publicTruth.test.js
+++ b/tests/publicTruth.test.js
@@ -126,7 +126,7 @@ test('visitor browsers never call api.github.com', () => {
     const download = read('pages/download.js')
     assert.match(download, /export async function getStaticProps/)
     assert.match(download, /getDesktopRelease/)
-    assert.match(download, /revalidate: 60/)
+    assert.match(download, /revalidate: 180/)
 })
 
 test('launch surfaces lead with capabilities instead of temporary gap labels', () => {


### PR DESCRIPTION
## What changed

- Reduce `/download` server-side ISR from five minutes to three minutes.
- Add a regression fixture matching the real release sequence: package-only
  `v0.9.0`, managed `ffmpeg-runtime-v8.1.2-r1`, legacy `desktop-v0.6.2`,
  and complete native `desktop-v0.9.0`.
- Keep all GitHub API reads server-side and preserve the existing graceful
  fallback.

## Root cause

The selector was correct. The Python package release appeared before the
complete native asset release, while `/download` still held its bounded
five-minute ISR snapshot. Once Netlify revalidated, the page correctly selected
`desktop-v0.9.0`.

## Impact

A newly published complete native installer set now becomes eligible for the
public page after a three-minute ISR interval (plus the normal stale-first
revalidation request), without restoring unauthenticated browser calls to
`api.github.com`. This bounds anonymous release-list reads to roughly 20/hour,
leaving headroom under GitHub's shared 60/hour server limit for the homepage,
paper, and footer while production has no server-side `GITHUB_TOKEN`.

## Validation

- `npm test` — 126/126 passed
- `npm run build` — passed
- focused release/public-truth tests — 26/26 passed after the cadence adjustment
- `git diff --check` — passed
- Live canonical page independently confirmed at `desktop-v0.9.0`
