### PR TITLE
fix: prevent query-blind JSON viewer caching

### DIFF
--- a/pages/artifacts/json.js
+++ b/pages/artifacts/json.js
@@ -8,15 +8,18 @@ import {
 } from '../../lib/publicJsonArtifacts.mjs'
 
 export async function getServerSideProps({ query, res }) {
+    // Netlify's edge cache does not include arbitrary query parameters in its
+    // cache key. `source` and `pointer` select both the artifact and the view,
+    // so caching this HTML by pathname can serve the wrong evidence page (or a
+    // cached success for a rejected source). Keep the route bookmarkable while
+    // requiring every request to be admitted from its exact query.
+    res.setHeader('Cache-Control', 'private, no-store, max-age=0')
+    res.setHeader('Netlify-CDN-Cache-Control', 'no-store')
+
     const source = typeof query.source === 'string' ? query.source : ''
     const pointer = typeof query.pointer === 'string' ? query.pointer : ''
     const artifact = getPublicJsonArtifact(source)
     if (!artifact || !isJsonPointer(pointer)) return { notFound: true }
-
-    res.setHeader(
-        'Cache-Control',
-        'public, max-age=0, s-maxage=3600, stale-while-revalidate=86400'
-    )
     return { props: { artifact, initialPointer: pointer } }
 }
 


### PR DESCRIPTION
## Summary

- disable shared edge caching for the query-addressed JSON evidence viewer
- require every `source` and `pointer` request to pass exact server-side admission
- preserve the bookmarkable viewer route and raw downloads

## Why

Netlify's edge cache keyed the server-rendered page by pathname without the viewer's arbitrary query parameters. A cached valid artifact could therefore be served for a different or rejected `source`. No arbitrary fetch occurred, but the response broke provenance and rejection semantics.

## Validation

- `node --test tests/jsonArtifacts.test.js`
- full 138-test prebuild suite via `npm run build`
- Next.js production build
