### PR TITLE
Polish shared evidence player overlay

### DIFF
--- a/components/EvidenceMediaPlayer.js
+++ b/components/EvidenceMediaPlayer.js
@@ -306,7 +306,6 @@ export default function EvidenceMediaPlayer({
                         className={styles.capsule}
                         aria-label={`OpenAdapt ${accessibleModeLabel.toLowerCase()} in ${application}`}
                         data-overlay-kind="canonical-runtime-state"
-                        data-interactive={overlayEvidenceHref ? 'true' : undefined}
                     >
                         <span className={styles.header}>
                             <span className={styles.brand}>
@@ -351,11 +350,6 @@ export default function EvidenceMediaPlayer({
                                 {presentation.explanation}
                             </span>
                         )}
-                        {overlayEvidenceHref && (
-                            <a className={styles.evidenceLink} href={overlayEvidenceHref}>
-                                View execution evidence
-                            </a>
-                        )}
                     </div>
                 )}
             </div>
@@ -396,6 +390,15 @@ export default function EvidenceMediaPlayer({
                     </>
                 ) : (
                     <span className={styles.time}>Looping evidence clip</span>
+                )}
+                {overlayEvidenceHref && (
+                    <a
+                        className={styles.evidenceLink}
+                        href={overlayEvidenceHref}
+                        aria-label={`View evidence for ${application} ${accessibleModeLabel.toLowerCase()}`}
+                    >
+                        Evidence
+                    </a>
                 )}
                 <button
                     type="button"

--- a/components/EvidenceMediaPlayer.module.css
+++ b/components/EvidenceMediaPlayer.module.css
@@ -51,10 +51,6 @@
     backdrop-filter: blur(10px);
 }
 
-.capsule[data-interactive='true'] {
-    pointer-events: auto;
-}
-
 .stage[data-overlay-placement='bottom-left'] .capsule {
     left: 10px;
 }
@@ -226,16 +222,18 @@
 }
 
 .evidenceLink {
-    justify-self: start;
-    min-height: 44px;
-    padding: 8px 12px;
+    display: inline-flex;
+    min-height: 36px;
+    flex: 0 0 auto;
+    align-items: center;
+    padding: 0 10px;
     border: 1px solid rgba(255, 255, 255, 0.22);
     border-radius: 7px;
     background: rgba(255, 255, 255, 0.08);
     color: #f4f7f2;
-    font-size: 12px;
+    font-size: 11px;
     font-weight: 700;
-    line-height: 28px;
+    line-height: 1.2;
     text-decoration: none;
 }
 
@@ -348,6 +346,10 @@
     .controls input {
         order: 3;
         min-width: 100%;
+    }
+
+    .evidenceLink {
+        min-height: 44px;
     }
 }
 

--- a/components/EvidenceMediaPlayer.module.css
+++ b/components/EvidenceMediaPlayer.module.css
@@ -340,16 +340,39 @@
     }
 
     .controls {
-        flex-wrap: wrap;
+        display: grid;
+        grid-template-columns: 44px minmax(0, 1fr) auto 44px;
+        grid-template-rows: auto auto;
+        gap: 4px 8px;
+    }
+
+    .controls > button:first-child {
+        grid-column: 1;
+        grid-row: 1;
     }
 
     .controls input {
-        order: 3;
-        min-width: 100%;
+        grid-column: 2 / 5;
+        grid-row: 1;
+        width: 100%;
+        min-width: 0;
+    }
+
+    .time {
+        grid-column: 1 / 3;
+        grid-row: 2;
+        margin-left: 0;
     }
 
     .evidenceLink {
+        grid-column: 3;
+        grid-row: 2;
         min-height: 44px;
+    }
+
+    .controls > button:last-child {
+        grid-column: 4;
+        grid-row: 2;
     }
 }
 

--- a/cypress/e2e/reference-demo.cy.js
+++ b/cypress/e2e/reference-demo.cy.js
@@ -103,7 +103,7 @@ describe('shared real-application demo', () => {
             cy.get('@player')
                 .should('have.attr', 'data-decoded-frame-index', '1')
                 .then(($player) => $player.find('video')[0].pause())
-                .should('contain.text', 'View execution evidence')
+                .should('contain.text', 'Evidence')
                 .and('contain.text', 'Application network traffic observed')
                 .find('[data-decoded-frame-index="1"]')
                 .should('be.visible')


### PR DESCRIPTION
## What changed
- keeps the runtime status capsule observation-only and moves the evidence CTA into the playback controls
- reduces the in-video footprint to match the proportional density of the Cloud demo while retaining exact status, stage, target, network, model-call, and verification labels
- preserves a 44px evidence target on mobile and the existing compact control on desktop

## Scope
The single shared player powers the homepage, Healthcare, Lending, Insurance, Dental, and How it works. Page-specific copy is unchanged.

## Verification
- live origin/main audit: focused Cypress 11/11 across all six routes
- exact local build: 131/131 tests; four presentation packs verified; 31 pages built
- local focused Cypress: 11/11 including keyboard tabs, 320/390 overflow, exact decoded-frame target binding, capsule collision, raw/guided modes, network wording, and meaningful media loading
- visual review against Cloud #151 desktop/mobile screenshots: target remains unobstructed; the status capsule no longer carries the large button; Evidence remains in the player controls

## Screenshots
- /private/tmp/openadapt-web-demo-consistency/cypress/screenshots/reference-demo.cy.js/frappe-exact-target-desktop.png
- /private/tmp/openadapt-web-demo-consistency/cypress/screenshots/reference-demo.cy.js/frappe-exact-target-mobile.png