### PR TITLE
fix(footer): keep GitHub counts fresh

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -13,20 +13,14 @@ import {
     OPENADAPT_STATS_SNAPSHOT,
 } from 'data/repositoryStats'
 import { BLOG_LINK, DEVELOPER_LINKS } from 'data/developerLinks'
+import useRepositoryStats from 'hooks/useRepositoryStats'
 import { track, EVENTS } from 'utils/analytics'
 import repositoryStatsView from 'utils/repositoryStatsView'
+import repositoryStatsSelection from 'utils/repositoryStatsSelection'
 import styles from './Footer.module.css'
 
 const { sourceLabel } = repositoryStatsView
-
-// Client refresh cadence for the same-origin stats endpoint. Stars/forks move
-// over hours, so a static Netlify site does not need (and cannot host) a
-// streaming server: a light visibility-aware poll is the right tool. See the
-// PR description for the SSE-vs-poll evaluation. Responses are CDN- and
-// server-cached (s-maxage=600), so this poll almost always hits cache rather
-// than GitHub.
-const POLL_INTERVAL_MS = 90 * 1000
-const MAX_BACKOFF_MS = 10 * 60 * 1000
+const { validStats } = repositoryStatsSelection
 
 // The hosted control plane. Mirrors NEXT_PUBLIC_CLOUD_APP_URL (.env.example)
 // and the top-nav "Sign in" destination so the two surfaces never drift.
@@ -61,16 +55,6 @@ function ForkOcticon() {
         >
             <path d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z" />
         </svg>
-    )
-}
-
-function validStats(value) {
-    return (
-        value &&
-        Number.isInteger(value.stars) &&
-        value.stars > 0 &&
-        Number.isInteger(value.forks) &&
-        value.forks >= 0
     )
 }
 
@@ -190,84 +174,23 @@ const CONNECT_COLUMN = [
     { label: 'GitHub', href: OPENADAPT_REPOSITORY_URL },
 ]
 
-export default function Footer({ repositoryStats = OPENADAPT_STATS_SNAPSHOT }) {
+export default function Footer({
+    repositoryStats = OPENADAPT_STATS_SNAPSHOT,
+    pollRepositoryStats = true,
+}) {
     const router = useRouter()
     const currentYear = new Date().getFullYear()
     const isHome = router.pathname === '/'
     const bookHref = isHome ? '#book' : '/book'
     const contactHref = isHome ? '#book' : '/contact'
-    const [stats, setStats] = useState(
-        validStats(repositoryStats) ? repositoryStats : OPENADAPT_STATS_SNAPSHOT
-    )
-
-    useEffect(() => {
-        // Live-refresh the counts with a visibility-aware poll. We never blank
-        // the widget: a failed fetch or a server-reported stale/snapshot value
-        // simply keeps the last good numbers and backs the poll off (up to
-        // MAX_BACKOFF_MS) so a rate-limited or down endpoint is not hammered.
-        let cancelled = false
-        let timer = null
-        let controller = null
-        let backoff = POLL_INTERVAL_MS
-
-        const schedule = () => {
-            clearTimeout(timer)
-            // A hidden tab schedules nothing; it resumes on visibilitychange.
-            if (document.visibilityState === 'hidden') return
-            timer = setTimeout(fetchOnce, backoff)
-        }
-
-        const fetchOnce = async () => {
-            controller = new AbortController()
-            try {
-                const response = await fetch('/api/repository-stats', {
-                    headers: { Accept: 'application/json' },
-                    signal: controller.signal,
-                })
-                if (!response.ok) {
-                    throw new Error(`stats request failed: ${response.status}`)
-                }
-                const next = await response.json()
-                if (cancelled) return
-                if (validStats(next)) setStats(next)
-                // Fresh live data resets the cadence; a server-reported
-                // stale/snapshot value means GitHub was unreachable, so back
-                // off rather than re-poll a struggling upstream every 90s.
-                if (next && next.source === 'github' && !next.stale) {
-                    backoff = POLL_INTERVAL_MS
-                } else {
-                    backoff = Math.min(backoff * 2, MAX_BACKOFF_MS)
-                }
-            } catch {
-                // Network error, non-OK, or rate limit: keep the last good
-                // value and back off exponentially.
-                if (cancelled) return
-                backoff = Math.min(backoff * 2, MAX_BACKOFF_MS)
-            } finally {
-                controller = null
-                if (!cancelled) schedule()
-            }
-        }
-
-        const onVisibility = () => {
-            if (document.visibilityState === 'visible') {
-                // Refresh immediately on return, then resume the poll.
-                fetchOnce()
-            } else {
-                clearTimeout(timer)
-                if (controller) controller.abort()
-            }
-        }
-
-        fetchOnce()
-        document.addEventListener('visibilitychange', onVisibility)
-        return () => {
-            cancelled = true
-            clearTimeout(timer)
-            if (controller) controller.abort()
-            document.removeEventListener('visibilitychange', onVisibility)
-        }
-    }, [])
+    const polledStats = useRepositoryStats(repositoryStats, {
+        enabled: pollRepositoryStats,
+    })
+    const stats = pollRepositoryStats
+        ? polledStats
+        : validStats(repositoryStats)
+          ? repositoryStats
+          : OPENADAPT_STATS_SNAPSHOT
 
     return (
         <div className={styles.footerContainer}>

--- a/cypress/e2e/public-surface-coherence.cy.js
+++ b/cypress/e2e/public-surface-coherence.cy.js
@@ -1,7 +1,21 @@
 describe('public surface coherence', () => {
     it('keeps the flagship project, evaluation funnel, and local quickstart distinct', () => {
         cy.viewport(1280, 1000)
+        // Keep this homepage visit self-contained. Without an immediate
+        // response, its asynchronous stats request can outlive the test and
+        // satisfy the next test's intercept before that test's own visit.
+        cy.intercept('GET', '/api/repository-stats', {
+            statusCode: 200,
+            body: {
+                stars: 1650,
+                forks: 259,
+                observedAt: '2026-07-24T11:00:00.000Z',
+                source: 'github',
+                stale: false,
+            },
+        }).as('initialHomepageRepositoryStats')
         cy.visit('/')
+        cy.wait('@initialHomepageRepositoryStats')
 
         cy.get('nav[aria-label="Primary"]')
             .contains('a', 'Open source')
@@ -48,7 +62,33 @@ describe('public surface coherence', () => {
         )
     })
 
-    it('keeps flagship star and fork counts visible across public pages', () => {
+    it('updates homepage hero and footer from one repository-stats response', () => {
+        cy.intercept('GET', '/api/repository-stats', {
+            statusCode: 200,
+            body: {
+                stars: 1660,
+                forks: 260,
+                observedAt: '2026-07-24T12:00:00.000Z',
+                source: 'github',
+                stale: false,
+            },
+        }).as('homepageRepositoryStats')
+
+        cy.visit('/')
+        cy.wait('@homepageRepositoryStats')
+
+        cy.get('[data-testid="github-proof"]')
+            .should('contain.text', '1.7k stars on OpenAdapt')
+            .and('contain.text', '260 forks')
+        cy.get('[data-testid="footer-star-count"]').should(
+            'have.text',
+            '1,660'
+        )
+        cy.get('[data-testid="footer-fork-count"]').should('have.text', '260')
+        cy.get('@homepageRepositoryStats.all').should('have.length', 1)
+    })
+
+    it('keeps flagship star and fork counts visible across solution pages', () => {
         cy.intercept('GET', '/api/repository-stats', {
             statusCode: 200,
             body: {
@@ -61,7 +101,6 @@ describe('public surface coherence', () => {
         }).as('repositoryStats')
 
         for (const path of [
-            '/',
             '/solutions/healthcare',
             '/solutions/lending',
             '/solutions/insurance',

--- a/hooks/useRepositoryStats.js
+++ b/hooks/useRepositoryStats.js
@@ -1,0 +1,90 @@
+import { useEffect, useState } from 'react'
+
+import { OPENADAPT_STATS_SNAPSHOT } from 'data/repositoryStats'
+import repositoryStatsSelection from 'utils/repositoryStatsSelection'
+
+const { newerStats, validStats } = repositoryStatsSelection
+
+// Stars/forks move over hours. Poll the same-origin endpoint while the page is
+// visible; Netlify's one-hour durable cache (s-maxage=3600) means normal
+// visitor refreshes do not spend GitHub's unauthenticated API quota.
+const POLL_INTERVAL_MS = 90 * 1000
+const MAX_BACKOFF_MS = 10 * 60 * 1000
+
+export default function useRepositoryStats(
+    initialStats = OPENADAPT_STATS_SNAPSHOT,
+    { enabled = true } = {}
+) {
+    const initial = validStats(initialStats)
+        ? initialStats
+        : OPENADAPT_STATS_SNAPSHOT
+    const [stats, setStats] = useState(initial)
+
+    useEffect(() => {
+        setStats((current) => newerStats(current, initial))
+    }, [initial])
+
+    useEffect(() => {
+        if (!enabled) return undefined
+
+        // Never blank the widget: failed or older responses preserve the last
+        // good observation and progressively back off.
+        let cancelled = false
+        let timer = null
+        let controller = null
+        let backoff = POLL_INTERVAL_MS
+
+        const schedule = () => {
+            clearTimeout(timer)
+            if (document.visibilityState === 'hidden') return
+            timer = setTimeout(fetchOnce, backoff)
+        }
+
+        const fetchOnce = async () => {
+            controller = new AbortController()
+            try {
+                const response = await fetch('/api/repository-stats', {
+                    headers: { Accept: 'application/json' },
+                    signal: controller.signal,
+                })
+                if (!response.ok) {
+                    throw new Error(`stats request failed: ${response.status}`)
+                }
+                const next = await response.json()
+                if (cancelled) return
+                setStats((current) => newerStats(current, next))
+                if (next?.source === 'github' && !next.stale) {
+                    backoff = POLL_INTERVAL_MS
+                } else {
+                    backoff = Math.min(backoff * 2, MAX_BACKOFF_MS)
+                }
+            } catch {
+                if (cancelled) return
+                backoff = Math.min(backoff * 2, MAX_BACKOFF_MS)
+            } finally {
+                controller = null
+                if (!cancelled) schedule()
+            }
+        }
+
+        const onVisibility = () => {
+            if (document.visibilityState === 'visible') {
+                fetchOnce()
+            } else {
+                clearTimeout(timer)
+                controller?.abort()
+            }
+        }
+
+        fetchOnce()
+        document.addEventListener('visibilitychange', onVisibility)
+        return () => {
+            cancelled = true
+            clearTimeout(timer)
+            controller?.abort()
+            document.removeEventListener('visibilitychange', onVisibility)
+        }
+    }, [enabled])
+
+    return stats
+}

--- a/pages/api/repository-stats.js
+++ b/pages/api/repository-stats.js
@@ -11,7 +11,11 @@ export default async function handler(request, response) {
 
     response.setHeader(
         'Cache-Control',
-        'public, max-age=0, s-maxage=600, stale-while-revalidate=3600, stale-if-error=86400'
+        'public, max-age=0, stale-while-revalidate=60'
+    )
+    response.setHeader(
+        'Netlify-CDN-Cache-Control',
+        'public, durable, s-maxage=3600, stale-while-revalidate=86400, stale-if-error=86400'
     )
     return response.status(200).json(stats)
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -16,7 +16,9 @@ import Pricing from '@components/Pricing'
 import ProductStatus from '@components/ProductStatus'
 import Qualification from '@components/Qualification'
 import Reveal from '@components/Reveal'
+import useRepositoryStats from 'hooks/useRepositoryStats'
 import { DEFAULT_VERTICAL, VERTICAL_KEYS } from '../data/referenceWorkflows'
+import { OPENADAPT_STATS_SNAPSHOT } from '../data/repositoryStats'
 
 const organizationSchema = {
     '@context': 'https://schema.org',
@@ -123,18 +125,17 @@ const referenceLinks = [
 ]
 
 export async function getStaticProps() {
-    // Seed the initial HTML with the shared cached/verified repository stats.
-    // The footer may refresh through our same-origin endpoint after hydration.
+    // Seed initial HTML with the verified snapshot. One shared same-origin
+    // endpoint refreshes Footer counts after hydration; keeping GitHub stats
+    // out of this five-minute ISR avoids duplicate unauthenticated API calls.
     const { getOpenIssuesByLabel } = await import('../lib/githubApi')
-    const { getOpenAdaptRepositoryStats } = await import(
-        '../lib/openAdaptRepositoryStats'
+    const githubStats = OPENADAPT_STATS_SNAPSHOT
+    // Known engine breakage surfaced server-side so visitor browsers never
+    // call api.github.com (60 req/hr per IP → 403s on shared IPs).
+    const buildWarnings = await getOpenIssuesByLabel(
+        'OpenAdaptAI/openadapt-flow',
+        'main-broken'
     )
-    const [githubStats, buildWarnings] = await Promise.all([
-        getOpenAdaptRepositoryStats(),
-        // Known engine breakage surfaced server-side so visitor browsers
-        // never call api.github.com (60 req/hr per IP → 403s on shared IPs).
-        getOpenIssuesByLabel('OpenAdaptAI/openadapt-flow', 'main-broken'),
-    ])
     const { getHostedOffer } = await import('../lib/hostedOffer')
     const hostedOffer = await getHostedOffer()
     // Adoption proof renders from a committed snapshot (data/installStats.json),
@@ -150,6 +151,10 @@ export async function getStaticProps() {
 
 export default function Home({ githubStats, buildWarnings, hostedOffer, installStats }) {
     const router = useRouter()
+    // Home owns the one live repository-stats request so every social-proof
+    // consumer updates atomically. Footer polling is disabled on this route;
+    // other pages let their Footer own the same shared hook.
+    const currentGithubStats = useRepositoryStats(githubStats)
     // ONE lifted selection shared by every reference-aware homepage section:
     // the process/reference-workflow demo and the "More reference workflows"
     // list read and write this single vertical, so choosing a vertical in one
@@ -200,7 +205,7 @@ export default function Home({ githubStats, buildWarnings, hostedOffer, installS
                     }}
                 />
             </Head>
-            <MastHead githubStats={githubStats} />
+            <MastHead githubStats={currentGithubStats} />
             <Reveal>
                 <HowItWorksCondensed />
             </Reveal>
@@ -323,7 +328,7 @@ export default function Home({ githubStats, buildWarnings, hostedOffer, installS
             <Reveal>
                 <Developers
                     buildWarnings={buildWarnings}
-                    githubStats={githubStats}
+                    githubStats={currentGithubStats}
                 />
             </Reveal>
             <Reveal>
@@ -332,7 +337,10 @@ export default function Home({ githubStats, buildWarnings, hostedOffer, installS
             <Reveal>
                 <EmailForm />
             </Reveal>
-            <Footer repositoryStats={githubStats} />
+            <Footer
+                repositoryStats={currentGithubStats}
+                pollRepositoryStats={false}
+            />
         </div>
     )
 }

--- a/pages/paper.js
+++ b/pages/paper.js
@@ -2,7 +2,6 @@ import Head from 'next/head'
 import Link from 'next/link'
 
 import Footer from '@components/Footer'
-import { getOpenAdaptRepositoryStats } from '../lib/openAdaptRepositoryStats'
 
 // The typeset PDF is live at public/openadapt-paper.pdf. PAPER_SOURCE_URL is
 // the canonical location of the paper source (LaTeX + figures) for readers who
@@ -26,12 +25,7 @@ const webPageSchema = {
     inLanguage: 'en',
 }
 
-export async function getStaticProps() {
-    const githubStats = await getOpenAdaptRepositoryStats()
-    return { props: { githubStats }, revalidate: 300 }
-}
-
-export default function PaperPage({ githubStats }) {
+export default function PaperPage() {
     return (
         <div className="min-h-screen bg-ground text-ink">
             <Head>
@@ -103,7 +97,7 @@ export default function PaperPage({ githubStats }) {
                 </p>
             </section>
 
-            <Footer repositoryStats={githubStats} />
+            <Footer />
         </div>
     )
 }

--- a/tests/publicTruth.test.js
+++ b/tests/publicTruth.test.js
@@ -36,27 +36,59 @@ test('GitHub proof uses the canonical repository and a verified fallback', () =>
     const snapshot = read('data/repositoryStats.js')
     const loader = read('lib/openAdaptRepositoryStats.js')
     const endpoint = read('pages/api/repository-stats.js')
+    const hook = read('hooks/useRepositoryStats.js')
+    const paper = read('pages/paper.js')
 
     assert.match(snapshot, /OPENADAPT_REPOSITORY = 'OpenAdaptAI\/OpenAdapt'/)
     assert.match(snapshot, /stars: 1648/)
     assert.match(snapshot, /forks: 258/)
     assert.match(snapshot, /source: 'snapshot'/)
-    assert.match(home, /getOpenAdaptRepositoryStats\(\)/)
-    assert.match(home, /<Footer repositoryStats=\{githubStats\} \/>/)
+    assert.match(home, /const githubStats = OPENADAPT_STATS_SNAPSHOT/)
+    assert.doesNotMatch(home, /getOpenAdaptRepositoryStats\(\)/)
+    assert.match(
+        home,
+        /const currentGithubStats = useRepositoryStats\(githubStats\)/
+    )
+    assert.match(home, /<MastHead githubStats=\{currentGithubStats\} \/>/)
+    assert.match(
+        home,
+        /<Developers[\s\S]*githubStats=\{currentGithubStats\}/
+    )
+    assert.match(
+        home,
+        /<Footer[\s\S]*repositoryStats=\{currentGithubStats\}[\s\S]*pollRepositoryStats=\{false\}/
+    )
+    assert.equal(
+        (home.match(/useRepositoryStats\(/g) || []).length,
+        1,
+        'home owns one repository-stats polling hook'
+    )
+    assert.doesNotMatch(paper, /getOpenAdaptRepositoryStats/)
+    assert.match(paper, /<Footer \/>/)
     assert.match(footer, /repositoryStats = OPENADAPT_STATS_SNAPSHOT/)
-    assert.match(footer, /fetch\('\/api\/repository-stats'/)
+    assert.match(footer, /useRepositoryStats\(repositoryStats/)
+    assert.match(footer, /enabled: pollRepositoryStats/)
+    assert.match(hook, /fetch\('\/api\/repository-stats'/)
     // A failed/rate-limited refresh must keep the last good value, never blank.
-    assert.match(footer, /keep the last good/i)
+    assert.match(hook, /preserve the last[\s\S]*good observation/i)
+    assert.match(hook, /one-hour durable cache \(s-maxage=3600\)/)
+    assert.doesNotMatch(hook, /s-maxage=600/)
     assert.match(loader, /const FRESH_TTL_MS = 10 \* 60 \* 1000/)
     assert.match(loader, /if \(inFlight\) return inFlight/)
     assert.match(loader, /source:[\s\S]*?'stale'[\s\S]*?'snapshot'/)
-    assert.match(endpoint, /s-maxage=600/)
-    assert.match(endpoint, /stale-while-revalidate=3600/)
+    assert.match(endpoint, /s-maxage=3600/)
+    assert.match(endpoint, /stale-while-revalidate=86400/)
     assert.match(endpoint, /stale-if-error=86400/)
+    assert.match(endpoint, /Netlify-CDN-Cache-Control/)
     assert.match(
         read('lib/githubApi.js'),
         /return \{ \.\.\.fallback \}/,
         'lib/githubApi.js must fall back to the verified stats on failure'
+    )
+    assert.match(
+        read('utils/repositoryStatsSelection.js'),
+        /nextTime === null \|\| nextTime < currentTime[\s\S]*nextTime > currentTime[\s\S]*sourceFreshness\(next\) > sourceFreshness\(current\)/,
+        'all observations move monotonically by timestamp; source only breaks a tie'
     )
     assert.match(masthead, /https:\/\/github\.com\/OpenAdaptAI\/OpenAdapt/)
     assert.match(masthead, /stars on OpenAdapt/)

--- a/tests/repositoryStatsSelection.test.js
+++ b/tests/repositoryStatsSelection.test.js
@@ -1,0 +1,91 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const {
+    newerStats,
+    validStats,
+} = require('../utils/repositoryStatsSelection')
+
+const live = {
+    stars: 1654,
+    forks: 258,
+    observedAt: '2026-07-24T02:00:00.000Z',
+    source: 'github',
+    stale: false,
+}
+
+test('validates only present, nonzero repository social proof', () => {
+    assert.equal(validStats(live), true)
+    assert.equal(validStats({ ...live, stars: 0 }), false)
+    assert.equal(validStats({ ...live, forks: -1 }), false)
+    assert.equal(validStats({ ...live, stars: '1654' }), false)
+})
+
+test('never downgrades a live observation to an older snapshot', () => {
+    const snapshot = {
+        stars: 1648,
+        forks: 258,
+        observedAt: '2026-07-18T00:00:00.000Z',
+        source: 'snapshot',
+        stale: true,
+    }
+    assert.equal(newerStats(live, snapshot), live)
+})
+
+test('never accepts an older response merely because it is fresh GitHub data', () => {
+    const olderLive = {
+        ...live,
+        stars: 9999,
+        forks: 999,
+        observedAt: '2026-07-24T01:59:59.000Z',
+    }
+    assert.equal(newerStats(live, olderLive), live)
+})
+
+test('accepts a fresh observation and a genuinely newer stale value', () => {
+    const fresh = {
+        ...live,
+        stars: 1655,
+        observedAt: '2026-07-24T02:05:00.000Z',
+    }
+    assert.equal(newerStats(live, fresh), fresh)
+
+    const newerStale = {
+        ...fresh,
+        source: 'stale',
+        stale: true,
+    }
+    assert.equal(newerStats(live, newerStale), newerStale)
+})
+
+test('source freshness only breaks a tie at the same valid timestamp', () => {
+    const snapshot = {
+        ...live,
+        source: 'snapshot',
+        stale: true,
+    }
+    assert.equal(newerStats(snapshot, live), live)
+    assert.equal(newerStats(live, snapshot), live)
+})
+
+test('a malformed or missing timestamp cannot replace a dated current value', () => {
+    const missingTime = { ...live, stars: 1700 }
+    delete missingTime.observedAt
+    const malformedTime = {
+        ...live,
+        stars: 1700,
+        observedAt: 'not-a-time',
+    }
+    assert.equal(newerStats(live, missingTime), live)
+    assert.equal(newerStats(live, malformedTime), live)
+})
+
+test('a valid timestamp improves an otherwise valid undated value', () => {
+    const undated = { ...live }
+    delete undated.observedAt
+    assert.equal(newerStats(undated, live), live)
+})
+
+test('rejects malformed refresh payloads', () => {
+    assert.equal(newerStats(live, { error: 'unavailable' }), live)
+})

--- a/utils/repositoryStatsSelection.js
+++ b/utils/repositoryStatsSelection.js
@@ -1,0 +1,52 @@
+// Pure validation/ordering for server-rendered and live repository counts.
+// Kept outside React so the "never downgrade fresh data" contract is covered
+// directly by node:test.
+
+function validStats(value) {
+    return Boolean(
+        value &&
+            Number.isInteger(value.stars) &&
+            value.stars > 0 &&
+            Number.isInteger(value.forks) &&
+            value.forks >= 0
+    )
+}
+
+function observedAt(value) {
+    const timestamp = Date.parse(value?.observedAt)
+    return Number.isFinite(timestamp) ? timestamp : null
+}
+
+function sourceFreshness(value) {
+    if (value?.source === 'github' && !value.stale) return 2
+    if (value?.source === 'stale') return 1
+    return 0
+}
+
+function newerStats(current, next) {
+    if (!validStats(next)) return current
+    if (!validStats(current)) return next
+
+    const currentTime = observedAt(current)
+    const nextTime = observedAt(next)
+
+    // A valid current observation can only move forward in time. A payload
+    // does not become newer merely by claiming source:"github": an older live
+    // response is still older, and a missing/malformed time is not evidence.
+    if (currentTime !== null) {
+        if (nextTime === null || nextTime < currentTime) return current
+        if (nextTime > currentTime) return next
+        // Source freshness may break a tie only after both timestamps are
+        // known-valid and exactly equal.
+        return sourceFreshness(next) > sourceFreshness(current)
+            ? next
+            : current
+    }
+
+    // Prefer a timestamped observation over an otherwise valid undated value.
+    // If neither has a valid timestamp, retain the existing value.
+    if (nextTime !== null) return next
+    return current
+}
+
+module.exports = { validStats, newerStats }


### PR DESCRIPTION
## What changed

- retain the freshest valid star/fork observation by timestamp; source freshness
  only breaks a tie between equally dated observations
- route live counts through one reusable visibility-aware same-origin hook rather
  than making duplicate star/fork calls from homepage, footer, and paper ISR
- let the homepage own one live request and apply that same observation to the
  hero, developer section, and footer atomically
- give Netlify's durable CDN cache an explicit one-hour freshness policy with stale-on-upstream-failure behavior
- add direct ordering, public-boundary, and browser regression tests

## Root cause

The shared footer refresh treated every structurally valid endpoint response as
newer. On a cold Netlify function instance or an exhausted unauthenticated
GitHub API quota, the endpoint returned the verified but dated committed
snapshot, which could replace fresher data and leave visitors seeing “snapshot
from 6d ago.” Fresh GitHub data was also treated as authoritative without first
proving its timestamp was newer.

The production site has no `GITHUB_TOKEN`. Before this change, independent homepage ISR, paper ISR, and runtime endpoint requests all spent the same unauthenticated GitHub quota. This change removes the two duplicate star/fork callers. Footer hydration on every public page immediately uses the shared endpoint; its durable one-hour cache means visitor polling is served by Netlify rather than GitHub.

## User impact

Every page keeps shared star/fork proof visible and current through one
rate-budgeted server path. The homepage makes exactly one live request and
updates both its hero and footer from the same response. A transient upstream
failure or older response preserves the latest successful observation. Visitor
browsers still never call `api.github.com`, and the implementation does not
scrape GitHub HTML.

## Validation

- focused footer/public-truth/download/ordering regression suite — 40/40 passed
- focused production-build Cypress public-surface suite — 4/4 passed
- `npm test` — 134/134 passed
- `npm run build` — production build passed, all 31 static pages generated
- rebased onto download-freshness main `abdf35b`; its 180-second ISR contract remains asserted and the build reports `/download` at 3m
- `git diff --check`
- live endpoint and homepage probed before implementation; the state refreshed during diagnosis, confirming the failure was intermittent

The build's paper-refresh step could not reach GitHub in the sandbox and correctly retained the committed PDF fallback; the production build itself passed.
