### PR TITLE
docs: sync Desktop 0.13 public status

### DIFF
--- a/components/ReplayHero.js
+++ b/components/ReplayHero.js
@@ -39,11 +39,11 @@ const usd = (n) => `$${Number(n).toFixed(2)}`
 const secs = (n) => `${Math.round(Number(n))}s`
 const per1k = Math.round(em.agent.cost_usd_per_run * 1000).toLocaleString()
 
-// The run_openemr footage is now recorded clean (no burned-in status badge;
-// openadapt-flow scripts/demo_media.py build_run_openemr composites no overlay),
-// so the floating OpenAdapt HUD below is the SOLE "running · local · $0"
-// indicator, painted as a DOM system overlay on top of the app. Set to false
-// only if the footage is ever reverted to a variant with a baked-in badge.
+// The source footage is clean. This DOM HUD is presentation-only marketing UI,
+// excluded from the recorded evidence and never used by runtime resolution,
+// actuation, accessibility observation, or verification. Real headed execution
+// uses the separate native Desktop overlay; hosted browser streams should use a
+// sibling controller layer rather than injecting controls into the target page.
 const SHOW_SYSTEM_OVERLAY = true
 
 export default function ReplayHero() {
@@ -85,15 +85,16 @@ export default function ReplayHero() {
                             alt="Real footage: OpenAdapt replaying a compiled 18-step workflow against OpenEMR's live public demo, logging in and filling the patient-intake form, locally and with no per-run model calls."
                         />
                         {/*
-                          Floating OpenAdapt system overlay: a HUD painted ON
-                          TOP of whatever app is running (here OpenEMR), a
-                          distinct visual layer from the browser chrome. It
-                          reinforces that OpenAdapt runs over your existing
-                          apps rather than replacing them. The footage is clean
-                          (no baked-in badge), so this is the sole indicator.
+                          Presentation-only HUD over clean evidence footage.
+                          It is intentionally excluded from the target page and
+                          must never be treated as runtime evidence.
                         */}
                         {SHOW_SYSTEM_OVERLAY && (
-                            <div className={styles.sysOverlay}>
+                            <div
+                                className={styles.sysOverlay}
+                                aria-hidden="true"
+                                data-overlay-boundary="presentation-only"
+                            >
                                 <span
                                     className={styles.sysMark}
                                     aria-hidden="true"

--- a/pages/security.js
+++ b/pages/security.js
@@ -15,7 +15,9 @@ const LIMITS_URL =
 const RELEASES_URL =
     'https://github.com/OpenAdaptAI/openadapt-desktop/blob/main/RELEASES.md'
 const NATIVE_RELEASE_URL =
-    'https://github.com/OpenAdaptAI/openadapt-desktop/releases/tag/desktop-v0.12.1'
+    'https://github.com/OpenAdaptAI/openadapt-desktop/releases/tag/desktop-v0.13.0'
+const CONTROL_OVERLAY_URL =
+    'https://github.com/OpenAdaptAI/openadapt-desktop/blob/desktop-v0.13.0/docs/CONTROL_OVERLAY.md'
 // Security reports go through GitHub private advisories or hello@openadapt.ai.
 // There is no security@openadapt.ai mailbox today — do not advertise one.
 const CONTACT_EMAIL = 'hello@openadapt.ai'
@@ -379,7 +381,7 @@ const releaseIntegrity = [
     {
         title: 'Build provenance & attestations',
         status: 'yes',
-        body: 'The PyPI engine publishes wheel and sdist with PEP 740 publish attestations. Desktop Beta 0.12.1 publishes a SHA256SUMS manifest and GitHub build-provenance attestations for every installer, metadata file, and SBOM. Provenance answers "was this built from our source by our CI"; it is not the same as code signing.',
+        body: 'The PyPI engine publishes wheel and sdist with PEP 740 publish attestations. Desktop Beta 0.13.0 publishes a SHA256SUMS manifest and GitHub build-provenance attestations for every installer, metadata file, and SBOM. Provenance answers "was this built from our source by our CI"; it is not the same as code signing.',
         evidenceUrl: NATIVE_RELEASE_URL,
         evidenceLabel: 'Inspect the public checksums and attestations',
     },
@@ -391,9 +393,16 @@ const releaseIntegrity = [
     {
         title: 'Software bill of materials (SBOM)',
         status: 'yes',
-        body: 'Desktop Beta 0.12.1 publishes a CycloneDX JSON SBOM generated from the exact smoke-tested installer set. The release workflow rejects an empty or malformed SBOM before publication, includes its hash in SHA256SUMS, and attests the SBOM alongside the installers.',
+        body: 'Desktop Beta 0.13.0 publishes a CycloneDX JSON SBOM generated from the exact smoke-tested installer set. The release workflow rejects an empty or malformed SBOM before publication, includes its hash in SHA256SUMS, and attests the SBOM alongside the installers.',
         evidenceUrl: NATIVE_RELEASE_URL,
         evidenceLabel: 'Download the public CycloneDX SBOM',
+    },
+    {
+        title: 'Execution control overlay',
+        status: 'yes',
+        body: 'Desktop Beta 0.13.0 provides a separate native status surface outside the target application. During active observation and execution it is click-through, non-focusable, and excluded from capture before it becomes visible; controls appear only at a safe paused or terminal boundary. Overlay presentation state is never used as target-resolution or verification evidence.',
+        evidenceUrl: CONTROL_OVERLAY_URL,
+        evidenceLabel: 'Inspect the released overlay contract',
     },
 ]
 

--- a/public/status.json
+++ b/public/status.json
@@ -4,9 +4,9 @@
     "product_lifecycle": "Beta",
     "versions": {
         "launcher": "1.7.3",
-        "flow": "1.22.0",
+        "flow": "1.23.0",
         "capture": "1.1.1",
-        "desktop": "0.11.0"
+        "desktop": "0.13.0"
     },
     "tiers": {
         "Available": "Implemented in the released compiler and governed runtime. Production use still qualifies the exact workflow, application, environment, identity contract, and effect oracle.",

--- a/tests/statusManifest.test.js
+++ b/tests/statusManifest.test.js
@@ -24,9 +24,9 @@ const CANONICAL_TIERS = ['Available', 'Beta']
 // Verified against the public releases on 2026-07-25.
 const CANONICAL_VERSIONS = {
     launcher: '1.7.3',
-    flow: '1.22.0',
+    flow: '1.23.0',
     capture: '1.1.1',
-    desktop: '0.11.0',
+    desktop: '0.13.0',
 }
 
 test('status manifest separates released substrate availability from evidence scope', () => {


### PR DESCRIPTION
## What changed

- Updates the canonical status manifest to released `openadapt-flow` 1.23.0 and Desktop 0.13.0.
- Updates the trust center release, SBOM, and native control-overlay evidence.
- Marks the homepage DOM HUD as presentation-only and excluded from runtime evidence.

## Why

The live download page already selects Desktop 0.13.0 dynamically, but the trust page and status manifest were stale. The marketing HUD also needed an explicit boundary so it cannot be confused with execution evidence or target-page runtime injection.

## Validation

- `npm test` (134 passing)
- `npm run build`
- `git diff --check`

The build-refreshed paper PDF was intentionally left out of this PR.
