### PR TITLE
fix: show newly published Desktop releases without a redeploy

### DIFF
--- a/cypress/e2e/download.cy.js
+++ b/cypress/e2e/download.cy.js
@@ -54,7 +54,7 @@ function completeRelease(tag, publishedAt) {
 
 describe('download page is server-rendered', () => {
     it('ships the desktop release state in the initial HTML', () => {
-        // The release list is resolved in getStaticProps, so the raw HTML
+        // The release list is resolved server-side, so the raw HTML
         // (before any JavaScript runs) must already contain a definite
         // state — never a client-side loading placeholder.
         cy.request('/download').its('body').then((html) => {

--- a/lib/githubApi.js
+++ b/lib/githubApi.js
@@ -3,9 +3,9 @@
 // Visitor browsers must NEVER call api.github.com: unauthenticated requests
 // are limited to 60/hour per client IP, so anyone on a shared IP (offices,
 // VPNs, CGNAT) gets 403s and sees broken release lists and social proof.
-// All GitHub data is fetched here from server-side loaders: getStaticProps
-// during build/revalidation or same-origin API routes at runtime (dynamic
-// imports only — keep this module out of client bundles).
+// All GitHub data is fetched here from server-side loaders or same-origin API
+// routes at runtime (dynamic imports only — keep this module out of client
+// bundles).
 //
 // An optional GITHUB_TOKEN environment variable raises the rate limit for
 // server/build requests. It is never shipped to the client.
@@ -85,7 +85,7 @@ export async function getOpenIssuesByLabel(repository, label) {
 
 /**
  * The newest complete native desktop prerelease, slimmed to the fields
- * the download page renders (getStaticProps props must stay small and
+ * the download page renders (server-rendered props must stay small and
  * JSON-serializable). Beta sets are accepted only with their per-platform
  * provenance metadata and SHA256SUMS; complete legacy Experimental sets remain
  * discoverable during the transition.

--- a/pages/download.js
+++ b/pages/download.js
@@ -21,13 +21,18 @@ function formatSize(bytes) {
     return `${mb.toFixed(1)} MB`
 }
 
-export async function getStaticProps() {
-    // The release list is fetched at build/revalidate time so visitor
-    // browsers never call api.github.com (60 unauthenticated req/hr per
-    // client IP means shared IPs got 403s and a broken download page).
+export async function getServerSideProps({ res }) {
+    // Resolve releases on the server at request time, then let the CDN cache
+    // the rendered page briefly. Visitors never call api.github.com, while a
+    // newly published installer becomes visible without waiting for a site
+    // rebuild or relying on host-specific ISR support.
     const { getDesktopRelease } = await import('../lib/githubApi')
     const { release, fetchFailed } = await getDesktopRelease()
-    return { props: { release, fetchFailed }, revalidate: 180 }
+    res.setHeader(
+        'Cache-Control',
+        'public, s-maxage=180, stale-while-revalidate=900'
+    )
+    return { props: { release, fetchFailed } }
 }
 
 export default function DownloadPage({ release, fetchFailed }) {

--- a/tests/publicTruth.test.js
+++ b/tests/publicTruth.test.js
@@ -68,8 +68,8 @@ test('visitor browsers never call api.github.com', () => {
     // api.github.com allows 60 unauthenticated requests/hour per client IP.
     // Any client-side fetch therefore 403s for visitors on shared IPs
     // (offices, VPNs, CGNAT) and breaks the page. GitHub data must only be
-    // fetched server-side: lib/ (dynamically imported in getStaticProps)
-    // and pages/api/ routes.
+    // fetched server-side: lib/ (dynamically imported in a server-side page
+    // loader) and pages/api/ routes.
     const clientSourceDirs = ['components', 'utils', 'pages']
     for (const dir of clientSourceDirs) {
         const entries = fs.readdirSync(path.join(root, dir), {
@@ -109,12 +109,13 @@ test('visitor browsers never call api.github.com', () => {
     assert.match(githubApi, /process\.env\.GITHUB_TOKEN/)
     assert.doesNotMatch(githubApi, /NEXT_PUBLIC/)
 
-    // The download page renders the release list from getStaticProps (ISR),
-    // so the release data is in the initial HTML for every visitor.
+    // The download page server-renders the release list, so release data is in
+    // the initial HTML without a visitor-side GitHub request. The CDN cache is
+    // intentionally short enough for new releases to appear without a deploy.
     const download = read('pages/download.js')
-    assert.match(download, /export async function getStaticProps/)
+    assert.match(download, /export async function getServerSideProps/)
     assert.match(download, /getDesktopRelease/)
-    assert.match(download, /revalidate: 180/)
+    assert.match(download, /s-maxage=180/)
 })
 
 test('public slogans scope demonstrated workflows and governed repair', () => {

--- a/utils/desktopRelease.js
+++ b/utils/desktopRelease.js
@@ -1,6 +1,6 @@
 export const DESKTOP_REPO = 'OpenAdaptAI/openadapt-desktop'
-// The releases API is only queried server-side (lib/githubApi.js, at
-// build/revalidate time). Visitor browsers must never call api.github.com.
+// The releases API is only queried server-side (lib/githubApi.js). Visitor
+// browsers must never call api.github.com.
 export const DESKTOP_RELEASES_PAGE = `https://github.com/${DESKTOP_REPO}/releases`
 
 const DESKTOP_TAG = /^desktop-v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/


### PR DESCRIPTION
## Outcome

The download page now resolves the newest complete Desktop release on the server for each CDN cache window instead of relying on host-specific ISR. Visitor browsers still make zero GitHub API calls, while desktop-v0.10.0 and future releases can appear without a site rebuild.

## Verification

- npm test: 134/134
- npx next build: download is server-rendered
- Release selection continues to require the complete Beta asset and provenance set
