### PR TITLE
chore: publish current launcher and desktop versions

### DIFF
--- a/public/status.json
+++ b/public/status.json
@@ -3,10 +3,10 @@
     "generated_at": "2026-07-25",
     "product_lifecycle": "Beta",
     "versions": {
-        "launcher": "1.7.2",
+        "launcher": "1.7.3",
         "flow": "1.22.0",
         "capture": "1.1.1",
-        "desktop": "0.10.0"
+        "desktop": "0.11.0"
     },
     "tiers": {
         "Available": "Implemented in the released compiler and governed runtime. Production use still qualifies the exact workflow, application, environment, identity contract, and effect oracle.",

--- a/tests/statusManifest.test.js
+++ b/tests/statusManifest.test.js
@@ -23,10 +23,10 @@ const CANONICAL_TIERS = ['Available', 'Beta']
 
 // Verified against the public releases on 2026-07-25.
 const CANONICAL_VERSIONS = {
-    launcher: '1.7.2',
+    launcher: '1.7.3',
     flow: '1.22.0',
     capture: '1.1.1',
-    desktop: '0.10.0',
+    desktop: '0.11.0',
 }
 
 test('status manifest separates released substrate availability from evidence scope', () => {


### PR DESCRIPTION
Refreshes the canonical public status manifest to the already-published OpenAdapt 1.7.3 and Desktop 0.11.0 releases. No capability or lifecycle claim changes. Local evidence: 134/134 tests and production build pass.