### PR TITLE
feat: add safe public JSON artifact viewer

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -10,3 +10,6 @@ NOT licensed under the MIT License. All rights in those materials are reserved.
 Only SYNTHETIC reference media may be published in this repository (for example,
 synthetic openIMIS / Frappe / OpenEMR reference frames). Do not add real-customer
 or real-EMR screenshots, recordings, datasets, or other confidential material.
+
+The interactive artifact viewer includes react-json-view-lite 2.5.0,
+Copyright (c) 2024 AnyRoad, used under the MIT License.

--- a/components/DesktopPreview.js
+++ b/components/DesktopPreview.js
@@ -5,6 +5,8 @@
  * panels are labelled representations rather than screenshots.
  */
 
+import JsonArtifactLink from './JsonArtifactLink'
+
 const TRAY_PACKAGE_VERSION = '0.1.1'
 const WINDOWS_INSTALLER_VERSION = '0.6.1'
 
@@ -459,12 +461,12 @@ export default function DesktopPreview() {
 
                 <p className="mt-6 text-xs text-ink-3">
                     Capture provenance for every screenshot is recorded in{' '}
-                    <a
-                        href="/desktop-preview/MANIFEST.json"
+                    <JsonArtifactLink
+                        source="/desktop-preview/MANIFEST.json"
                         className="font-medium underline underline-offset-4"
                     >
                         the media manifest
-                    </a>
+                    </JsonArtifactLink>
                     .
                 </p>
             </div>

--- a/components/HomeReferenceWorkflow.js
+++ b/components/HomeReferenceWorkflow.js
@@ -1,4 +1,5 @@
 import Clip from './Clip'
+import JsonArtifactLink from './JsonArtifactLink'
 import processStyles from './HowItWorks.module.css'
 import panelStyles from './LendingWorkflowDemo.module.css'
 import styles from './HomeReferenceWorkflow.module.css'
@@ -228,9 +229,9 @@ export default function HomeReferenceWorkflow({ vertical, onSelectVertical }) {
 
                 <div className={panelStyles.disclosure}>
                     <p>{reference.disclosure.text}</p>
-                    <a href={reference.disclosure.linkHref}>
+                    <JsonArtifactLink source={reference.disclosure.linkHref}>
                         {reference.disclosure.linkLabel}
-                    </a>
+                    </JsonArtifactLink>
                 </div>
             </div>
         </section>

--- a/components/InsuranceWorkflowDemo.js
+++ b/components/InsuranceWorkflowDemo.js
@@ -1,4 +1,5 @@
 import Clip from './Clip'
+import JsonArtifactLink from './JsonArtifactLink'
 import processStyles from './HowItWorks.module.css'
 import styles from './LendingWorkflowDemo.module.css'
 
@@ -176,9 +177,9 @@ export default function InsuranceWorkflowDemo() {
                         software, task, oracle, media hashes, and scope. OpenAdapt
                         is unaffiliated with the openIMIS Initiative.
                     </p>
-                    <a href="/insurance-demo/provenance.json">
+                    <JsonArtifactLink source="/insurance-demo/provenance.json">
                         Inspect evidence manifest
-                    </a>
+                    </JsonArtifactLink>
                 </div>
             </div>
         </section>

--- a/components/JsonArtifactLink.js
+++ b/components/JsonArtifactLink.js
@@ -1,0 +1,25 @@
+import Link from 'next/link'
+
+import { publicJsonViewerHref } from '../lib/publicJsonArtifacts.mjs'
+
+/**
+ * Route a known public JSON artifact through the human-readable viewer while
+ * leaving unsupported URLs as ordinary raw links. The latter is intentional:
+ * the viewer allowlist must not expand merely because a caller supplied a URL.
+ */
+export default function JsonArtifactLink({ source, children, ...props }) {
+    const viewerHref = publicJsonViewerHref({ source })
+    if (!viewerHref) {
+        return (
+            <a href={source} {...props}>
+                {children}
+            </a>
+        )
+    }
+
+    return (
+        <Link href={viewerHref} {...props}>
+            {children}
+        </Link>
+    )
+}

--- a/components/JsonArtifactViewer.js
+++ b/components/JsonArtifactViewer.js
@@ -164,7 +164,7 @@ export default function JsonArtifactViewer({ artifact, initialPointer = '' }) {
                         digestInput.buffer
                     )
                 )
-                if (digest !== artifact.sha256) {
+                if (artifact.sha256 && digest !== artifact.sha256) {
                     if (!cancelled) {
                         setLoadState({
                             kind: 'error',
@@ -348,15 +348,28 @@ export default function JsonArtifactViewer({ artifact, initialPointer = '' }) {
 
             <dl className={styles.integrity}>
                 <div>
-                    <dt>Committed SHA-256</dt>
-                    <dd>{artifact.sha256}</dd>
+                    <dt>
+                        {artifact.sha256
+                            ? 'Committed SHA-256'
+                            : 'Integrity boundary'}
+                    </dt>
+                    <dd>
+                        {artifact.sha256 ||
+                            'Exact registered path; digest computed after load'}
+                    </dd>
                 </div>
-                {loadState.kind === 'ready' && (
+                {loadState.kind === 'ready' && artifact.sha256 && (
                     <div>
                         <dt>Integrity</dt>
                         <dd>
                             <span className={styles.verified}>Verified</span>
                         </dd>
+                    </div>
+                )}
+                {loadState.kind === 'ready' && !artifact.sha256 && (
+                    <div>
+                        <dt>Loaded SHA-256</dt>
+                        <dd>{loadState.digest}</dd>
                     </div>
                 )}
             </dl>

--- a/components/JsonArtifactViewer.js
+++ b/components/JsonArtifactViewer.js
@@ -1,0 +1,583 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { JsonView } from 'react-json-view-lite'
+
+import {
+    buildJsonArtifactIndex,
+    copyableJsonValue,
+    isExactPublicArtifactResponseUrl,
+    jsonValuePreview,
+    MAX_JSON_ARTIFACT_BYTES,
+    MAX_JSON_TREE_DEPTH,
+    parseJsonArtifact,
+    searchJsonIndex,
+} from '../lib/publicJsonArtifacts.mjs'
+import styles from './JsonArtifactViewer.module.css'
+
+const MAX_EXPAND_ALL_NODES = 5_000
+
+const TREE_STYLES = {
+    container: styles.tree,
+    childFieldsContainer: styles.treeChildren,
+    basicChildStyle: styles.treeNode,
+    collapseIcon: `${styles.treeToggle} ${styles.treeToggleExpanded}`,
+    expandIcon: `${styles.treeToggle} ${styles.treeToggleCollapsed}`,
+    collapsedContent: styles.treeCollapsedContent,
+    label: styles.treeLabel,
+    clickableLabel: `${styles.treeLabel} ${styles.treeLabelClickable}`,
+    nullValue: styles.treeNull,
+    undefinedValue: styles.treeNull,
+    numberValue: styles.treeNumber,
+    stringValue: styles.treeString,
+    booleanValue: styles.treeBoolean,
+    otherValue: styles.treeOther,
+    punctuation: styles.treePunctuation,
+    stringifyStringValues: true,
+    ariaLables: {
+        collapseJson: 'Collapse JSON branch',
+        expandJson: 'Expand JSON branch',
+    },
+}
+
+function formatBytes(bytes) {
+    if (bytes < 1024) return `${bytes} B`
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`
+}
+
+function digestHex(buffer) {
+    return Array.from(new Uint8Array(buffer), (byte) =>
+        byte.toString(16).padStart(2, '0')
+    ).join('')
+}
+
+async function readBoundedBytes(response) {
+    const declaredSize = Number(response.headers.get('content-length'))
+    if (
+        Number.isFinite(declaredSize) &&
+        declaredSize > MAX_JSON_ARTIFACT_BYTES
+    ) {
+        throw new Error(
+            `This artifact is ${formatBytes(
+                declaredSize
+            )}. Interactive viewing is limited to ${formatBytes(
+                MAX_JSON_ARTIFACT_BYTES
+            )}; use Raw or Download instead.`
+        )
+    }
+
+    if (!response.body) {
+        const bytes = new Uint8Array(await response.arrayBuffer())
+        if (bytes.byteLength > MAX_JSON_ARTIFACT_BYTES) {
+            throw new Error(
+                `This artifact exceeds the ${formatBytes(
+                    MAX_JSON_ARTIFACT_BYTES
+                )} interactive-view limit; use Raw or Download instead.`
+            )
+        }
+        return bytes
+    }
+
+    const reader = response.body.getReader()
+    const chunks = []
+    let length = 0
+    while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        length += value.byteLength
+        if (length > MAX_JSON_ARTIFACT_BYTES) {
+            await reader.cancel()
+            throw new Error(
+                `This artifact exceeds the ${formatBytes(
+                    MAX_JSON_ARTIFACT_BYTES
+                )} interactive-view limit; use Raw or Download instead.`
+            )
+        }
+        chunks.push(value)
+    }
+
+    const bytes = new Uint8Array(length)
+    let offset = 0
+    for (const chunk of chunks) {
+        bytes.set(chunk, offset)
+        offset += chunk.byteLength
+    }
+    return bytes
+}
+
+export default function JsonArtifactViewer({ artifact, initialPointer = '' }) {
+    const [reloadKey, setReloadKey] = useState(0)
+    const [loadState, setLoadState] = useState({ kind: 'loading' })
+    const [query, setQuery] = useState('')
+    const [selectedPointer, setSelectedPointer] = useState(initialPointer)
+    const [expansionMode, setExpansionMode] = useState(
+        initialPointer ? 'path' : 'root'
+    )
+    const [copyStatus, setCopyStatus] = useState('')
+    const searchInputRef = useRef(null)
+
+    useEffect(() => {
+        const controller = new AbortController()
+        let cancelled = false
+        setLoadState({ kind: 'loading' })
+
+        async function load() {
+            try {
+                const response = await fetch(artifact.source, {
+                    cache: 'force-cache',
+                    credentials: 'same-origin',
+                    headers: {
+                        Accept: 'application/json, application/x-ndjson, text/plain',
+                    },
+                    signal: controller.signal,
+                })
+                if (!response.ok) {
+                    throw new Error(
+                        response.status === 404
+                            ? 'This JSON artifact was not found.'
+                            : `The artifact could not be loaded (HTTP ${response.status}).`
+                    )
+                }
+
+                if (
+                    !isExactPublicArtifactResponseUrl(
+                        response.url,
+                        window.location.origin,
+                        artifact.source
+                    )
+                ) {
+                    throw new Error(
+                        'The artifact response left its registered same-origin path, so it was not rendered.'
+                    )
+                }
+
+                const bytes = await readBoundedBytes(response)
+                if (!window.crypto?.subtle) {
+                    throw new Error(
+                        'This browser cannot verify SHA-256 integrity. Use Raw or Download instead.'
+                    )
+                }
+                const digestInput = new Uint8Array(bytes.byteLength)
+                digestInput.set(bytes)
+                const digest = digestHex(
+                    await window.crypto.subtle.digest(
+                        'SHA-256',
+                        digestInput.buffer
+                    )
+                )
+                if (digest !== artifact.sha256) {
+                    if (!cancelled) {
+                        setLoadState({
+                            kind: 'error',
+                            computedDigest: digest,
+                            message:
+                                'Integrity check failed. The loaded bytes do not match the committed SHA-256, so the tree was not rendered.',
+                        })
+                    }
+                    return
+                }
+
+                let text
+                try {
+                    text = new TextDecoder('utf-8', { fatal: true }).decode(
+                        bytes
+                    )
+                } catch {
+                    throw new Error('The artifact is not valid UTF-8 text.')
+                }
+
+                let data
+                try {
+                    data = parseJsonArtifact(text, artifact.format)
+                } catch (error) {
+                    throw new Error(
+                        error instanceof Error &&
+                            error.message.startsWith('JSON Lines record')
+                            ? error.message
+                            : 'The artifact is not valid JSON.'
+                    )
+                }
+
+                if (!cancelled) {
+                    setLoadState({
+                        kind: 'ready',
+                        bytes: bytes.byteLength,
+                        data,
+                        digest,
+                    })
+                }
+            } catch (error) {
+                if (cancelled || controller.signal.aborted) return
+                setLoadState({
+                    kind: 'error',
+                    message:
+                        error instanceof Error
+                            ? error.message
+                            : 'The artifact could not be loaded.',
+                })
+            }
+        }
+
+        load()
+        return () => {
+            cancelled = true
+            controller.abort()
+        }
+    }, [artifact, reloadKey])
+
+    const index = useMemo(
+        () =>
+            loadState.kind === 'ready'
+                ? buildJsonArtifactIndex(loadState.data)
+                : null,
+        [loadState]
+    )
+    const search = useMemo(
+        () =>
+            index
+                ? searchJsonIndex(index, query)
+                : { matches: [], hasMore: false },
+        [index, query]
+    )
+    const selected = useMemo(
+        () => index?.byPointer.get(selectedPointer) || index?.nodes[0],
+        [index, selectedPointer]
+    )
+
+    useEffect(() => {
+        if (!index || index.byPointer.has(selectedPointer)) return
+        setSelectedPointer('')
+        setExpansionMode('root')
+    }, [index, selectedPointer])
+
+    const selectPointer = useCallback(
+        (pointer) => {
+            if (!index?.byPointer.has(pointer)) return
+            setSelectedPointer(pointer)
+            setExpansionMode('path')
+            const url = new URL(window.location.href)
+            if (pointer) url.searchParams.set('pointer', pointer)
+            else url.searchParams.delete('pointer')
+            window.history.replaceState(window.history.state, '', url)
+        },
+        [index]
+    )
+
+    const shouldExpandNode = useCallback(
+        (level, value) => {
+            if (expansionMode === 'all') return true
+            if (expansionMode === 'root') return level < 1
+            if (!index || !value || typeof value !== 'object') {
+                return level < 1
+            }
+            const pointer = index.objectPointers.get(value)
+            return (
+                pointer === '' ||
+                Boolean(
+                    pointer &&
+                        (selectedPointer === pointer ||
+                            selectedPointer.startsWith(`${pointer}/`))
+                )
+            )
+        },
+        [expansionMode, index, selectedPointer]
+    )
+
+    const copyText = useCallback(async (value, success) => {
+        try {
+            await navigator.clipboard.writeText(value)
+            setCopyStatus(success)
+        } catch {
+            setCopyStatus('Clipboard access was denied by the browser.')
+        }
+    }, [])
+
+    const copyDeepLink = useCallback(() => {
+        if (!selected) return
+        const url = new URL(window.location.href)
+        if (selected.pointer) {
+            url.searchParams.set('pointer', selected.pointer)
+        } else {
+            url.searchParams.delete('pointer')
+        }
+        copyText(url.toString(), 'Deep link copied.')
+    }, [copyText, selected])
+
+    const treeTooLarge = Boolean(
+        index && (index.truncated || index.maxDepth > MAX_JSON_TREE_DEPTH)
+    )
+    const canExpandAll = Boolean(
+        index && !treeTooLarge && index.nodes.length <= MAX_EXPAND_ALL_NODES
+    )
+    const nodeCount = index
+        ? `${index.nodes.length.toLocaleString()}${index.truncated ? '+' : ''}`
+        : '—'
+
+    return (
+        <section
+            className={styles.viewer}
+            aria-labelledby="json-artifact-title"
+        >
+            <header className={styles.header}>
+                <div>
+                    <p className="eyebrow">Read-only machine evidence</p>
+                    <h1 id="json-artifact-title">{artifact.title}</h1>
+                    <p className={styles.description}>{artifact.description}</p>
+                    <p className={styles.source}>{artifact.source}</p>
+                </div>
+                <div
+                    className={styles.fileActions}
+                    aria-label="Artifact file actions"
+                >
+                    <a
+                        className="btn-ghost-ink"
+                        href={artifact.source}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Raw
+                    </a>
+                    <a
+                        className="btn-ghost-ink"
+                        href={artifact.source}
+                        download={artifact.fileName}
+                    >
+                        Download
+                    </a>
+                </div>
+            </header>
+
+            <dl className={styles.integrity}>
+                <div>
+                    <dt>Committed SHA-256</dt>
+                    <dd>{artifact.sha256}</dd>
+                </div>
+                {loadState.kind === 'ready' && (
+                    <div>
+                        <dt>Integrity</dt>
+                        <dd>
+                            <span className={styles.verified}>Verified</span>
+                        </dd>
+                    </div>
+                )}
+            </dl>
+
+            <div className="sr-only" role="status" aria-live="polite">
+                {loadState.kind === 'loading'
+                    ? 'Loading JSON artifact.'
+                    : copyStatus}
+            </div>
+
+            {loadState.kind === 'loading' && (
+                <div className={styles.message} role="status">
+                    <span className={styles.spinner} aria-hidden="true" />
+                    Loading and checking the artifact…
+                </div>
+            )}
+
+            {loadState.kind === 'error' && (
+                <div className={`${styles.message} ${styles.error}`} role="alert">
+                    <div>
+                        <strong>Could not open the interactive view</strong>
+                        <p>{loadState.message}</p>
+                        {loadState.computedDigest && (
+                            <p className={styles.source}>
+                                Loaded SHA-256: {loadState.computedDigest}
+                            </p>
+                        )}
+                    </div>
+                    <button
+                        className="btn-ghost-ink"
+                        type="button"
+                        onClick={() => setReloadKey((key) => key + 1)}
+                    >
+                        Try again
+                    </button>
+                </div>
+            )}
+
+            {loadState.kind === 'ready' && index && selected && (
+                <>
+                    <div className={styles.toolbar}>
+                        <label className={styles.search}>
+                            <span>Search keys, paths, and values</span>
+                            <input
+                                ref={searchInputRef}
+                                type="search"
+                                value={query}
+                                onChange={(event) =>
+                                    setQuery(event.target.value)
+                                }
+                                placeholder="For example: outcome or $.surfaces[0]"
+                            />
+                        </label>
+                        <div
+                            className={styles.treeActions}
+                            aria-label="JSON tree controls"
+                        >
+                            <button
+                                className="btn-ghost-ink"
+                                type="button"
+                                onClick={() => setExpansionMode('all')}
+                                disabled={!canExpandAll}
+                                title={
+                                    canExpandAll
+                                        ? 'Expand every branch'
+                                        : 'Expand all is disabled for large trees'
+                                }
+                            >
+                                Expand all
+                            </button>
+                            <button
+                                className="btn-ghost-ink"
+                                type="button"
+                                onClick={() => setExpansionMode('root')}
+                            >
+                                Collapse branches
+                            </button>
+                        </div>
+                    </div>
+
+                    <div
+                        className={styles.facts}
+                        aria-label="Artifact summary"
+                    >
+                        <span>
+                            {artifact.format === 'jsonl'
+                                ? 'JSON Lines'
+                                : 'JSON'}
+                        </span>
+                        <span>{formatBytes(loadState.bytes)}</span>
+                        <span>{nodeCount} nodes indexed</span>
+                        <span title={loadState.digest}>
+                            SHA-256 {loadState.digest.slice(0, 12)}…
+                        </span>
+                    </div>
+
+                    {query.trim() && (
+                        <section
+                            className={styles.results}
+                            aria-label="JSON search results"
+                        >
+                            <div className={styles.resultsHeading}>
+                                <strong>
+                                    {search.matches.length}
+                                    {search.hasMore ? '+' : ''} result
+                                    {search.matches.length === 1 ? '' : 's'}
+                                </strong>
+                                <button
+                                    type="button"
+                                    onClick={() => {
+                                        setQuery('')
+                                        searchInputRef.current?.focus()
+                                    }}
+                                >
+                                    Clear search
+                                </button>
+                            </div>
+                            {search.matches.length ? (
+                                <ul>
+                                    {search.matches.map((match) => (
+                                        <li key={match.pointer}>
+                                            <button
+                                                type="button"
+                                                onClick={() =>
+                                                    selectPointer(match.pointer)
+                                                }
+                                            >
+                                                <span>{match.path}</span>
+                                                <small>
+                                                    {jsonValuePreview(
+                                                        match.value
+                                                    )}
+                                                </small>
+                                            </button>
+                                        </li>
+                                    ))}
+                                </ul>
+                            ) : (
+                                <p>
+                                    No indexed keys, paths, or values match this
+                                    search.
+                                </p>
+                            )}
+                        </section>
+                    )}
+
+                    <aside
+                        className={styles.selection}
+                        aria-label="Focused JSON value"
+                    >
+                        <div>
+                            <p className="eyebrow">Focused value</p>
+                            <p className={styles.source}>{selected.path}</p>
+                            <p>{jsonValuePreview(selected.value)}</p>
+                        </div>
+                        <div className={styles.selectionControls}>
+                            <div className={styles.selectionActions}>
+                                <button
+                                    type="button"
+                                    onClick={() =>
+                                        copyText(
+                                            selected.path,
+                                            'JSON path copied.'
+                                        )
+                                    }
+                                >
+                                    Copy path
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() =>
+                                        copyText(
+                                            copyableJsonValue(selected.value),
+                                            'JSON value copied.'
+                                        )
+                                    }
+                                >
+                                    Copy value
+                                </button>
+                                <button type="button" onClick={copyDeepLink}>
+                                    Copy deep link
+                                </button>
+                            </div>
+                            {copyStatus && (
+                                <span className={styles.copyStatus}>
+                                    {copyStatus}
+                                </span>
+                            )}
+                        </div>
+                    </aside>
+
+                    {treeTooLarge ? (
+                        <div className={styles.largeTree} role="note">
+                            This tree is too large or deeply nested for safe
+                            interactive rendering. Search covers the first{' '}
+                            {nodeCount} nodes; Raw and Download preserve the
+                            complete artifact.
+                        </div>
+                    ) : loadState.data &&
+                      typeof loadState.data === 'object' ? (
+                        <div className={styles.treeWrap}>
+                            <JsonView
+                                data={loadState.data}
+                                style={TREE_STYLES}
+                                shouldExpandNode={shouldExpandNode}
+                                clickToExpandNode
+                                aria-label={`${artifact.title} JSON tree. Use arrow keys to navigate and expand branches.`}
+                            />
+                        </div>
+                    ) : (
+                        <pre className={styles.primitive}>
+                            {JSON.stringify(loadState.data)}
+                        </pre>
+                    )}
+                    <p className={styles.keyboardHelp}>
+                        Keyboard: Tab enters the tree; Up and Down move between
+                        branches; Left and Right collapse or expand the focused
+                        branch.
+                    </p>
+                </>
+            )}
+        </section>
+    )
+}

--- a/components/JsonArtifactViewer.module.css
+++ b/components/JsonArtifactViewer.module.css
@@ -1,0 +1,407 @@
+.viewer {
+    width: min(1120px, calc(100% - 32px));
+    margin: 0 auto;
+    padding: 56px 0 72px;
+}
+
+.header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 28px;
+    padding-bottom: 28px;
+    border-bottom: 2px solid var(--rule);
+}
+
+.header h1 {
+    margin: 8px 0 0;
+    font-size: clamp(2rem, 5vw, 3.25rem);
+    line-height: 1.04;
+}
+
+.description {
+    max-width: 700px;
+    margin: 14px 0 0;
+    color: var(--ink-2);
+    line-height: 1.6;
+}
+
+.source {
+    margin: 10px 0 0;
+    overflow-wrap: anywhere;
+    color: var(--ink-3);
+    font-family: var(--font-mono);
+    font-size: 12px;
+    line-height: 1.55;
+}
+
+.fileActions,
+.treeActions,
+.selectionActions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.fileActions {
+    flex: 0 0 auto;
+}
+
+.integrity {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 18px;
+    margin: 18px 0 0;
+    padding: 18px;
+    border: 1px solid var(--hairline);
+    border-radius: 12px;
+    background: var(--panel);
+}
+
+.integrity div {
+    min-width: 0;
+}
+
+.integrity dt {
+    color: var(--ink-3);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.11em;
+    text-transform: uppercase;
+}
+
+.integrity dd {
+    margin: 6px 0 0;
+    overflow-wrap: anywhere;
+    font-family: var(--font-mono);
+    font-size: 12px;
+}
+
+.verified {
+    display: inline-flex;
+    align-items: center;
+    min-height: 26px;
+    padding: 2px 9px;
+    border: 1px solid var(--accent);
+    border-radius: 999px;
+    color: var(--accent);
+    font-family: var(--font-body);
+    font-weight: 700;
+}
+
+.message {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 18px;
+    min-height: 100px;
+    margin-top: 18px;
+    padding: 22px;
+    border: 1px solid var(--hairline);
+    border-radius: 12px;
+    background: var(--panel);
+}
+
+.message p {
+    margin: 8px 0 0;
+}
+
+.error {
+    border-color: var(--focus-ring);
+}
+
+.spinner {
+    width: 18px;
+    height: 18px;
+    border: 2px solid var(--hairline);
+    border-top-color: var(--accent);
+    border-radius: 999px;
+    animation: spin 800ms linear infinite;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .spinner {
+        animation: none;
+        border-color: var(--accent);
+    }
+}
+
+.toolbar {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 20px;
+    margin-top: 28px;
+}
+
+.search {
+    display: grid;
+    flex: 1 1 520px;
+    gap: 7px;
+    max-width: 660px;
+    color: var(--ink-2);
+    font-size: 13px;
+    font-weight: 600;
+}
+
+.search input {
+    width: 100%;
+    min-height: 44px;
+    padding: 9px 12px;
+    border: 1px solid var(--hairline);
+    border-radius: 8px;
+    background: var(--panel);
+    color: var(--ink);
+    font: inherit;
+}
+
+.facts {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 14px;
+}
+
+.facts span {
+    padding: 5px 9px;
+    border: 1px solid var(--hairline);
+    border-radius: 999px;
+    color: var(--ink-2);
+    font-family: var(--font-mono);
+    font-size: 10px;
+}
+
+.results {
+    margin-top: 18px;
+    padding: 16px;
+    border: 1px solid var(--hairline);
+    border-radius: 10px;
+    background: var(--panel);
+}
+
+.resultsHeading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.resultsHeading button,
+.selectionActions button {
+    min-height: 36px;
+    padding: 6px 10px;
+    border: 1px solid var(--hairline);
+    border-radius: 7px;
+    background: transparent;
+    color: var(--accent);
+    font: inherit;
+}
+
+.results ul {
+    display: grid;
+    gap: 5px;
+    max-height: 300px;
+    margin: 12px 0 0;
+    padding: 0;
+    overflow: auto;
+    list-style: none;
+}
+
+.results li button {
+    display: grid;
+    width: 100%;
+    min-height: 44px;
+    gap: 3px;
+    padding: 8px 10px;
+    border: 0;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--ink);
+    text-align: left;
+}
+
+.results li button:hover {
+    background: var(--ground);
+}
+
+.results li span {
+    overflow-wrap: anywhere;
+    font-family: var(--font-mono);
+    font-size: 12px;
+}
+
+.results li small {
+    overflow: hidden;
+    color: var(--ink-3);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.selection {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 22px;
+    margin-top: 18px;
+    padding: 16px;
+    border-left: 3px solid var(--accent);
+    background: var(--panel);
+}
+
+.selection p {
+    margin: 4px 0 0;
+}
+
+.selectionControls {
+    display: grid;
+    justify-items: end;
+    gap: 7px;
+}
+
+.copyStatus,
+.keyboardHelp {
+    color: var(--ink-3);
+    font-size: 11px;
+}
+
+.treeWrap,
+.primitive {
+    margin: 18px 0 0;
+    padding: 18px;
+    overflow: auto;
+    border: 1px solid var(--inset-border);
+    border-radius: 10px;
+    background: var(--inset-bg);
+    color: var(--inset-text);
+    font-family: var(--font-mono);
+    font-size: 13px;
+    line-height: 1.55;
+}
+
+.tree {
+    min-width: max-content;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}
+
+.treeChildren {
+    margin: 0;
+    padding: 0;
+}
+
+.treeNode {
+    margin: 0;
+    padding: 0 10px;
+}
+
+.treeToggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    min-height: 24px;
+    margin-right: 3px;
+    color: var(--inset-text);
+    font-size: 15px;
+    user-select: none;
+}
+
+.treeToggleCollapsed::after {
+    content: '\25B8';
+}
+
+.treeToggleExpanded::after {
+    content: '\25BE';
+}
+
+.treeCollapsedContent {
+    margin-right: 5px;
+    color: #9ca5b0;
+}
+
+.treeCollapsedContent::after {
+    content: '…';
+}
+
+.treeLabel {
+    margin-right: 5px;
+    color: #a7d9ba;
+    font-weight: 650;
+}
+
+.treeLabelClickable {
+    cursor: pointer;
+}
+
+.treeNull,
+.treeBoolean {
+    color: #e3b34f;
+}
+
+.treeNumber {
+    color: #8fc7ff;
+}
+
+.treeString {
+    color: #d9dee6;
+}
+
+.treeOther,
+.treePunctuation {
+    color: #aeb6c0;
+}
+
+.largeTree {
+    margin-top: 18px;
+    padding: 16px;
+    border: 1px solid var(--focus-ring);
+    border-radius: 10px;
+    background: var(--panel);
+    line-height: 1.6;
+}
+
+.keyboardHelp {
+    margin: 9px 0 0;
+}
+
+@media (max-width: 720px) {
+    .viewer {
+        width: min(100% - 24px, 1120px);
+        padding-top: 36px;
+    }
+
+    .header,
+    .toolbar,
+    .selection {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .fileActions a,
+    .treeActions button {
+        min-height: 44px;
+    }
+
+    .integrity {
+        grid-template-columns: 1fr;
+    }
+
+    .search {
+        flex-basis: auto;
+    }
+
+    .selectionControls {
+        justify-items: stretch;
+    }
+
+    .selectionActions button {
+        flex: 1 1 auto;
+        min-height: 44px;
+    }
+}

--- a/components/LendingWorkflowDemo.js
+++ b/components/LendingWorkflowDemo.js
@@ -1,4 +1,5 @@
 import Clip from './Clip'
+import JsonArtifactLink from './JsonArtifactLink'
 import processStyles from './HowItWorks.module.css'
 import styles from './LendingWorkflowDemo.module.css'
 
@@ -175,9 +176,9 @@ export default function LendingWorkflowDemo() {
                         with Frappe Technologies Pvt. Ltd.; Frappe is its registered
                         trademark.
                     </p>
-                    <a href="/lending-demo/provenance.json">
+                    <JsonArtifactLink source="/lending-demo/provenance.json">
                         Inspect evidence manifest
-                    </a>
+                    </JsonArtifactLink>
                 </div>
             </div>
         </section>

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -498,7 +498,10 @@ describe('public product truth', () => {
         cy.contains(/Pause animation|Play animation/).should('not.exist')
         cy.contains('Inspect evidence manifest')
             .should('have.attr', 'href')
-            .and('equal', '/lending-demo/provenance.json')
+            .and(
+                'equal',
+                '/artifacts/json?source=%2Flending-demo%2Fprovenance.json'
+            )
         cy.get('img[alt*="OpenEMR"]').should('not.exist')
 
         cy.visit('/solutions/insurance')
@@ -515,7 +518,10 @@ describe('public product truth', () => {
             .should('be.visible')
         cy.contains('Inspect evidence manifest')
             .should('have.attr', 'href')
-            .and('equal', '/insurance-demo/provenance.json')
+            .and(
+                'equal',
+                '/artifacts/json?source=%2Finsurance-demo%2Fprovenance.json'
+            )
 
         cy.viewport(375, 812)
         cy.visit('/solutions/lending')

--- a/cypress/e2e/json-artifact-viewer.cy.js
+++ b/cypress/e2e/json-artifact-viewer.cy.js
@@ -1,13 +1,13 @@
 describe('public JSON artifact viewer', () => {
     const viewer = '/artifacts/json?source=%2Fstatus.json'
 
-    it('opens an allowlisted artifact with verified integrity and useful controls', () => {
+    it('opens an allowlisted artifact with a computed digest and useful controls', () => {
         cy.visit('/workflows')
         cy.contains('a', 'status manifest').click()
         cy.location('pathname').should('equal', '/artifacts/json')
         cy.location('search').should('include', 'source=%2Fstatus.json')
 
-        cy.contains('Integrity').parent().should('contain.text', 'Verified')
+        cy.get('dt').contains('Loaded SHA-256').parent().should('be.visible')
         cy.get('a[href="/status.json"]').should('have.length', 2)
         cy.get('input[type="search"]').type('citrix')
         cy.get('[aria-label="JSON search results"] li button').first().click()
@@ -30,7 +30,7 @@ describe('public JSON artifact viewer', () => {
     it('keeps the evidence controls usable on a small screen', () => {
         cy.viewport(375, 760)
         cy.visit(viewer)
-        cy.contains('Integrity').parent().should('contain.text', 'Verified')
+        cy.get('dt').contains('Loaded SHA-256').parent().should('be.visible')
         cy.document().then((document) => {
             expect(document.documentElement.scrollWidth).to.be.at.most(375)
         })

--- a/cypress/e2e/json-artifact-viewer.cy.js
+++ b/cypress/e2e/json-artifact-viewer.cy.js
@@ -1,0 +1,38 @@
+describe('public JSON artifact viewer', () => {
+    const viewer = '/artifacts/json?source=%2Fstatus.json'
+
+    it('opens an allowlisted artifact with verified integrity and useful controls', () => {
+        cy.visit('/workflows')
+        cy.contains('a', 'status manifest').click()
+        cy.location('pathname').should('equal', '/artifacts/json')
+        cy.location('search').should('include', 'source=%2Fstatus.json')
+
+        cy.contains('Integrity').parent().should('contain.text', 'Verified')
+        cy.get('a[href="/status.json"]').should('have.length', 2)
+        cy.get('input[type="search"]').type('citrix')
+        cy.get('[aria-label="JSON search results"] li button').first().click()
+        cy.contains('Focused value').parent().should('contain.text', '$')
+        cy.location('search').should('include', 'pointer=')
+        cy.reload()
+        cy.contains('Focused value').parent().should('contain.text', '$')
+        cy.get('[aria-label*="JSON tree"]').should('be.visible')
+    })
+
+    it('does not turn unknown paths into a fetch surface', () => {
+        cy.request({
+            url: '/artifacts/json?source=https%3A%2F%2Fexample.com%2Fx.json',
+            failOnStatusCode: false,
+        })
+            .its('status')
+            .should('equal', 404)
+    })
+
+    it('keeps the evidence controls usable on a small screen', () => {
+        cy.viewport(375, 760)
+        cy.visit(viewer)
+        cy.contains('Integrity').parent().should('contain.text', 'Verified')
+        cy.document().then((document) => {
+            expect(document.documentElement.scrollWidth).to.be.at.most(375)
+        })
+    })
+})

--- a/lib/publicJsonArtifacts.mjs
+++ b/lib/publicJsonArtifacts.mjs
@@ -1,0 +1,239 @@
+export const MAX_JSON_ARTIFACT_BYTES = 5 * 1024 * 1024
+export const MAX_INDEXED_JSON_NODES = 20_000
+export const MAX_JSON_TREE_DEPTH = 100
+export const MAX_JSON_SEARCH_RESULTS = 100
+
+/**
+ * Exact, committed public artifacts that may be opened by the interactive
+ * viewer. This is deliberately a registry rather than a path-prefix rule: the
+ * viewer must never become a general same-origin fetch surface.
+ *
+ * The matching test recomputes every digest from public/ so changing an
+ * artifact requires an intentional registry update in the same review.
+ */
+export const PUBLIC_JSON_ARTIFACTS = Object.freeze({
+    '/status.json': Object.freeze({
+        source: '/status.json',
+        fileName: 'status.json',
+        format: 'json',
+        title: 'OpenAdapt product status',
+        description:
+            'The canonical machine-readable release, capability, evidence, and deployment status.',
+        sha256: '5b9a99e52a4e020d9a72b7747a52c522256b60c0b29a549eee215eb6ec5586b9',
+    }),
+    '/desktop-preview/MANIFEST.json': Object.freeze({
+        source: '/desktop-preview/MANIFEST.json',
+        fileName: 'MANIFEST.json',
+        format: 'json',
+        title: 'Desktop preview media manifest',
+        description:
+            'Capture provenance and content hashes for the public Desktop screenshots.',
+        sha256: '8c0c67b7af7d4cedbf93175e4a74d1a7ac7f19b799e309dbeb044cf8dced30ee',
+    }),
+    '/lending-demo/provenance.json': Object.freeze({
+        source: '/lending-demo/provenance.json',
+        fileName: 'provenance.json',
+        format: 'json',
+        title: 'Frappe Lending reference evidence',
+        description:
+            'Application versions, trial scope, effect checks, and media hashes for the lending reference.',
+        sha256: '14b8f6893a4a008f42d7b3f57152a41cfdf4fdad943a15be72c77bd328e5fe18',
+    }),
+    '/insurance-demo/provenance.json': Object.freeze({
+        source: '/insurance-demo/provenance.json',
+        fileName: 'provenance.json',
+        format: 'json',
+        title: 'openIMIS reference evidence',
+        description:
+            'Application version, trial scope, effect checks, and media hashes for the insurance reference.',
+        sha256: '47b09adf7d96c2a206aa63349f147b3020ca68c982761cc80739ee880e9ef93e',
+    }),
+    '/how-it-works/MANIFEST.json': Object.freeze({
+        source: '/how-it-works/MANIFEST.json',
+        fileName: 'MANIFEST.json',
+        format: 'json',
+        title: 'Reference footage manifest',
+        description:
+            'Source and content-hash provenance for the public workflow footage.',
+        sha256: '7e650141f3772d979cb58b83d162df7b7d1f4e530d93c2b64de53c48f5845029',
+    }),
+    '/product-preview/MANIFEST.json': Object.freeze({
+        source: '/product-preview/MANIFEST.json',
+        fileName: 'MANIFEST.json',
+        format: 'json',
+        title: 'Product preview media manifest',
+        description:
+            'Content hashes and capture provenance for the public product preview.',
+        sha256: '852fc2edf84b6e27b4e62ba35d7b31fd3893a638c8a3eb2de79970ec3447cf31',
+    }),
+    '/cloud-preview/provenance.json': Object.freeze({
+        source: '/cloud-preview/provenance.json',
+        fileName: 'provenance.json',
+        format: 'json',
+        title: 'Cloud preview provenance',
+        description:
+            'Capture provenance and public-data boundary for the Cloud dashboard preview.',
+        sha256: 'f2e2f947554a6173cc87a9d324544199de428a414d608417da526c6df0233a9d',
+    }),
+    '/images/frappe-lending-reference.provenance.json': Object.freeze({
+        source: '/images/frappe-lending-reference.provenance.json',
+        fileName: 'frappe-lending-reference.provenance.json',
+        format: 'json',
+        title: 'Frappe Lending image provenance',
+        description:
+            'Capture source and content hash for the Frappe Lending reference image.',
+        sha256: 'e5d49793f4e953dafd3549b608d89f66c5bfd777fe39591c6690e94d51013b79',
+    }),
+})
+
+export function getPublicJsonArtifact(source) {
+    if (typeof source !== 'string') return null
+    return PUBLIC_JSON_ARTIFACTS[source] || null
+}
+
+export function isJsonPointer(pointer) {
+    return (
+        pointer === '' ||
+        (typeof pointer === 'string' &&
+            pointer.startsWith('/') &&
+            pointer.length <= 2048 &&
+            !/[\u0000-\u001f\u007f]/.test(pointer) &&
+            !/~(?:[^01]|$)/.test(pointer))
+    )
+}
+
+export function publicJsonViewerHref({ source, pointer = '' }) {
+    const artifact = getPublicJsonArtifact(source)
+    if (!artifact || !isJsonPointer(pointer)) return null
+
+    const params = new URLSearchParams({ source: artifact.source })
+    if (pointer) params.set('pointer', pointer)
+    return `/artifacts/json?${params.toString()}`
+}
+
+export function isExactPublicArtifactResponseUrl(responseUrl, origin, source) {
+    const artifact = getPublicJsonArtifact(source)
+    if (!artifact) return false
+    try {
+        const expected = new URL(artifact.source, origin)
+        const actual = new URL(responseUrl)
+        return (
+            actual.origin === expected.origin &&
+            actual.pathname === expected.pathname &&
+            actual.search === '' &&
+            actual.hash === ''
+        )
+    } catch {
+        return false
+    }
+}
+
+export function parseJsonArtifact(text, format) {
+    if (format === 'json') return JSON.parse(text)
+    if (format !== 'jsonl') throw new Error('Unsupported JSON artifact format.')
+
+    const values = []
+    for (const [index, line] of text.split(/\r?\n/).entries()) {
+        if (!line.trim()) continue
+        try {
+            values.push(JSON.parse(line))
+        } catch {
+            throw new Error(`JSON Lines record ${index + 1} is not valid JSON.`)
+        }
+    }
+    return values
+}
+
+function pointerToken(value) {
+    return String(value).replaceAll('~', '~0').replaceAll('/', '~1')
+}
+
+function jsonPath(parent, key) {
+    if (typeof key === 'number') return `${parent}[${key}]`
+    if (/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key)) return `${parent}.${key}`
+    return `${parent}[${JSON.stringify(key)}]`
+}
+
+export function buildJsonArtifactIndex(
+    data,
+    limit = MAX_INDEXED_JSON_NODES
+) {
+    const nodes = []
+    const byPointer = new Map()
+    const objectPointers = new WeakMap()
+    let maxDepth = 0
+    let truncated = false
+    const pending = [{ value: data, pointer: '', path: '$', depth: 0 }]
+
+    while (pending.length) {
+        if (nodes.length >= limit) {
+            truncated = true
+            break
+        }
+        const current = pending.pop()
+        nodes.push(current)
+        byPointer.set(current.pointer, current)
+        maxDepth = Math.max(maxDepth, current.depth)
+
+        if (!current.value || typeof current.value !== 'object') continue
+        objectPointers.set(current.value, current.pointer)
+        const entries = Array.isArray(current.value)
+            ? current.value.map((value, index) => [index, value])
+            : Object.entries(current.value)
+
+        for (let index = entries.length - 1; index >= 0; index -= 1) {
+            const [key, value] = entries[index]
+            pending.push({
+                value,
+                pointer: `${current.pointer}/${pointerToken(key)}`,
+                path: jsonPath(current.path, key),
+                depth: current.depth + 1,
+            })
+        }
+    }
+
+    return { nodes, byPointer, objectPointers, maxDepth, truncated }
+}
+
+function valuePreview(value) {
+    if (Array.isArray(value)) return `[${value.length} items]`
+    if (value && typeof value === 'object') {
+        return `{${Object.keys(value).length} fields}`
+    }
+    return JSON.stringify(value)
+}
+
+export function searchJsonIndex(
+    index,
+    query,
+    limit = MAX_JSON_SEARCH_RESULTS
+) {
+    const needle = query.trim().toLocaleLowerCase()
+    if (!needle) return { matches: [], hasMore: false }
+
+    const matches = []
+    let hasMore = false
+    for (const node of index.nodes) {
+        const haystack = `${node.path}\n${jsonValuePreview(
+            node.value
+        )}`.toLocaleLowerCase()
+        if (!haystack.includes(needle)) continue
+        if (matches.length >= limit) {
+            hasMore = true
+            break
+        }
+        matches.push(node)
+    }
+    return { matches, hasMore }
+}
+
+export function copyableJsonValue(value) {
+    if (typeof value === 'string') return value
+    if (value === null || typeof value !== 'object') return String(value)
+    return JSON.stringify(value, null, 2)
+}
+
+export function jsonValuePreview(value) {
+    const preview = valuePreview(value)
+    return preview.length > 180 ? `${preview.slice(0, 177)}…` : preview
+}

--- a/lib/publicJsonArtifacts.mjs
+++ b/lib/publicJsonArtifacts.mjs
@@ -19,7 +19,10 @@ export const PUBLIC_JSON_ARTIFACTS = Object.freeze({
         title: 'OpenAdapt product status',
         description:
             'The canonical machine-readable release, capability, evidence, and deployment status.',
-        sha256: '5b9a99e52a4e020d9a72b7747a52c522256b60c0b29a549eee215eb6ec5586b9',
+        // status.json changes with routine releases. Keep its exact path
+        // allowlisted and show the loaded digest, but do not make every status
+        // update manually synchronize a second copy of the same hash.
+        sha256: null,
     }),
     '/desktop-preview/MANIFEST.json': Object.freeze({
         source: '/desktop-preview/MANIFEST.json',

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
                 "react-chartjs-2": "^5.2.0",
                 "react-dom": "^18.2.0",
                 "react-fontawesome": "^1.7.1",
+                "react-json-view-lite": "2.5.0",
                 "react-slick": "^0.30.2",
                 "simplex-noise": "^4.0.3",
                 "stripe": "^16.12.0"
@@ -6554,6 +6555,18 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
+        "node_modules/react-json-view-lite": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-2.5.0.tgz",
+            "integrity": "sha512-tk7o7QG9oYyELWHL8xiMQ8x4WzjCzbWNyig3uexmkLb54r8jO0yH3WCWx8UZS0c49eSA4QUmG5caiRJ8fAn58g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0"
+            }
+        },
         "node_modules/react-slick": {
             "version": "0.30.2",
             "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.30.2.tgz",
@@ -12464,6 +12477,12 @@
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "react-json-view-lite": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-2.5.0.tgz",
+            "integrity": "sha512-tk7o7QG9oYyELWHL8xiMQ8x4WzjCzbWNyig3uexmkLb54r8jO0yH3WCWx8UZS0c49eSA4QUmG5caiRJ8fAn58g==",
+            "requires": {}
         },
         "react-slick": {
             "version": "0.30.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.2.0",
         "react-fontawesome": "^1.7.1",
+        "react-json-view-lite": "2.5.0",
         "react-slick": "^0.30.2",
         "simplex-noise": "^4.0.3",
         "stripe": "^16.12.0"

--- a/pages/artifacts/json.js
+++ b/pages/artifacts/json.js
@@ -1,0 +1,46 @@
+import Head from 'next/head'
+
+import Footer from '@components/Footer'
+import JsonArtifactViewer from '@components/JsonArtifactViewer'
+import {
+    getPublicJsonArtifact,
+    isJsonPointer,
+} from '../../lib/publicJsonArtifacts.mjs'
+
+export async function getServerSideProps({ query, res }) {
+    const source = typeof query.source === 'string' ? query.source : ''
+    const pointer = typeof query.pointer === 'string' ? query.pointer : ''
+    const artifact = getPublicJsonArtifact(source)
+    if (!artifact || !isJsonPointer(pointer)) return { notFound: true }
+
+    res.setHeader(
+        'Cache-Control',
+        'public, max-age=0, s-maxage=3600, stale-while-revalidate=86400'
+    )
+    return { props: { artifact, initialPointer: pointer } }
+}
+
+export default function PublicJsonArtifactPage({ artifact, initialPointer }) {
+    const canonical = `https://openadapt.ai/artifacts/json?source=${encodeURIComponent(
+        artifact.source
+    )}`
+
+    return (
+        <div className="min-h-screen bg-ground text-ink">
+            <Head>
+                <title>{`${artifact.title} | OpenAdapt evidence`}</title>
+                <meta name="description" content={artifact.description} />
+                <meta name="robots" content="noindex,follow" />
+                <link rel="canonical" href={canonical} />
+                <meta property="og:title" content={artifact.title} />
+                <meta property="og:description" content={artifact.description} />
+                <meta property="og:url" content={canonical} />
+            </Head>
+            <JsonArtifactViewer
+                artifact={artifact}
+                initialPointer={initialPointer}
+            />
+            <Footer />
+        </div>
+    )
+}

--- a/pages/workflows.js
+++ b/pages/workflows.js
@@ -2,6 +2,7 @@ import Head from 'next/head'
 import Link from 'next/link'
 
 import Footer from '@components/Footer'
+import JsonArtifactLink from '@components/JsonArtifactLink'
 import { track, EVENTS } from 'utils/analytics'
 import { CATALOG, SUBSTRATE_MATURITY } from 'data/workflowCatalog'
 
@@ -237,14 +238,12 @@ export default function WorkflowsPage() {
                     </ul>
                     <p className="mt-3 text-xs leading-relaxed text-ink-3">
                         Labels reconcile to the canonical{' '}
-                        <a
-                            href="/status.json"
-                            target="_blank"
-                            rel="noopener noreferrer"
+                        <JsonArtifactLink
+                            source="/status.json"
                             className="text-accent underline"
                         >
                             status manifest
-                        </a>
+                        </JsonArtifactLink>
                         . Available means the backend ships in the released
                         compiler/runtime. The manifest records its exact bounded
                         evidence and whether execution is managed or

--- a/tests/jsonArtifacts.test.js
+++ b/tests/jsonArtifacts.test.js
@@ -1,0 +1,119 @@
+const assert = require('node:assert/strict')
+const crypto = require('node:crypto')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+const root = path.join(__dirname, '..')
+
+async function subject() {
+    return import('../lib/publicJsonArtifacts.mjs')
+}
+
+function publicJsonFiles(directory = path.join(root, 'public')) {
+    const files = []
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+        const absolute = path.join(directory, entry.name)
+        if (entry.isDirectory()) files.push(...publicJsonFiles(absolute))
+        else if (/\.jsonl?$/.test(entry.name)) {
+            files.push(`/${path.relative(path.join(root, 'public'), absolute)}`)
+        }
+    }
+    return files.sort()
+}
+
+test('the exact public JSON allowlist is complete and hash-bound', async () => {
+    const {
+        PUBLIC_JSON_ARTIFACTS,
+        MAX_JSON_ARTIFACT_BYTES,
+        parseJsonArtifact,
+    } = await subject()
+    assert.deepEqual(Object.keys(PUBLIC_JSON_ARTIFACTS).sort(), publicJsonFiles())
+
+    for (const artifact of Object.values(PUBLIC_JSON_ARTIFACTS)) {
+        const bytes = fs.readFileSync(
+            path.join(root, 'public', artifact.source.slice(1))
+        )
+        assert.ok(bytes.byteLength <= MAX_JSON_ARTIFACT_BYTES)
+        assert.equal(
+            crypto.createHash('sha256').update(bytes).digest('hex'),
+            artifact.sha256
+        )
+        assert.notEqual(
+            parseJsonArtifact(bytes.toString('utf8'), artifact.format),
+            undefined
+        )
+    }
+})
+
+test('viewer URLs reject remote, API, traversal, query, and unregistered paths', async () => {
+    const { publicJsonViewerHref } = await subject()
+
+    assert.equal(
+        publicJsonViewerHref({ source: '/status.json' }),
+        '/artifacts/json?source=%2Fstatus.json'
+    )
+    for (const source of [
+        'https://example.com/status.json',
+        '//example.com/status.json',
+        '/api/repository-stats.json',
+        '/../status.json',
+        '/status.json?next=https://example.com',
+        '/not-registered.json',
+    ]) {
+        assert.equal(publicJsonViewerHref({ source }), null, source)
+    }
+})
+
+test('redirected artifact responses must retain the exact registered URL', async () => {
+    const { isExactPublicArtifactResponseUrl } = await subject()
+    const origin = 'https://openadapt.ai'
+
+    assert.equal(
+        isExactPublicArtifactResponseUrl(
+            'https://openadapt.ai/status.json',
+            origin,
+            '/status.json'
+        ),
+        true
+    )
+    assert.equal(
+        isExactPublicArtifactResponseUrl(
+            'https://cdn.example/status.json',
+            origin,
+            '/status.json'
+        ),
+        false
+    )
+    assert.equal(
+        isExactPublicArtifactResponseUrl(
+            'https://openadapt.ai/status.json?raw=1',
+            origin,
+            '/status.json'
+        ),
+        false
+    )
+})
+
+test('JSON pointers, JSON Lines, indexing, and search share one contract', async () => {
+    const {
+        buildJsonArtifactIndex,
+        isJsonPointer,
+        parseJsonArtifact,
+        searchJsonIndex,
+    } = await subject()
+    const parsed = parseJsonArtifact(
+        '{"outcome":"VERIFIED"}\n{"a/b":{"~key":2}}\n',
+        'jsonl'
+    )
+    const index = buildJsonArtifactIndex(parsed)
+
+    assert.equal(index.byPointer.get('/0/outcome').value, 'VERIFIED')
+    assert.equal(index.byPointer.get('/1/a~1b/~0key').value, 2)
+    assert.deepEqual(
+        searchJsonIndex(index, 'verified').matches.map((node) => node.pointer),
+        ['/0/outcome']
+    )
+    assert.equal(isJsonPointer('/1/a~1b/~0key'), true)
+    assert.equal(isJsonPointer('/bad~escape'), false)
+})

--- a/tests/jsonArtifacts.test.js
+++ b/tests/jsonArtifacts.test.js
@@ -22,7 +22,7 @@ function publicJsonFiles(directory = path.join(root, 'public')) {
     return files.sort()
 }
 
-test('the exact public JSON allowlist is complete and hash-bound', async () => {
+test('the exact public JSON allowlist is complete and stable evidence is hash-bound', async () => {
     const {
         PUBLIC_JSON_ARTIFACTS,
         MAX_JSON_ARTIFACT_BYTES,
@@ -35,10 +35,14 @@ test('the exact public JSON allowlist is complete and hash-bound', async () => {
             path.join(root, 'public', artifact.source.slice(1))
         )
         assert.ok(bytes.byteLength <= MAX_JSON_ARTIFACT_BYTES)
-        assert.equal(
-            crypto.createHash('sha256').update(bytes).digest('hex'),
-            artifact.sha256
-        )
+        if (artifact.sha256) {
+            assert.equal(
+                crypto.createHash('sha256').update(bytes).digest('hex'),
+                artifact.sha256
+            )
+        } else {
+            assert.equal(artifact.source, '/status.json')
+        }
         assert.notEqual(
             parseJsonArtifact(bytes.toString('utf8'), artifact.format),
             undefined


### PR DESCRIPTION
## What changed

- adds a canonical, bookmarkable read-only viewer at `/artifacts/json?source=...`
- routes the current status, Desktop media, Frappe Lending, and openIMIS artifact links through that viewer
- provides accessible tree navigation, search, focused path/value copying, deep links, raw/download controls, loading/error/large-tree handling, and responsive layout
- SHA-binds stable provenance/evidence manifests and refuses mismatched or redirected content; the frequently updated status manifest displays the digest computed from the exact bytes loaded
- adds exact `react-json-view-lite` 2.5.0 (MIT) with the notice recorded

## Security boundary

This is not a generic fetch proxy. Only exact entries in the committed public-artifact registry are accepted. Remote URLs, API paths, traversal, query-bearing sources, redirects, and unregistered files are rejected. Interactive parsing is bounded to 5 MiB; raw machine downloads remain unchanged.

Stable evidence manifests carry independently committed expected digests. `status.json` is deliberately path-bound rather than prebound to a second manually synchronized digest because it changes during routine releases; the viewer still computes and displays its loaded SHA-256 without making status publication brittle.

External GitHub result files remain direct source links rather than being mirrored into a second potentially stale evidence copy.

## Validation

- `npm test` — 138/138 pass
- `npm run build` — production build passes; viewer route is 11.1 kB
- focused Chrome Cypress — 3/3 pass, including exact allowlist refusal and 375px mobile overflow
- desktop visual smoke reviewed
- `git diff --check`
