### PR TITLE
Expose three homepage entry paths

### DIFF
--- a/components/DashboardShowcase.js
+++ b/components/DashboardShowcase.js
@@ -366,9 +366,9 @@ export default function DashboardShowcase() {
                 <div className={styles.actions}>
                     <a
                         className="btn-ink"
-                        href="https://app.openadapt.ai/dashboard"
+                        href="https://app.openadapt.ai/demo"
                     >
-                        Open the Cloud app
+                        Explore the public demo
                     </a>
                     <a className="btn-ghost-ink" href="/pricing">
                         See launch plans

--- a/components/MastHead.js
+++ b/components/MastHead.js
@@ -86,6 +86,20 @@ export default function Home({ githubStats }) {
                                     >
                                         Run locally for free
                                     </a>
+                                    <a
+                                        className="btn-ghost-ink"
+                                        href="https://app.openadapt.ai/demo"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        data-testid="cloud-demo-cta"
+                                        onClick={() =>
+                                            track(EVENTS.HERO_CTA_CLICK, {
+                                                cta: 'explore_cloud_demo',
+                                            })
+                                        }
+                                    >
+                                        Explore the app
+                                    </a>
                                 </div>
                                 <p className="mb-8 text-sm leading-relaxed text-ink-3">
                                     <code className="rounded border border-hairline bg-panel px-2 py-1 text-ink">

--- a/cypress/e2e/dashboard-showcase.cy.js
+++ b/cypress/e2e/dashboard-showcase.cy.js
@@ -70,11 +70,15 @@ describe('Cloud product showcase', () => {
             'demo.openadapt.ai'
         )
 
-        // The CTA opens the real hosted app.
+        // The CTA opens the real public hosted-product demo without requiring
+        // an account.
         cy.get('#cloud-product')
-            .contains('a', 'Open the Cloud app')
-            .should('have.attr', 'href')
-            .and('include', 'app.openadapt.ai')
+            .contains('a', 'Explore the public demo')
+            .should(
+                'have.attr',
+                'href',
+                'https://app.openadapt.ai/demo'
+            )
 
         // Clicking a tab jumps the large slot to that real frame and moves the
         // highlight and browser address with it.

--- a/cypress/e2e/public-surface-coherence.cy.js
+++ b/cypress/e2e/public-surface-coherence.cy.js
@@ -38,6 +38,13 @@ describe('public surface coherence', () => {
                 'href',
                 'https://docs.openadapt.ai/get-started/'
             )
+        cy.get('[data-testid="cloud-demo-cta"]')
+            .should('be.visible')
+            .and(
+                'have.attr',
+                'href',
+                'https://app.openadapt.ai/demo'
+            )
     })
 
     it('updates homepage hero and footer from one repository-stats response', () => {


### PR DESCRIPTION
## What changed

- adds `Explore the app` beside `Qualify one workflow` and `Run locally for free` in the homepage hero
- routes the app path to the real public OpenAdapt Cloud demo at `https://app.openadapt.ai/demo`
- changes the existing Cloud product showcase action from the authenticated dashboard to the same public demo
- gives each path a distinct, payload-free analytics label
- keeps qualification as the sole filled CTA while presenting local and hosted exploration as peer secondary paths

## Why

The homepage needs to serve the three immediate user intents without making visitors hunt through the page: qualify an enterprise workflow, run the MIT product locally, or inspect the shipping Cloud interface.

## Validation

- `npm test` — 134 passing
- `npx next build` — production build passed
- focused Cypress public-surface + Cloud showcase suites — 6 passing, including mobile
- `git diff --check`
