### PR TITLE
Document platform-admin MFA in the trust center

### DIFF
--- a/pages/security.js
+++ b/pages/security.js
@@ -73,7 +73,7 @@ const summary = [
         area: 'Identity, access & tenancy',
         anchor: 'access',
         status: 'partial',
-        note: 'Org RBAC + row-level tenant isolation today; SSO / SAML / SCIM not yet.',
+        note: 'Org RBAC, row-level tenant isolation, and TOTP step-up protect privileged access; SSO / SAML / SCIM is not included.',
     },
     {
         area: 'Release integrity',
@@ -942,6 +942,34 @@ export default function SecurityPage() {
                             scoped to organization membership, so data is
                             isolated per organization rather than shared across
                             tenants.
+                        </p>
+                        <p>
+                            Authenticator-app two-factor authentication is
+                            available to every account and enforced for
+                            privileged access. The platform-admin console
+                            always requires both the server-side administrator
+                            allowlist and a current two-factor session. The
+                            default policy also requires two-factor
+                            authentication for organization owners and admins.
+                            When a signed-in session needs this additional
+                            assurance, Cloud asks for one current 6-digit code
+                            and returns the user to the protected page after it
+                            is accepted.
+                        </p>
+                        <p>
+                            The signed-in account menu keeps identity and
+                            organization context visible. It provides Security
+                            &amp; 2FA, organization switching when an account
+                            belongs to more than one workspace, and an explicit
+                            sign-out action. The{' '}
+                            <a
+                                href="https://docs.openadapt.ai/guides/account-security/"
+                                className="text-accent underline"
+                            >
+                                account-security guide
+                            </a>{' '}
+                            covers enrollment, step-up, and account or workspace
+                            switching.
                         </p>
                         <p>
                             What is <strong className="text-ink">not</strong>{' '}

--- a/pages/security.js
+++ b/pages/security.js
@@ -73,7 +73,7 @@ const summary = [
         area: 'Identity, access & tenancy',
         anchor: 'access',
         status: 'partial',
-        note: 'Org RBAC, row-level tenant isolation, and TOTP step-up protect privileged access; SSO / SAML / SCIM is not included.',
+        note: 'Org RBAC, row-level tenant isolation, and TOTP step-up protect platform administration; SSO / SAML / SCIM is not included.',
     },
     {
         area: 'Release integrity',
@@ -946,11 +946,9 @@ export default function SecurityPage() {
                         <p>
                             Authenticator-app two-factor authentication is
                             available to every account and enforced for
-                            privileged access. The platform-admin console
+                            platform administration. The platform-admin console
                             always requires both the server-side administrator
                             allowlist and a current two-factor session. The
-                            default policy also requires two-factor
-                            authentication for organization owners and admins.
                             When a signed-in session needs this additional
                             assurance, Cloud asks for one current 6-digit code
                             and returns the user to the protected page after it

--- a/pages/security.js
+++ b/pages/security.js
@@ -948,11 +948,19 @@ export default function SecurityPage() {
                             available to every account and enforced for
                             platform administration. The platform-admin console
                             always requires both the server-side administrator
-                            allowlist and a current two-factor session. The
+                            allowlist and a current two-factor session.
                             When a signed-in session needs this additional
                             assurance, Cloud asks for one current 6-digit code
                             and returns the user to the protected page after it
                             is accepted.
+                        </p>
+                        <p>
+                            Enrollment also produces one-time recovery codes.
+                            If an authenticator is lost, a recovery code removes
+                            the inaccessible factors and returns the signed-in
+                            user to Security &amp; 2FA to enroll a replacement.
+                            Recovery never grants the protected session by
+                            itself.
                         </p>
                         <p>
                             The signed-in account menu keeps identity and
@@ -966,8 +974,8 @@ export default function SecurityPage() {
                             >
                                 account-security guide
                             </a>{' '}
-                            covers enrollment, step-up, and account or workspace
-                            switching.
+                            covers enrollment, step-up, recovery, and account or
+                            workspace switching.
                         </p>
                         <p>
                             What is <strong className="text-ink">not</strong>{' '}

--- a/pages/security.js
+++ b/pages/security.js
@@ -957,10 +957,11 @@ export default function SecurityPage() {
                         <p>
                             Enrollment also produces one-time recovery codes.
                             If an authenticator is lost, a recovery code removes
-                            the inaccessible factors and returns the signed-in
-                            user to Security &amp; 2FA to enroll a replacement.
-                            Recovery never grants the protected session by
-                            itself.
+                            the inaccessible factors. Factor removal invalidates
+                            active sessions, so Cloud explicitly returns through
+                            sign-in and then to Security &amp; 2FA to enroll a
+                            replacement. Recovery never grants the protected
+                            session by itself.
                         </p>
                         <p>
                             The signed-in account menu keeps identity and

--- a/tests/securityMfa.test.js
+++ b/tests/securityMfa.test.js
@@ -11,7 +11,7 @@ test('trust center describes the platform-admin MFA and account-menu contract', 
     assert.match(security, /two-factor authentication is[\s\S]*enforced for[\s\S]*platform administration/i)
     assert.match(security, /platform-admin console[\s\S]*server-side administrator[\s\S]*current two-factor session/i)
     assert.match(security, /one current 6-digit code[\s\S]*returns the user to the protected page/i)
-    assert.match(security, /recovery code[\s\S]*returns[\s\S]*signed-in[\s\S]*user to Security[\s\S]*never grants the protected session/i)
+    assert.match(security, /recovery code[\s\S]*invalidates[\s\S]*returns through[\s\S]*sign-in[\s\S]*Security[\s\S]*never grants[\s\S]*protected[\s\S]*session/i)
     assert.match(security, /organization switching[\s\S]*explicit[\s\S]*sign-out action/i)
     assert.match(security, /docs\.openadapt\.ai\/guides\/account-security/)
     assert.doesNotMatch(security, /default policy also requires two-factor[\s\S]*organization owners/i)

--- a/tests/securityMfa.test.js
+++ b/tests/securityMfa.test.js
@@ -11,6 +11,7 @@ test('trust center describes the platform-admin MFA and account-menu contract', 
     assert.match(security, /two-factor authentication is[\s\S]*enforced for[\s\S]*platform administration/i)
     assert.match(security, /platform-admin console[\s\S]*server-side administrator[\s\S]*current two-factor session/i)
     assert.match(security, /one current 6-digit code[\s\S]*returns the user to the protected page/i)
+    assert.match(security, /recovery code[\s\S]*returns[\s\S]*signed-in[\s\S]*user to Security[\s\S]*never grants the protected session/i)
     assert.match(security, /organization switching[\s\S]*explicit[\s\S]*sign-out action/i)
     assert.match(security, /docs\.openadapt\.ai\/guides\/account-security/)
     assert.doesNotMatch(security, /default policy also requires two-factor[\s\S]*organization owners/i)

--- a/tests/securityMfa.test.js
+++ b/tests/securityMfa.test.js
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const security = fs.readFileSync(path.join(root, 'pages/security.js'), 'utf8')
+
+test('trust center describes the privileged MFA and account-menu contract', () => {
+    assert.match(security, /two-factor authentication is[\s\S]*enforced for[\s\S]*privileged access/i)
+    assert.match(security, /platform-admin console[\s\S]*server-side administrator[\s\S]*current two-factor session/i)
+    assert.match(security, /one current 6-digit code[\s\S]*returns the user to the protected page/i)
+    assert.match(security, /organization switching[\s\S]*explicit[\s\S]*sign-out action/i)
+    assert.match(security, /docs\.openadapt\.ai\/guides\/account-security/)
+})

--- a/tests/securityMfa.test.js
+++ b/tests/securityMfa.test.js
@@ -7,10 +7,11 @@ import { fileURLToPath } from 'node:url'
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const security = fs.readFileSync(path.join(root, 'pages/security.js'), 'utf8')
 
-test('trust center describes the privileged MFA and account-menu contract', () => {
-    assert.match(security, /two-factor authentication is[\s\S]*enforced for[\s\S]*privileged access/i)
+test('trust center describes the platform-admin MFA and account-menu contract', () => {
+    assert.match(security, /two-factor authentication is[\s\S]*enforced for[\s\S]*platform administration/i)
     assert.match(security, /platform-admin console[\s\S]*server-side administrator[\s\S]*current two-factor session/i)
     assert.match(security, /one current 6-digit code[\s\S]*returns the user to the protected page/i)
     assert.match(security, /organization switching[\s\S]*explicit[\s\S]*sign-out action/i)
     assert.match(security, /docs\.openadapt\.ai\/guides\/account-security/)
+    assert.doesNotMatch(security, /default policy also requires two-factor[\s\S]*organization owners/i)
 })


### PR DESCRIPTION
## What changed

- adds authenticator-app two-factor authentication and platform-admin step-up to the Trust Center access-control summary
- explains the independent platform-admin allowlist and current-session MFA gates
- describes bounded recovery: a one-time code returns the signed-in account to replacement-factor enrollment but never grants the protected session
- documents the signed-in account menu’s organization switcher, Security & 2FA link, and sign-out action
- links to the new account-security guide and adds a focused public-copy contract test

## Why

The live Trust Center described organization RBAC and row-level tenant isolation but omitted the shipped MFA and platform-admin controls. It also did not explain the account-menu behavior customers actually see.

This PR intentionally does **not** claim that ordinary organization-owner or organization-admin pages are AAL2-gated; that broader action-level enforcement is a separate implementation track.

## Ordering

This PR is intentionally draft. Merge it only after:

1. Cloud PR [#122](https://github.com/OpenAdaptAI/openadapt-cloud/pull/122) is merged and deployed; and
2. the docs account-security guide is merged and live at `/guides/account-security/`.

That ordering prevents the public site from promising the corrected one-code return behavior or linking to a route before those surfaces exist.

## Validation

- `npm test` — 135/135 passed
- `npm run build` — production build passed
- `git diff --check` — passed
