### PR TITLE
fix: describe RVU audit outputs accurately

### DIFF
--- a/data/customerCaseStudies.js
+++ b/data/customerCaseStudies.js
@@ -9,14 +9,14 @@ export const ABRICH_RVU_AUDIT_CASE = {
     },
     title: 'Recovering missed billables with automated RVU audits',
     summary:
-        'OpenAdapt automated the repetitive EMR navigation, clicking, and data entry behind Dr. Abrich’s monthly RVU audits.',
+        'OpenAdapt automated the repetitive EMR navigation and programmatic reconciliation behind Dr. Abrich’s monthly RVU audits, then produced a review workbook and a ready-to-send recovery email.',
     challenge:
         'RVU audits took several hours every month and still did not consistently surface every missed billable.',
     workflow: [
-        'Review the month’s procedures and expected RVUs.',
-        'Navigate the relevant records in the EMR.',
-        'Enter and reconcile audit information through the existing interface.',
-        'Surface missed billables for correction and follow-through.',
+        'Load the month’s RVU report spreadsheets.',
+        'Navigate the relevant EMR records and collect the clinical-note evidence needed for the audit.',
+        'Programmatically compare documented procedures with the RVUs that were credited.',
+        'Write the findings to an analysis spreadsheet and generate a copy-ready recovery email.',
     ],
     results: [
         {
@@ -28,13 +28,13 @@ export const ABRICH_RVU_AUDIT_CASE = {
             label: 'of manual audit work saved each month',
         },
         {
-            value: 'EMR-native',
-            label: 'navigation, clicking, and data entry automated',
+            value: 'Review-ready',
+            label: 'analysis workbook and recovery email generated',
         },
     ],
     result:
         'The automated audit caught billables that manual review did not consistently find, recovering approximately $75,000 per year while saving several hours of physician time each month.',
-    surface: 'Electronic medical record',
+    surface: 'Electronic medical record and spreadsheets',
     workflowType: 'Monthly physician RVU audit',
     industry: 'Healthcare',
 }

--- a/pages/customers/rvu-audit-heart-care.js
+++ b/pages/customers/rvu-audit-heart-care.js
@@ -114,11 +114,10 @@ export default function RvuAuditHeartCareCaseStudy() {
                                     {customerCase.challenge}
                                 </p>
                                 <p className="mt-4 text-base leading-relaxed text-ink-2">
-                                    The job required moving through the existing
-                                    EMR, reconciling procedure and RVU
-                                    information, and entering the audit results
-                                    through the same interface used by the
-                                    clinical team.
+                                    The job required collecting evidence from
+                                    the existing EMR, comparing it with monthly
+                                    RVU spreadsheets, and preparing the findings
+                                    for review and recovery.
                                 </p>
                             </div>
 
@@ -147,7 +146,7 @@ export default function RvuAuditHeartCareCaseStudy() {
                             <p className="eyebrow">The result</p>
                             <h2 className="mt-2 max-w-3xl font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl">
                                 More complete audits without spending physician
-                                hours clicking through the EMR
+                                hours collecting and reconciling the data by hand
                             </h2>
                             <p className="mt-5 max-w-3xl text-base leading-relaxed text-ink-2 md:text-lg">
                                 {customerCase.result}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -20,7 +20,7 @@
 - [Privacy Module](https://github.com/OpenAdaptAI/openadapt-privacy): Open-source PII/PHI scrubbing
 
 ## Use Cases
-- [Customer Case Study — RVU Audits](https://openadapt.ai/customers/rvu-audit-heart-care): How Dr. Victor Abrich used OpenAdapt to automate monthly EMR-based RVU audits, save several hours of manual work each month, and recover approximately $75,000 per year in missed billables
+- [Customer Case Study — RVU Audits](https://openadapt.ai/customers/rvu-audit-heart-care): How Dr. Victor Abrich used OpenAdapt to collect audit evidence from an EMR, reconcile it against RVU spreadsheets, generate review-ready outputs, save several hours of manual work each month, and recover approximately $75,000 per year in missed billables
 - [Healthcare Execution Infrastructure](https://openadapt.ai/solutions/healthcare): Governed last-mile execution for RCM vendors, healthcare BPOs, automation teams, and vertical-software companies that already have structured input and business logic
 - [Lending Operations](https://openadapt.ai/solutions/lending): A demonstrated Frappe Lending workflow compiled into model-free replay and checked against independent REST and SQL effect oracles
 - [Insurance Claims Execution](https://openadapt.ai/solutions/insurance): A demonstrated openIMIS claims-intake workflow compiled into model-free replay and checked against a direct SQL claim-row oracle


### PR DESCRIPTION
## What changed

- describe the RVU audit as EMR evidence collection followed by programmatic spreadsheet reconciliation
- name the actual outputs: an analysis workbook and a copy-ready recovery email
- remove the inaccurate claim that audit information was entered through the EMR
- keep machine-readable discovery copy aligned with the customer page

## Why

The previous copy conflated the EMR navigation stage with the programmatic audit and output stage. The implementation loaded RVU report spreadsheets, collected clinical-note evidence through the existing EMR, reconciled documented procedures against credited RVUs, wrote an analysis spreadsheet, and generated recovery-email text for review and copying.

## Validation

- 133/133 web unit tests
- production Next.js build
- historical implementation review of the spreadsheet writer and recovery-email generator
