### PR TITLE
Harden repository stats prerender

### DIFF
--- a/tests/publishedRepositoryStats.test.js
+++ b/tests/publishedRepositoryStats.test.js
@@ -2,7 +2,7 @@ const assert = require('node:assert/strict')
 const test = require('node:test')
 
 const {
-    DEFAULT_ENDPOINT,
+    DEFAULT_ENDPOINTS,
     FETCH_TIMEOUT_MS,
     fetchPublishedRepositoryStats,
 } = require('../utils/publishedRepositoryStats')
@@ -32,20 +32,40 @@ test('published stats prefer a newer same-origin observation and fail back safel
             return { ok: true, json: async () => current }
         },
     })
-    assert.equal(requestedUrl, DEFAULT_ENDPOINT)
+    assert.equal(requestedUrl, DEFAULT_ENDPOINTS[0])
     assert.equal(refreshed, current)
 
-    let requestedTimeout
+    const attemptedUrls = []
+    const recovered = await fetchPublishedRepositoryStats({
+        fallback,
+        fetchImpl: async (url, options) => {
+            attemptedUrls.push(url)
+            if (attemptedUrls.length === 1) options.signal.throwIfAborted()
+            return { ok: true, json: async () => current }
+        },
+        signalFactory: () =>
+            attemptedUrls.length === 0
+                ? AbortSignal.abort()
+                : new AbortController().signal,
+    })
+    assert.deepEqual(attemptedUrls, DEFAULT_ENDPOINTS)
+    assert.equal(recovered, current)
+
+    const requestedTimeouts = []
+    let warnings = 0
     const preserved = await fetchPublishedRepositoryStats({
         fallback,
         signalFactory: (timeoutMs) => {
-            requestedTimeout = timeoutMs
+            requestedTimeouts.push(timeoutMs)
             return AbortSignal.abort()
         },
-        fetchImpl: async (_url, options) => {
-            options.signal.throwIfAborted()
-        },
+        fetchImpl: async (_url, options) => options.signal.throwIfAborted(),
+        warn: () => warnings++,
     })
-    assert.equal(requestedTimeout, FETCH_TIMEOUT_MS)
+    assert.deepEqual(requestedTimeouts, [
+        FETCH_TIMEOUT_MS,
+        FETCH_TIMEOUT_MS,
+    ])
     assert.equal(preserved, fallback)
+    assert.equal(warnings, 1)
 })

--- a/utils/publishedRepositoryStats.js
+++ b/utils/publishedRepositoryStats.js
@@ -1,7 +1,10 @@
 const { newerStats, validStats } = require('./repositoryStatsSelection')
 
-const DEFAULT_ENDPOINT = 'https://openadapt.ai/api/repository-stats'
-const FETCH_TIMEOUT_MS = 3 * 1000
+const DEFAULT_ENDPOINTS = [
+    'https://openadapt.ai/api/repository-stats',
+    'https://main--cosmic-klepon-3c693c.netlify.app/api/repository-stats',
+]
+const FETCH_TIMEOUT_MS = 5 * 1000
 
 function completeStats(value) {
     return Boolean(
@@ -15,26 +18,37 @@ function completeStats(value) {
 async function fetchPublishedRepositoryStats({
     fallback,
     fetchImpl = fetch,
-    endpoint = DEFAULT_ENDPOINT,
+    endpoints = DEFAULT_ENDPOINTS,
     signalFactory = (timeoutMs) => AbortSignal.timeout(timeoutMs),
+    warn = console.warn,
 } = {}) {
-    try {
-        const response = await fetchImpl(endpoint, {
-            headers: { Accept: 'application/json' },
-            signal: signalFactory(FETCH_TIMEOUT_MS),
-        })
-        if (!response.ok) return fallback
+    let best = fallback
 
-        const current = await response.json()
-        if (!completeStats(current)) return fallback
-        return newerStats(fallback, current)
-    } catch {
-        return fallback
+    for (const endpoint of endpoints) {
+        try {
+            const response = await fetchImpl(endpoint, {
+                headers: { Accept: 'application/json' },
+                signal: signalFactory(FETCH_TIMEOUT_MS),
+            })
+            if (!response.ok) continue
+
+            const current = await response.json()
+            if (!completeStats(current)) continue
+            best = newerStats(best, current)
+            if (current.source === 'github' && !current.stale) return best
+        } catch {
+            // Try the next first-party cache. A final miss remains fail-safe.
+        }
     }
+
+    warn(
+        '[repository-stats] fresh first-party cache unavailable; using last-known counts'
+    )
+    return best
 }
 
 module.exports = {
-    DEFAULT_ENDPOINT,
+    DEFAULT_ENDPOINTS,
     FETCH_TIMEOUT_MS,
     fetchPublishedRepositoryStats,
 }


### PR DESCRIPTION
## What changed

- Replace the single three-second prerender cache read with two independently cached first-party endpoints.
- Give each attempt a bounded five-second timeout.
- Continue past failed, malformed, stale, or snapshot responses when another first-party cache is available.
- Preserve the newest valid last-known observation when neither cache can provide a fresh GitHub result.
- Emit one payload-free build diagnostic only when both bounded attempts miss.

Visitor browsers still call only `/api/repository-stats`; neither GitHub nor the Netlify fallback is added to client-side polling.

## Root cause

The first production deployment of #281 initially prerendered the committed snapshot even though its preview and runtime endpoint were current. The immutable deploy later recovered through ISR. The previous helper had exactly one silent fallback path: a single three-second request that returned non-current data, failed, or timed out. Because the error was swallowed, Netlify's build log could not distinguish those cases.

Production currently serves current prerendered data, so the transient cannot be replayed after the fact. The canonical and stable Netlify first-party endpoints expose independent cache observations, making them a small, bounded hedge against the one-shot build-context failure.

## Validation

- Focused repository-stats tests: 9/9 passed
- Full test suite: 134/134 passed
- Next 15.5.20 production build passed
- Generated homepage HTML contains current `1,655` hero/footer counts and `GitHub · updated ...`
- Explicit failover run with an unavailable primary returned current data from the secondary first-party cache
- `git diff --check` passed
