### PR TITLE
fix: render desktop release evidence links

### DIFF
--- a/pages/security.js
+++ b/pages/security.js
@@ -611,19 +611,6 @@ export default function SecurityPage() {
                                 </div>
                                 <p className="mt-2 text-sm leading-relaxed text-ink-2">
                                     {item.body}
-                                    {item.evidenceUrl && (
-                                        <>
-                                            {' '}
-                                            <a
-                                                href={item.evidenceUrl}
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                                className="text-accent underline underline-offset-4"
-                                            >
-                                                {item.evidenceLabel} →
-                                            </a>
-                                        </>
-                                    )}
                                 </p>
                             </div>
                         ))}
@@ -1081,6 +1068,19 @@ export default function SecurityPage() {
                                 </div>
                                 <p className="mt-2 text-sm leading-relaxed text-ink-2">
                                     {item.body}
+                                    {item.evidenceUrl && (
+                                        <>
+                                            {' '}
+                                            <a
+                                                href={item.evidenceUrl}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                className="text-accent underline underline-offset-4"
+                                            >
+                                                {item.evidenceLabel} →
+                                            </a>
+                                        </>
+                                    )}
                                 </p>
                             </div>
                         ))}


### PR DESCRIPTION
## Summary

- move the optional evidence-link renderer into the release-integrity card loop
- remove the unreachable renderer from unrelated control-posture cards
- make both Desktop 0.12.1 checksum/provenance and CycloneDX SBOM links visible

## Verification

- focused tests: 15 passing
- production Next build passed
- generated `/security` HTML contains both link labels and two exact `desktop-v0.12.1` URLs
- `git diff --check`
