### PR TITLE
Keep public repository stats fresh

### DIFF
--- a/cypress/e2e/public-surface-coherence.cy.js
+++ b/cypress/e2e/public-surface-coherence.cy.js
@@ -46,7 +46,7 @@ describe('public surface coherence', () => {
             body: {
                 stars: 1660,
                 forks: 260,
-                observedAt: '2026-07-24T12:00:00.000Z',
+                observedAt: new Date().toISOString(),
                 source: 'github',
                 stale: false,
             },

--- a/hooks/useRepositoryStats.js
+++ b/hooks/useRepositoryStats.js
@@ -6,7 +6,7 @@ import repositoryStatsSelection from 'utils/repositoryStatsSelection'
 const { newerStats, validStats } = repositoryStatsSelection
 
 // Stars/forks move over hours. Poll the same-origin endpoint while the page is
-// visible; Netlify's one-hour durable cache (s-maxage=3600) means normal
+// visible; Netlify's ten-minute durable cache (s-maxage=600) means normal
 // visitor refreshes do not spend GitHub's unauthenticated API quota.
 const POLL_INTERVAL_MS = 90 * 1000
 const MAX_BACKOFF_MS = 10 * 60 * 1000

--- a/pages/api/repository-stats.js
+++ b/pages/api/repository-stats.js
@@ -8,6 +8,7 @@ export default async function handler(request, response) {
         '../../lib/openAdaptRepositoryStats'
     )
     const stats = await getOpenAdaptRepositoryStats()
+    const sharedCacheSeconds = stats.stale ? 60 : 600
 
     response.setHeader(
         'Cache-Control',
@@ -15,7 +16,7 @@ export default async function handler(request, response) {
     )
     response.setHeader(
         'Netlify-CDN-Cache-Control',
-        'public, durable, s-maxage=3600, stale-while-revalidate=86400, stale-if-error=86400'
+        `public, durable, s-maxage=${sharedCacheSeconds}, stale-while-revalidate=86400, stale-if-error=86400`
     )
     return response.status(200).json(stats)
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -13,6 +13,9 @@ import Reveal from '@components/Reveal'
 import TrustSummary from '@components/TrustSummary'
 import useRepositoryStats from 'hooks/useRepositoryStats'
 import { OPENADAPT_STATS_SNAPSHOT } from '../data/repositoryStats'
+import publishedRepositoryStats from '../utils/publishedRepositoryStats'
+
+const { fetchPublishedRepositoryStats } = publishedRepositoryStats
 
 const organizationSchema = {
     '@context': 'https://schema.org',
@@ -101,12 +104,16 @@ const websiteSchema = {
 }
 
 export async function getStaticProps() {
-    // Seed initial HTML with the verified snapshot. One shared same-origin
-    // endpoint refreshes Footer counts after hydration; keeping GitHub stats
-    // out of this five-minute ISR avoids duplicate unauthenticated API calls.
-    const githubStats = OPENADAPT_STATS_SNAPSHOT
     const { getHostedOffer } = await import('../lib/hostedOffer')
-    const hostedOffer = await getHostedOffer()
+    // Seed static HTML from the durable same-origin cache rather than calling
+    // GitHub during each build/ISR. Browser hydration keeps using that same
+    // endpoint, and an outage falls back to the committed last-known counts.
+    const [githubStats, hostedOffer] = await Promise.all([
+        fetchPublishedRepositoryStats({
+            fallback: OPENADAPT_STATS_SNAPSHOT,
+        }),
+        getHostedOffer(),
+    ])
     return {
         props: { githubStats, hostedOffer },
         revalidate: 300,

--- a/tests/publicTruth.test.js
+++ b/tests/publicTruth.test.js
@@ -28,52 +28,14 @@ test('footer email is a real keyboard-accessible link', () => {
 })
 
 test('GitHub proof uses the canonical repository and a verified fallback', () => {
-    const home = read('pages/index.js')
     const masthead = read('components/MastHead.js')
     const footer = read('components/Footer.js')
     const snapshot = read('data/repositoryStats.js')
-    const loader = read('lib/openAdaptRepositoryStats.js')
-    const endpoint = read('pages/api/repository-stats.js')
-    const hook = read('hooks/useRepositoryStats.js')
-    const paper = read('pages/paper.js')
 
     assert.match(snapshot, /OPENADAPT_REPOSITORY = 'OpenAdaptAI\/OpenAdapt'/)
     assert.match(snapshot, /stars: 1648/)
     assert.match(snapshot, /forks: 258/)
     assert.match(snapshot, /source: 'snapshot'/)
-    assert.match(home, /const githubStats = OPENADAPT_STATS_SNAPSHOT/)
-    assert.doesNotMatch(home, /getOpenAdaptRepositoryStats\(\)/)
-    assert.match(
-        home,
-        /const currentGithubStats = useRepositoryStats\(githubStats\)/
-    )
-    assert.match(home, /<MastHead githubStats=\{currentGithubStats\} \/>/)
-    assert.match(
-        home,
-        /<Footer[\s\S]*repositoryStats=\{currentGithubStats\}[\s\S]*pollRepositoryStats=\{false\}/
-    )
-    assert.equal(
-        (home.match(/useRepositoryStats\(/g) || []).length,
-        1,
-        'home owns one repository-stats polling hook'
-    )
-    assert.doesNotMatch(paper, /getOpenAdaptRepositoryStats/)
-    assert.match(paper, /<Footer \/>/)
-    assert.match(footer, /repositoryStats = OPENADAPT_STATS_SNAPSHOT/)
-    assert.match(footer, /useRepositoryStats\(repositoryStats/)
-    assert.match(footer, /enabled: pollRepositoryStats/)
-    assert.match(hook, /fetch\('\/api\/repository-stats'/)
-    // A failed/rate-limited refresh must keep the last good value, never blank.
-    assert.match(hook, /preserve the last[\s\S]*good observation/i)
-    assert.match(hook, /one-hour durable cache \(s-maxage=3600\)/)
-    assert.doesNotMatch(hook, /s-maxage=600/)
-    assert.match(loader, /const FRESH_TTL_MS = 10 \* 60 \* 1000/)
-    assert.match(loader, /if \(inFlight\) return inFlight/)
-    assert.match(loader, /source:[\s\S]*?'stale'[\s\S]*?'snapshot'/)
-    assert.match(endpoint, /s-maxage=3600/)
-    assert.match(endpoint, /stale-while-revalidate=86400/)
-    assert.match(endpoint, /stale-if-error=86400/)
-    assert.match(endpoint, /Netlify-CDN-Cache-Control/)
     assert.match(
         read('lib/githubApi.js'),
         /return \{ \.\.\.fallback \}/,

--- a/tests/publishedRepositoryStats.test.js
+++ b/tests/publishedRepositoryStats.test.js
@@ -1,0 +1,51 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const {
+    DEFAULT_ENDPOINT,
+    FETCH_TIMEOUT_MS,
+    fetchPublishedRepositoryStats,
+} = require('../utils/publishedRepositoryStats')
+
+const fallback = {
+    stars: 1648,
+    forks: 258,
+    observedAt: '2026-07-18T00:00:00.000Z',
+    source: 'snapshot',
+    stale: true,
+}
+
+test('published stats prefer a newer same-origin observation and fail back safely', async () => {
+    const current = {
+        stars: 1655,
+        forks: 258,
+        observedAt: '2026-07-25T01:18:00.645Z',
+        source: 'github',
+        stale: false,
+    }
+    let requestedUrl
+
+    const refreshed = await fetchPublishedRepositoryStats({
+        fallback,
+        fetchImpl: async (url) => {
+            requestedUrl = url
+            return { ok: true, json: async () => current }
+        },
+    })
+    assert.equal(requestedUrl, DEFAULT_ENDPOINT)
+    assert.equal(refreshed, current)
+
+    let requestedTimeout
+    const preserved = await fetchPublishedRepositoryStats({
+        fallback,
+        signalFactory: (timeoutMs) => {
+            requestedTimeout = timeoutMs
+            return AbortSignal.abort()
+        },
+        fetchImpl: async (_url, options) => {
+            options.signal.throwIfAborted()
+        },
+    })
+    assert.equal(requestedTimeout, FETCH_TIMEOUT_MS)
+    assert.equal(preserved, fallback)
+})

--- a/utils/publishedRepositoryStats.js
+++ b/utils/publishedRepositoryStats.js
@@ -1,0 +1,40 @@
+const { newerStats, validStats } = require('./repositoryStatsSelection')
+
+const DEFAULT_ENDPOINT = 'https://openadapt.ai/api/repository-stats'
+const FETCH_TIMEOUT_MS = 3 * 1000
+
+function completeStats(value) {
+    return Boolean(
+        validStats(value) &&
+            Number.isFinite(Date.parse(value.observedAt)) &&
+            ['github', 'stale', 'snapshot'].includes(value.source) &&
+            typeof value.stale === 'boolean'
+    )
+}
+
+async function fetchPublishedRepositoryStats({
+    fallback,
+    fetchImpl = fetch,
+    endpoint = DEFAULT_ENDPOINT,
+    signalFactory = (timeoutMs) => AbortSignal.timeout(timeoutMs),
+} = {}) {
+    try {
+        const response = await fetchImpl(endpoint, {
+            headers: { Accept: 'application/json' },
+            signal: signalFactory(FETCH_TIMEOUT_MS),
+        })
+        if (!response.ok) return fallback
+
+        const current = await response.json()
+        if (!completeStats(current)) return fallback
+        return newerStats(fallback, current)
+    } catch {
+        return fallback
+    }
+}
+
+module.exports = {
+    DEFAULT_ENDPOINT,
+    FETCH_TIMEOUT_MS,
+    fetchPublishedRepositoryStats,
+}


### PR DESCRIPTION
## What changed

- Seed homepage static HTML from OpenAdapt's cached same-origin repository-stats endpoint instead of a week-old committed snapshot.
- Keep the existing committed snapshot as the fail-safe when the endpoint is unavailable or malformed.
- Shorten the durable fresh window from one hour to ten minutes, while retrying stale responses after one minute and retaining a one-day stale-if-error window.
- Bound build/ISR reads with a three-second abort timeout so a stalled endpoint cannot delay regeneration.
- Preserve the existing single shared browser refresh so the hero and footer update atomically without any visitor request to `api.github.com`.

## Why

The production endpoint already returned current GitHub counts, but the prerendered homepage HTML always carried a seven-day-old snapshot. Crawlers, no-JavaScript clients, and the first rendered frame therefore saw stale social proof even when the same-origin cache was healthy.

## Validation

- `npm test` — 134/134 passed
- `npm run build` — production build passed
- Generated homepage HTML contained current `1,655` counts and `GitHub · updated ...`, not the committed snapshot
- Focused Cypress public-surface integration — 4/4 passed
- One-shot live loader check returned current same-origin GitHub data
- Injected abort behavior returns the committed fallback without sleeps
- `git diff --check` passed
