### PR TITLE
Restore the free local open-source homepage path

### DIFF
--- a/components/CommercialOffer.js
+++ b/components/CommercialOffer.js
@@ -19,7 +19,33 @@ export default function CommercialOffer({ hostedOffer }) {
                 <h2 className="mx-auto mt-2 max-w-3xl text-center font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl">
                     Qualify the workflow before scaling the deployment
                 </h2>
-                <div className="mt-9 grid gap-6 md:grid-cols-[1.25fr_0.75fr]">
+                <div className="mt-8 flex flex-col gap-5 rounded-2xl border border-hairline bg-panel p-5 sm:flex-row sm:items-center sm:justify-between md:px-7">
+                    <div>
+                        <p className="eyebrow">OpenAdapt Community</p>
+                        <p className="mt-2 text-sm leading-relaxed text-ink-2">
+                            Free and MIT licensed. Record, compile, qualify, and
+                            run locally with no account or Cloud service.
+                        </p>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-4 text-sm">
+                        <a
+                            href="https://docs.openadapt.ai/get-started/"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="btn-ghost-ink inline-block"
+                        >
+                            Start locally
+                        </a>
+                        <a
+                            href="https://github.com/OpenAdaptAI/OpenAdapt"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            View source
+                        </a>
+                    </div>
+                </div>
+                <div className="mt-6 grid gap-6 md:grid-cols-[1.25fr_0.75fr]">
                     <article className="rounded-2xl border-2 border-ink bg-panel p-6 md:p-8">
                         <p className="eyebrow">Workflow Qualification Sprint</p>
                         <h3 className="mt-2 font-display text-3xl font-semibold tracking-tight text-ink">

--- a/components/MastHead.js
+++ b/components/MastHead.js
@@ -22,7 +22,7 @@ export default function Home({ githubStats }) {
                             </div>
                             <div className="mb-4 flex flex-wrap items-center justify-center gap-3">
                                 <span className={styles.heroPill}>
-                                    LOCAL-FIRST · MIT OPEN SOURCE
+                                    FREE TO RUN LOCALLY · MIT OPEN SOURCE
                                 </span>
                                 {githubStats && githubStats.stars > 0 && (
                                     <a
@@ -72,26 +72,29 @@ export default function Home({ githubStats }) {
                                     >
                                         Qualify one workflow
                                     </Link>
-                                    <Link
-                                        className="btn-ghost-ink"
-                                        href="#verified-execution"
-                                        onClick={() =>
-                                            track(EVENTS.HERO_CTA_CLICK, {
-                                                cta: 'see_verified_execution',
-                                            })
-                                        }
-                                    >
-                                        See verified execution
-                                    </Link>
-                                </div>
-                                <p className="mb-8 text-sm text-ink-3">
                                     <a
+                                        className="btn-ghost-ink"
                                         href="https://docs.openadapt.ai/get-started/"
                                         target="_blank"
                                         rel="noopener noreferrer"
+                                        data-testid="local-quickstart-cta"
+                                        onClick={() =>
+                                            track(EVENTS.HERO_CTA_CLICK, {
+                                                cta: 'run_locally_free',
+                                            })
+                                        }
                                     >
-                                        Run the open-source demo
+                                        Run locally for free
                                     </a>
+                                </div>
+                                <p className="mb-8 text-sm leading-relaxed text-ink-3">
+                                    <code className="rounded border border-hairline bg-panel px-2 py-1 text-ink">
+                                        pip install openadapt
+                                    </code>
+                                    <span aria-hidden="true"> · </span>
+                                    MIT licensed
+                                    <span aria-hidden="true"> · </span>
+                                    No account or Cloud required
                                 </p>
                             </div>
                             <div className="flex flex-col align-center justify-center px-4 min-w-0 max-w-full overflow-hidden">

--- a/components/MastHead.module.css
+++ b/components/MastHead.module.css
@@ -22,10 +22,9 @@
     color: var(--ink-3);
 }
 
-/* Primary hero CTA: the elevated OpenAdapt Cloud action. A single solid
-   accent pill sized to match the ghost secondaries (Evaluate a workflow / Try
-   locally) so the row reads as one primary plus a consistent secondary set,
-   not three competing styles. */
+/* Primary enterprise CTA. The adjacent ghost action is the equally direct
+   local/open-source path, while the install command below carries the
+   no-account trust contract without adding a third competing button. */
 .heroCloud {
     display: inline-flex;
     align-items: center;

--- a/cypress/e2e/public-surface-coherence.cy.js
+++ b/cypress/e2e/public-surface-coherence.cy.js
@@ -31,10 +31,13 @@ describe('public surface coherence', () => {
         cy.contains('a', 'Qualify one workflow')
             .should('be.visible')
             .and('have.attr', 'href', '/qualify')
-        cy.contains('a', 'Run the open-source demo')
+        cy.get('[data-testid="local-quickstart-cta"]')
             .should('be.visible')
-            .and('have.attr', 'href')
-            .and('include', 'docs.openadapt.ai')
+            .and(
+                'have.attr',
+                'href',
+                'https://docs.openadapt.ai/get-started/'
+            )
     })
 
     it('updates homepage hero and footer from one repository-stats response', () => {

--- a/pages/index.js
+++ b/pages/index.js
@@ -143,7 +143,7 @@ export default function Home({ githubStats, hostedOffer }) {
                 />
             </Head>
             <MastHead githubStats={currentGithubStats} />
-            <div id="verified-execution">
+            <div id="customer-result">
                 <Reveal>
                     <CustomerCaseStudy />
                 </Reveal>


### PR DESCRIPTION
## Outcome

Restores the free local open-source path as a first-class homepage entry point
without undoing the buyer-oriented commercial redesign.

## Changes

- Keeps `Qualify one workflow` as the primary enterprise CTA.
- Replaces the misleading `See verified execution` customer-case link with
  `Run locally for free` to the canonical quickstart.
- Shows `pip install openadapt`, MIT licensing, and the no-account/no-Cloud
  contract directly below the hero actions.
- Renames the customer-result anchor so the historical RVU outcome is not
  presented as current-runtime verified execution.
- Adds a compact OpenAdapt Community/free lane above the paid commercial
  offers, with direct local-start and flagship-source links.

## Validation

- 133/133 unit tests passed.
- Next.js 15.5.20 production build passed.
- Focused Cypress public-surface contract passed 4/4.
- Headless visual review passed at desktop 1440x1000 and mobile 390x844.

The Cypress change asserts the durable CTA destination rather than layout or
marketing prose.
