### PR TITLE
fix: refresh desktop release downloads promptly

### DIFF
--- a/pages/download.js
+++ b/pages/download.js
@@ -28,9 +28,14 @@ export async function getServerSideProps({ res }) {
     // rebuild or relying on host-specific ISR support.
     const { getDesktopRelease } = await import('../lib/githubApi')
     const { release, fetchFailed } = await getDesktopRelease()
+    // Browser/proxy caches must revalidate, while Netlify's durable shared
+    // cache refreshes the GitHub-backed release list every minute. A generic
+    // `s-maxage` header is not enough here: Netlify can retain the function
+    // response in its durable cache without the provider-specific TTL.
+    res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate')
     res.setHeader(
-        'Cache-Control',
-        'public, s-maxage=180, stale-while-revalidate=900'
+        'Netlify-CDN-Cache-Control',
+        'public, durable, s-maxage=60, stale-while-revalidate=120, stale-if-error=86400'
     )
     return { props: { release, fetchFailed } }
 }

--- a/pages/security.js
+++ b/pages/security.js
@@ -14,6 +14,8 @@ const LIMITS_URL =
     'https://github.com/OpenAdaptAI/openadapt-flow/blob/main/docs/LIMITS.md'
 const RELEASES_URL =
     'https://github.com/OpenAdaptAI/openadapt-desktop/blob/main/RELEASES.md'
+const NATIVE_RELEASE_URL =
+    'https://github.com/OpenAdaptAI/openadapt-desktop/releases/tag/desktop-v0.12.1'
 // Security reports go through GitHub private advisories or hello@openadapt.ai.
 // There is no security@openadapt.ai mailbox today — do not advertise one.
 const CONTACT_EMAIL = 'hello@openadapt.ai'
@@ -377,7 +379,9 @@ const releaseIntegrity = [
     {
         title: 'Build provenance & attestations',
         status: 'yes',
-        body: 'The PyPI engine publishes wheel and sdist with PEP 740 publish attestations. Native desktop installers ship a SHA256SUMS manifest with SLSA provenance-v1 build attestations you can verify with sha256sum -c and gh attestation verify. Provenance answers "was this built from our source by our CI"; it is not the same as code signing.',
+        body: 'The PyPI engine publishes wheel and sdist with PEP 740 publish attestations. Desktop Beta 0.12.1 publishes a SHA256SUMS manifest and GitHub build-provenance attestations for every installer, metadata file, and SBOM. Provenance answers "was this built from our source by our CI"; it is not the same as code signing.',
+        evidenceUrl: NATIVE_RELEASE_URL,
+        evidenceLabel: 'Inspect the public checksums and attestations',
     },
     {
         title: 'Code signing',
@@ -386,8 +390,10 @@ const releaseIntegrity = [
     },
     {
         title: 'Software bill of materials (SBOM)',
-        status: 'roadmap',
-        body: 'We do not currently publish a machine-readable SBOM as a release asset. Dependencies are visible in the open-source lockfiles, and dependency updates flow through Dependabot. A published SBOM is a roadmap item.',
+        status: 'yes',
+        body: 'Desktop Beta 0.12.1 publishes a CycloneDX JSON SBOM generated from the exact smoke-tested installer set. The release workflow rejects an empty or malformed SBOM before publication, includes its hash in SHA256SUMS, and attests the SBOM alongside the installers.',
+        evidenceUrl: NATIVE_RELEASE_URL,
+        evidenceLabel: 'Download the public CycloneDX SBOM',
     },
 ]
 
@@ -605,6 +611,19 @@ export default function SecurityPage() {
                                 </div>
                                 <p className="mt-2 text-sm leading-relaxed text-ink-2">
                                     {item.body}
+                                    {item.evidenceUrl && (
+                                        <>
+                                            {' '}
+                                            <a
+                                                href={item.evidenceUrl}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                className="text-accent underline underline-offset-4"
+                                            >
+                                                {item.evidenceLabel} →
+                                            </a>
+                                        </>
+                                    )}
                                 </p>
                             </div>
                         ))}

--- a/tests/publicTruth.test.js
+++ b/tests/publicTruth.test.js
@@ -115,7 +115,8 @@ test('visitor browsers never call api.github.com', () => {
     const download = read('pages/download.js')
     assert.match(download, /export async function getServerSideProps/)
     assert.match(download, /getDesktopRelease/)
-    assert.match(download, /s-maxage=180/)
+    assert.match(download, /Netlify-CDN-Cache-Control/)
+    assert.match(download, /s-maxage=60/)
 })
 
 test('public slogans scope demonstrated workflows and governed repair', () => {


### PR DESCRIPTION
## Summary

- give the dynamic download page an explicit Netlify durable-cache TTL
- keep browser caches revalidation-only
- refresh GitHub release data every 60 seconds, with a short stale-while-revalidate window and stale-if-error resilience
- link the trust center to Desktop Beta 0.12.1 checksums and provenance attestations
- promote the now-published CycloneDX release SBOM while keeping Apple/Windows identity signing as an explicit external gate

## Why

The public `/download` page remained on `desktop-v0.10.0` after `desktop-v0.12.1` was published because Netlify retained the server response in durable cache without the provider-specific TTL.

Desktop Beta 0.12.1 now also supplies the public release-integrity evidence that the trust center previously described as pending.

## Verification

- `npm test` (134 passing)
- `npx next build`
- `git diff --check`
- Desktop native release run 30171343662: all platform, checksum, SBOM, attestation, and draft-publication jobs passed
- Post-publication freshness run 30171938426 passed
- Public release and all 12 download URLs return HTTP 200
