### PR TITLE
Simplify pricing into three decision paths

### DIFF
--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -47,6 +47,55 @@ function FeatureList({ items }) {
     )
 }
 
+function EntryCard({
+    id,
+    eyebrow,
+    title,
+    price,
+    priceDetail,
+    description,
+    features,
+    children,
+    featured = false,
+}) {
+    const titleId = `${id}-title`
+
+    return (
+        <article
+            id={id}
+            role="listitem"
+            aria-labelledby={titleId}
+            className={[
+                'flex h-full scroll-mt-24 flex-col rounded-2xl bg-panel p-6 md:p-7',
+                featured
+                    ? 'border-2 border-ink shadow-[0_8px_32px_rgba(35,40,31,0.10)]'
+                    : 'border border-hairline',
+            ].join(' ')}
+        >
+            <p className="eyebrow">{eyebrow}</p>
+            <h2
+                id={titleId}
+                className="mt-2 font-display text-xl font-semibold tracking-tight text-ink"
+            >
+                {title}
+            </h2>
+            <div className="mt-4 flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                <span className="font-display text-3xl font-semibold tracking-tight text-ink">
+                    {price}
+                </span>
+                {priceDetail && (
+                    <span className="text-sm text-ink-3">{priceDetail}</span>
+                )}
+            </div>
+            <p className="mt-4 text-sm leading-relaxed text-ink-2">
+                {description}
+            </p>
+            <FeatureList items={features} />
+            <div className="mt-auto pt-6">{children}</div>
+        </article>
+    )
+}
+
 function HostedCheckoutButton({ available }) {
     const [state, setState] = useState('idle')
     const [message, setMessage] = useState('')
@@ -66,7 +115,9 @@ function HostedCheckoutButton({ available }) {
             })
             const payload = await response.json()
             if (!response.ok || !payload.url) {
-                throw new Error('We could not open secure checkout. Please try again.')
+                throw new Error(
+                    'We could not open secure checkout. Please try again.'
+                )
             }
             window.location.assign(payload.url)
         } catch (error) {
@@ -89,14 +140,7 @@ function HostedCheckoutButton({ available }) {
                         })
                     }
                 >
-                    Start with our team
-                </Link>
-                <Link
-                    href="/qualify"
-                    data-testid="hosted-waitlist"
-                    className="mt-3 block text-center text-xs text-accent underline"
-                >
-                    Qualify a managed workflow
+                    Get Cloud setup help
                 </Link>
             </div>
         )
@@ -119,7 +163,10 @@ function HostedCheckoutButton({ available }) {
                     : 'Start hosted subscription'}
             </button>
             {state === 'error' && (
-                <p role="alert" className="mt-3 text-xs leading-relaxed text-ink-3">
+                <p
+                    role="alert"
+                    className="mt-3 text-xs leading-relaxed text-ink-3"
+                >
                     {message}{' '}
                     <Link href="/qualify" className="text-accent underline">
                         Contact us to complete setup.
@@ -136,9 +183,9 @@ export default function Pricing({ hostedOffer = null }) {
     )
     const hostedOfferAvailable = Boolean(
         hostedOffer?.amount &&
-        hostedOffer?.cadence &&
-        hostedOffer?.product &&
-        runCapLabel
+            hostedOffer?.cadence &&
+            hostedOffer?.product &&
+            runCapLabel
     )
 
     return (
@@ -149,34 +196,32 @@ export default function Pricing({ hostedOffer = null }) {
             <div className="mx-auto max-w-6xl">
                 <p className="eyebrow text-center">Pricing</p>
                 <h1 className="mx-auto mt-2 max-w-3xl text-center font-display text-2xl font-semibold tracking-tight text-ink md:text-4xl">
-                    Start with one workflow. Earn the right to scale it.
+                    Choose how you want to start.
                 </h1>
                 <p className="mx-auto mt-4 max-w-3xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
-                    OpenAdapt Community is free. Enterprise work begins with a paid
-                    qualification of one application, one environment, and one
-                    measurable business effect. The managed Cloud subscription is a
-                    separate self-service lane for approved workflows.
+                    Run OpenAdapt yourself, qualify a consequential enterprise
+                    workflow with our team, or subscribe to managed Cloud for an
+                    approved workflow.
                 </p>
 
-                <div className="mt-10 grid items-stretch gap-6 lg:grid-cols-3">
-                    <div className="flex h-full flex-col rounded-2xl border border-hairline bg-panel p-6">
-                        <p className="eyebrow">OpenAdapt Community</p>
-                        <p className="mt-2 font-display text-3xl font-semibold tracking-tight text-ink">
-                            Free
-                        </p>
-                        <p className="mt-3 text-sm leading-relaxed text-ink-2">
-                            MIT-licensed local runtime and qualification tools for
-                            self-directed use.
-                        </p>
-                        <FeatureList
-                            items={[
-                                'Local record, compile, qualify, run, and evidence',
-                                'Governed repair review and basic scheduling',
-                                'Community support',
-                                'No Cloud account required',
-                            ]}
-                        />
-                        <div className="mt-6 flex-grow" />
+                <div
+                    role="list"
+                    aria-label="Ways to start with OpenAdapt"
+                    className="mt-10 grid items-stretch gap-6 lg:grid-cols-3"
+                >
+                    <EntryCard
+                        id="community"
+                        eyebrow="Build it yourself"
+                        title="OpenAdapt Community"
+                        price="Free"
+                        description="MIT-licensed local runtime and qualification tools for self-directed use."
+                        features={[
+                            'Local record, compile, qualify, run, and evidence',
+                            'Governed repair review and basic scheduling',
+                            'Community support',
+                            'No Cloud account required',
+                        ]}
+                    >
                         <a
                             href="https://docs.openadapt.ai/get-started/"
                             className="btn-ghost-ink w-full text-center"
@@ -186,152 +231,186 @@ export default function Pricing({ hostedOffer = null }) {
                         <p className="mt-3 text-center font-mono text-xs text-ink-3">
                             pip install openadapt
                         </p>
-                    </div>
+                    </EntryCard>
 
-                    <div
+                    <EntryCard
                         id="pricing-enterprise"
-                        className="relative flex h-full flex-col rounded-2xl border-2 border-ink bg-panel p-6 shadow-[0_8px_32px_rgba(35,40,31,0.10)]"
+                        eyebrow="Recommended for enterprise"
+                        title="Workflow Qualification Sprint"
+                        price="From $15,000"
+                        priceDetail="ten-business-day target"
+                        description="Qualify one application, one environment, and one measurable business effect before scaling."
+                        features={[
+                            'Suitability decision and qualified prototype',
+                            'Identity and effect-verification contract',
+                            'Failure, exception, and deployment analysis',
+                            'ROI model and signed go/no-go report',
+                        ]}
+                        featured
                     >
-                        <span className="absolute -top-3 left-6 rounded-full bg-ink px-3 py-1 font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-ground">
-                            Recommended first step
-                        </span>
-                        <p className="eyebrow">Workflow Qualification Sprint</p>
-                        <p className="mt-2 font-display text-3xl font-semibold tracking-tight text-ink">
-                            From $15,000
-                        </p>
-                        <p className="mt-1 text-sm text-ink-3">
-                            Ten-business-day target for a bounded workflow
-                        </p>
-                        <FeatureList
-                            items={[
-                                'Suitability decision and qualified prototype',
-                                'Identity and effect-verification contract',
-                                'Failure, exception, and deployment analysis',
-                                'ROI model and signed go/no-go report',
-                            ]}
-                        />
                         <p className="mt-4 text-xs leading-relaxed text-ink-3">
                             Native, RDP, and Citrix qualifications are typically
-                            $25,000–$40,000. The sprint is paid even when the correct
-                            outcome is not to automate.
+                            $25,000–$40,000. The sprint is paid even when the
+                            correct outcome is not to automate.
                         </p>
-                        <div className="mt-6 flex-grow" />
-                        <Link href="/qualify" className="btn-ink w-full text-center">
+                        <Link
+                            href="/qualify"
+                            className="btn-ink mt-5 w-full text-center"
+                        >
                             Qualify one workflow
                         </Link>
-                    </div>
+                    </EntryCard>
 
-                    <div className="flex h-full flex-col rounded-2xl border border-hairline bg-panel p-6">
-                        <p className="eyebrow">Supervised Production Pilot</p>
-                        <p className="mt-2 font-display text-3xl font-semibold tracking-tight text-ink">
-                            $30,000–$60,000
-                        </p>
-                        <p className="mt-3 text-sm leading-relaxed text-ink-2">
-                            One workflow, one application, and one environment
-                            running representative cases under supervision or in
-                            shadow mode.
-                        </p>
-                        <FeatureList
-                            items={[
-                                'Representative real cases',
-                                'Measured VERIFIED, HALTED, and intervention rates',
-                                'Security and deployment review',
-                                'Production acceptance report',
-                            ]}
-                        />
-                        <div className="mt-6 flex-grow" />
-                        <Link href="/qualify" className="btn-ghost-ink w-full text-center">
-                            Scope a pilot
-                        </Link>
-                    </div>
-                </div>
-
-                <div className="mt-6 grid gap-6 md:grid-cols-2">
-                    <article className="rounded-2xl border border-hairline bg-panel p-6">
-                        <p className="eyebrow">Production</p>
-                        <h3 className="mt-2 font-display text-2xl font-semibold tracking-tight text-ink">
-                            $48,000–$120,000 annually
-                        </h3>
-                        <p className="mt-3 text-sm leading-relaxed text-ink-2">
-                            Priced by qualified workflow family, application and
-                            environment, runners, evidence requirements, support,
-                            and requalification obligations—not primarily by seat
-                            or run.
-                        </p>
-                    </article>
-                    <article className="rounded-2xl border border-hairline bg-panel p-6">
-                        <p className="eyebrow">OEM</p>
-                        <h3 className="mt-2 font-display text-2xl font-semibold tracking-tight text-ink">
-                            $75,000–$150,000 annual minimum
-                        </h3>
-                        <p className="mt-3 text-sm leading-relaxed text-ink-2">
-                            Embed the governed contract in your product:
-                            <span className="mt-2 block font-mono text-xs text-ink">
-                                execute(bundle, parameters) → VERIFIED | HALTED → evidence
+                    <EntryCard
+                        id="cloud-preview"
+                        eyebrow="Managed self-service"
+                        title="OpenAdapt Cloud"
+                        price={hostedOffer?.amount || LAUNCH_PRICE_DISPLAY}
+                        priceDetail={
+                            hostedOffer?.cadence || LAUNCH_PRICE_CADENCE
+                        }
+                        description="Run approved workflows with history, evidence, usage, and governed updates in one managed control plane."
+                        features={[
+                            'Managed execution, evidence, usage, and workflow updates',
+                            'Separate from enterprise qualification',
+                            'No production SLA or regulated deployment included',
+                            'Live subscription with secure Stripe checkout',
+                        ]}
+                    >
+                        <div className="mb-5 flex items-center gap-3">
+                            <span
+                                className="rounded-full border border-hairline bg-ground px-3 py-1 font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-ink-2"
+                                data-testid="hosted-status-label"
+                            >
+                                {hostedStatusLabel}
                             </span>
-                            Integration work is scoped separately.
-                        </p>
-                    </article>
-                </div>
-
-                <div className="mt-10 rounded-2xl border border-hairline bg-panel p-6 md:p-8">
-                    <div className="grid gap-8 lg:grid-cols-[1fr_0.8fr]">
-                        <div>
-                            <div className="flex flex-wrap items-center gap-3">
-                                <p className="eyebrow">OpenAdapt Cloud</p>
-                                <span
-                                    className="rounded-full border border-hairline bg-ground px-3 py-1 font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-ink-2"
-                                    data-testid="hosted-status-label"
-                                >
-                                    {hostedStatusLabel}
-                                </span>
-                            </div>
-                            <div className="mt-2 flex items-baseline gap-2">
-                                <span className="font-display text-3xl font-semibold tracking-tight text-ink">
-                                    {hostedOffer?.amount || LAUNCH_PRICE_DISPLAY}
-                                </span>
-                                <span className="text-sm text-ink-3">
-                                    {hostedOffer?.cadence || LAUNCH_PRICE_CADENCE}
-                                </span>
-                            </div>
                             {runCapLabel && (
-                                <p
-                                    className="mt-2 text-sm font-semibold text-ink"
+                                <span
+                                    className="text-xs font-medium text-ink-2"
                                     data-testid="hosted-run-cap"
                                 >
                                     {runCapLabel}
-                                </p>
+                                </span>
                             )}
-                            <p className="mt-3 max-w-2xl text-sm leading-relaxed text-ink-2">
-                                A separate self-service managed lane for approved
-                                workflows: run history, evidence, usage, and workflow
-                                updates in one control plane. It does not include an
-                                enterprise qualification sprint, production SLA, or
-                                regulated deployment.
-                            </p>
-                            <p className="mt-3 text-xs leading-relaxed text-ink-3">
-                                Approved sanitized artifacts may enter Cloud; sensitive
-                                live observations stay inside the declared execution
-                                boundary.{' '}
-                                <Link href="/security" className="text-accent underline">
-                                    Review the security boundary.
-                                </Link>
-                            </p>
                         </div>
-                        <div className="flex flex-col justify-center">
-                            <HostedCheckoutButton available={hostedOfferAvailable} />
-                            <p className="mt-3 text-center text-xs leading-relaxed text-ink-3">
-                                By subscribing, you agree to the{' '}
-                                <Link href="/terms-of-service" className="text-accent underline">
-                                    Terms of Service
-                                </Link>{' '}
-                                and{' '}
-                                <Link href="/privacy-policy" className="text-accent underline">
-                                    acknowledge the Privacy Notice
-                                </Link>
-                                .
+                        <HostedCheckoutButton
+                            available={hostedOfferAvailable}
+                        />
+                        <p className="mt-3 text-center text-xs leading-relaxed text-ink-3">
+                            By subscribing, you agree to the{' '}
+                            <Link
+                                href="/terms-of-service"
+                                className="text-accent underline"
+                            >
+                                Terms of Service
+                            </Link>{' '}
+                            and{' '}
+                            <Link
+                                href="/privacy-policy"
+                                className="text-accent underline"
+                            >
+                                acknowledge the Privacy Notice
+                            </Link>
+                            .
+                        </p>
+                        <p className="mt-3 text-xs leading-relaxed text-ink-3">
+                            Approved sanitized artifacts may enter Cloud;
+                            sensitive live observations stay inside the declared
+                            execution boundary.{' '}
+                            <Link
+                                href="/security"
+                                className="text-accent underline"
+                            >
+                                Review the security boundary.
+                            </Link>
+                        </p>
+                    </EntryCard>
+                </div>
+
+                <div
+                    aria-labelledby="enterprise-path-title"
+                    className="mt-12 rounded-2xl border border-hairline bg-panel p-6 md:p-8"
+                >
+                    <p className="eyebrow">After a successful qualification</p>
+                    <h2
+                        id="enterprise-path-title"
+                        className="mt-2 font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl"
+                    >
+                        Move from evidence to production.
+                    </h2>
+                    <p className="mt-3 max-w-3xl text-sm leading-relaxed text-ink-2">
+                        A sprint ends with a go/no-go decision. When the
+                        workflow qualifies, the next two scopes take it through
+                        representative cases and into an annual production
+                        deployment.
+                    </p>
+
+                    <div className="mt-8 grid gap-8 lg:grid-cols-[1.45fr_0.75fr]">
+                        <ol className="grid gap-4 md:grid-cols-2">
+                            <li className="rounded-xl border border-hairline bg-ground p-5">
+                                <p className="font-mono text-xs font-medium text-accent">
+                                    1 · SUPERVISED PRODUCTION PILOT
+                                </p>
+                                <p className="mt-2 font-display text-2xl font-semibold tracking-tight text-ink">
+                                    $30,000–$60,000
+                                </p>
+                                <p className="mt-3 text-sm leading-relaxed text-ink-2">
+                                    One workflow, one application, and one
+                                    environment running representative cases
+                                    under supervision or in shadow mode.
+                                </p>
+                                <p className="mt-3 text-xs leading-relaxed text-ink-3">
+                                    Includes measured VERIFIED, HALTED, and
+                                    intervention rates, security and deployment
+                                    review, and a production acceptance report.
+                                </p>
+                            </li>
+                            <li className="rounded-xl border border-hairline bg-ground p-5">
+                                <p className="font-mono text-xs font-medium text-accent">
+                                    2 · PRODUCTION
+                                </p>
+                                <p className="mt-2 font-display text-2xl font-semibold tracking-tight text-ink">
+                                    $48,000–$120,000 annually
+                                </p>
+                                <p className="mt-3 text-sm leading-relaxed text-ink-2">
+                                    Priced by qualified workflow family,
+                                    application and environment, runners,
+                                    evidence requirements, support, and
+                                    requalification obligations.
+                                </p>
+                                <p className="mt-3 text-xs leading-relaxed text-ink-3">
+                                    Pricing is based on the operating scope—not
+                                    primarily by seat or run.
+                                </p>
+                            </li>
+                        </ol>
+
+                        <aside className="border-t border-hairline pt-6 lg:border-l lg:border-t-0 lg:pl-8 lg:pt-0">
+                            <p className="eyebrow">Embedding OpenAdapt?</p>
+                            <h3 className="mt-2 font-display text-xl font-semibold tracking-tight text-ink">
+                                OEM
+                            </h3>
+                            <p className="mt-2 font-display text-2xl font-semibold tracking-tight text-ink">
+                                $75,000–$150,000 annual minimum
                             </p>
-                        </div>
+                            <p className="mt-3 text-sm leading-relaxed text-ink-2">
+                                Embed the governed contract in your product.
+                                Integration work is scoped separately.
+                            </p>
+                            <code className="mt-4 block overflow-x-auto rounded-lg bg-inset px-4 py-3 text-xs leading-relaxed text-inset-text">
+                                execute(bundle, parameters)
+                                <br />→ VERIFIED | HALTED
+                                <br />→ evidence
+                            </code>
+                        </aside>
+                    </div>
+                    <div className="mt-7">
+                        <Link
+                            href="/qualify"
+                            className="btn-ghost-ink inline-block"
+                        >
+                            Scope the enterprise path
+                        </Link>
                     </div>
                 </div>
 
@@ -339,8 +418,8 @@ export default function Pricing({ hostedOffer = null }) {
                     {hostedOfferAvailable
                         ? 'The Cloud subscription price comes directly from Stripe and is confirmed again at checkout.'
                         : 'Cloud offer details are loaded from the live billing contract.'}{' '}
-                    Enterprise scope, support, security, and continuity terms are
-                    documented in the applicable order form.
+                    Enterprise scope, support, security, and continuity terms
+                    are documented in the applicable order form.
                 </p>
             </div>
         </section>

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -26,14 +26,12 @@ describe('canonical booking destination', () => {
         assertCanonicalBooking()
     })
 
-    it('connects the qualification funnel to the canonical booking path', () => {
+    it('publishes the structured qualification entry point', () => {
         cy.visit('/qualify')
         cy.get('form[name="workflow-qualification"]').should('be.visible')
         cy.contains('Bring one workflow. Leave with a go/no-go answer.').should(
             'be.visible'
         )
-        cy.visit('/book')
-        assertCanonicalBooking()
     })
 })
 
@@ -433,7 +431,9 @@ describe('public product truth', () => {
         cy.get('#side-by-side [role="region"]')
             .should('be.visible')
             .and('have.attr', 'tabindex', '0')
-        cy.contains('Qualify one workflow').scrollIntoView().should('be.visible')
+        cy.contains('Qualify one workflow')
+            .scrollIntoView()
+            .should('be.visible')
         cy.contains('Try locally').should('be.visible')
     })
 
@@ -447,7 +447,9 @@ describe('public product truth', () => {
 
         cy.viewport(375, 812)
         cy.visit('/')
-        cy.get('[data-testid="customer-case-study"]').scrollIntoView().should('be.visible')
+        cy.get('[data-testid="customer-case-study"]')
+            .scrollIntoView()
+            .should('be.visible')
         cy.document().then((document) => {
             expect(document.documentElement.scrollWidth).to.be.at.most(375)
         })
@@ -461,7 +463,10 @@ describe('public product truth', () => {
             .first()
             .scrollIntoView()
             .should('be.visible')
-        cy.get('a[href="/safety"]').first().scrollIntoView().should('be.visible')
+        cy.get('a[href="/safety"]')
+            .first()
+            .scrollIntoView()
+            .should('be.visible')
         cy.document().then((document) => {
             expect(document.documentElement.scrollWidth).to.be.at.most(375)
         })
@@ -553,8 +558,7 @@ describe('public product truth', () => {
             const inScrollContainer = (el) => {
                 let node = el.parentElement
                 while (node) {
-                    const overflowX =
-                        win.getComputedStyle(node).overflowX
+                    const overflowX = win.getComputedStyle(node).overflowX
                     if (overflowX === 'auto' || overflowX === 'scroll') {
                         return true
                     }
@@ -591,6 +595,38 @@ describe('public product truth', () => {
                 expect(response.status).to.equal(503)
                 expect(response.body.error).to.equal('checkout_not_configured')
             }
+        })
+    })
+
+    it('presents three entry paths and keeps the Cloud deep link stable', () => {
+        cy.visit('/pricing#cloud-preview')
+        cy.location('hash').should('equal', '#cloud-preview')
+
+        cy.get('[role="list"][aria-label="Ways to start with OpenAdapt"]')
+            .find('[role="listitem"]')
+            .should('have.length', 3)
+
+        cy.get('#cloud-preview')
+            .should('be.visible')
+            .within(() => {
+                cy.contains('OpenAdapt Cloud').should('be.visible')
+                cy.get('[data-testid="hosted-run-cap"]').should('be.visible')
+                cy.get(
+                    '[data-testid="hosted-checkout"], [data-testid="hosted-contact"]'
+                ).should('have.length', 1)
+            })
+
+        cy.get('[aria-labelledby="enterprise-path-title"]').within(() => {
+            cy.contains(/supervised production pilot/i).should('be.visible')
+            cy.contains(/production/i).should('be.visible')
+            cy.contains(/OEM/i).should('be.visible')
+        })
+
+        cy.viewport(375, 812)
+        cy.visit('/pricing#cloud-preview')
+        cy.get('#cloud-preview').scrollIntoView().should('be.visible')
+        cy.document().then((document) => {
+            expect(document.documentElement.scrollWidth).to.be.at.most(375)
         })
     })
 


### PR DESCRIPTION
## What changed

- presents Community, Workflow Qualification, and managed Cloud as the three clear ways to start
- moves Supervised Pilot → Production into one enterprise progression after qualification
- presents OEM as the alternate embedding path instead of another equal-weight storefront card
- preserves every published price, scope term, legal acknowledgment, the stable `#cloud-preview` deep link, and the live Stripe checkout
- adds one browser-level contract for the three-path hierarchy, deep link, responsive width, and checkout/contact surface

## Why

The prior page gave six commercial stages nearly equal visual weight, making the first decision harder than it needed to be. The new hierarchy separates entry choices from the enterprise expansion sequence without removing or weakening any offer.

## Validation

- `npm test` — 133/133 passed
- `npm run build` — passed
- `npx cypress run --spec cypress/e2e/basic.cy.js --browser electron` — 17/17 passed
- `git diff --check` — passed
