### PR TITLE
Align public demo evidence semantics

### DIFF
--- a/components/DentalHaltMoment.js
+++ b/components/DentalHaltMoment.js
@@ -37,8 +37,8 @@ export default function DentalHaltMoment() {
 
             <ReferenceDemoShowcase
                 initialIndustry="insurance"
-                heading="See the governed loop in a public insurance application"
-                intro="Compare a captured demonstration with its compiled replay, then inspect the exact evidence boundary for the result."
+                heading="See the governance mechanism in a public insurance application"
+                intro="This openIMIS clip is a claims-entry reference, not payer-portal eligibility footage. It demonstrates the same capture, deterministic replay, result evidence, and halt mechanism used for an eligibility workflow."
             />
 
             <p className="mx-auto max-w-5xl px-4 pb-12 text-sm">

--- a/components/EvidenceMediaPlayer.js
+++ b/components/EvidenceMediaPlayer.js
@@ -287,7 +287,7 @@ export default function EvidenceMediaPlayer({
                     <div
                         ref={capsuleRef}
                         className={styles.capsule}
-                        aria-label={`OpenAdapt ${phaseLabel.toLowerCase()}`}
+                        aria-label={`OpenAdapt ${phaseLabel.toLowerCase()} in ${application}`}
                         data-overlay-kind="canonical-runtime-state"
                         data-interactive={presentation.evidenceHref ? 'true' : undefined}
                     >
@@ -324,7 +324,7 @@ export default function EvidenceMediaPlayer({
                                 />
                             )}
                         <span className={styles.secondary}>
-                            <span>{application}</span>
+                            <span className={styles.applicationName}>{application}</span>
                             {presentation.secondaryLabels.map((label) => (
                                 <span key={label}>{label}</span>
                             ))}

--- a/components/EvidenceMediaPlayer.module.css
+++ b/components/EvidenceMediaPlayer.module.css
@@ -212,6 +212,11 @@
     content: '·';
 }
 
+.applicationName {
+    color: #cbd5ce;
+    font-weight: 700;
+}
+
 .explanation {
     padding-top: 6px;
     border-top: 1px solid rgba(255, 255, 255, 0.12);

--- a/components/ReferenceDemoShowcase.js
+++ b/components/ReferenceDemoShowcase.js
@@ -166,7 +166,11 @@ export default function ReferenceDemoShowcase({
                     </div>
 
                     <aside className={styles.proof}>
-                        <p className={styles.proofClass}>{demo.evidenceClass}</p>
+                        <p className={styles.proofClass}>
+                            {phase === 'recording'
+                                ? 'Source demonstration · synthetic data'
+                                : demo.evidenceClass}
+                        </p>
                         <h3>{demo.application}</h3>
                         <p className={styles.applicationDetail}>{demo.applicationDetail}</p>
                         <p className={styles.task}>{demo.task}</p>

--- a/cypress/e2e/reference-demo.cy.js
+++ b/cypress/e2e/reference-demo.cy.js
@@ -66,6 +66,9 @@ describe('shared real-application demo', () => {
             .should(($video) =>
                 expect($video[0].currentSrc).to.include('openemr-replay.mp4')
             )
+        cy.get('@showcase')
+            .find('[data-overlay-kind="canonical-runtime-state"]')
+            .should('contain.text', 'OpenEMR')
         cy.get('@showcase').contains('button', 'Guided view').should('be.visible')
         cy.get('@showcase').contains('button', 'Raw footage').click()
         cy.get('@showcase')
@@ -77,6 +80,10 @@ describe('shared real-application demo', () => {
             )
         cy.get('@showcase').contains('button', 'Guided view').click()
         cy.get('@showcase').contains('button', 'Recorded demonstration').click()
+        cy.get('@showcase')
+            .contains('Source demonstration · synthetic data')
+            .should('be.visible')
+        cy.get('@showcase').should('not.contain.text', 'Reference qualification')
         cy.get('@showcase')
             .find('video')
             .should(($video) =>

--- a/tests/executionOverlayTimeline.test.js
+++ b/tests/executionOverlayTimeline.test.js
@@ -210,6 +210,20 @@ test('capsule placement is event-stable and presentation facts require exact bou
         executionRailForBoundContext(activeFrame, context).map(({ state }) => state),
         ['complete', 'active', 'pending']
     )
+    const haltedFrame = frame(6, 'halted')
+    assert.deepEqual(executionRailForBoundContext(haltedFrame, null), [])
+    const exactHaltContext = bindExecutionOverlayContext(haltedFrame, {
+        state_id: haltedFrame.state_id,
+        event_sequence: haltedFrame.event_sequence,
+        execution_stage: 'verify',
+        halt_delivery_class: 'refuted_effect',
+    })
+    assert.deepEqual(
+        executionRailForBoundContext(haltedFrame, exactHaltContext).map(
+            ({ state }) => state
+        ),
+        ['complete', 'complete', 'halted']
+    )
     const presentation = executionOverlayPresentation(activeFrame, context, 12_000)
     assert.equal(presentation.progressLabel, 'Step 1 of 2')
     assert.deepEqual(presentation.secondaryLabels, [


### PR DESCRIPTION
## What changed

- labels source recordings as `Source demonstration · synthetic data` instead of carrying a replay outcome classification into the recording view
- keeps the application name visibly and accessibly present in every exact execution capsule
- preserves the stage-rail rule: canonical runtime phase or exact bound `execution_stage`, otherwise no rail
- clarifies that the Dental page's current openIMIS clip is a claims-entry reference demonstrating the same governance mechanism, not payer-portal eligibility footage

## Why

The website now uses one shared real-application player across the homepage, vertical pages, How it works, and Dental. These changes align its evidence semantics with the Cloud demo without fabricating target or outcome evidence.

## Verification

- `node --test tests/executionOverlayTimeline.test.js` (4/4)
- `npm run build` (131/131 unit tests, exact presentation verifier, 31-page production build)
- `npx cypress run --browser chrome --spec cypress/e2e/reference-demo.cy.js --config baseUrl=http://127.0.0.1:3121,video=false` (8/8 across all shared-player routes, narrow viewport, keyboard tabs, Guided/Raw)
