### PR TITLE
Compact shared demo status overlay

### DIFF
--- a/components/EvidenceMediaPlayer.js
+++ b/components/EvidenceMediaPlayer.js
@@ -318,16 +318,11 @@ export default function EvidenceMediaPlayer({
                                 {presentation.progressLabel}
                             </span>
                         </span>
-                        {presentation.rail.length > 0 && (
-                            <span className={styles.rail} aria-label="Execution stage">
-                                {presentation.rail.map((item) => (
-                                    <i key={item.label} data-state={item.state}>
-                                        {item.label}
-                                    </i>
-                                ))}
-                            </span>
-                        )}
-                        <strong className={styles.status} data-state={frame.phase}>
+                        <strong
+                            className={styles.status}
+                            data-state={frame.phase}
+                            title={presentation.safetyLabel}
+                        >
                             {presentation.safetyLabel}
                         </strong>
                         {presentation.progressValue !== null &&
@@ -339,17 +334,6 @@ export default function EvidenceMediaPlayer({
                                     aria-label={`Workflow progress: ${presentation.progressValue} of ${presentation.progressMax}`}
                                 />
                             )}
-                        <span className={styles.secondary}>
-                            <span className={styles.applicationName}>{application}</span>
-                            {presentation.secondaryLabels.map((label) => (
-                                <span key={label}>{label}</span>
-                            ))}
-                        </span>
-                        {presentation.expanded && presentation.explanation && (
-                            <span className={styles.explanation}>
-                                {presentation.explanation}
-                            </span>
-                        )}
                     </div>
                 )}
             </div>

--- a/components/EvidenceMediaPlayer.module.css
+++ b/components/EvidenceMediaPlayer.module.css
@@ -37,18 +37,19 @@
     z-index: 2;
     bottom: 10px;
     display: grid;
-    gap: 6px;
+    gap: 5px;
     box-sizing: border-box;
-    width: min(310px, calc(100% - 20px));
+    width: min(260px, calc(100% - 20px));
+    height: 72px;
     min-width: 0;
-    padding: 9px 10px 8px;
+    padding: 8px 10px;
     border: 1px solid rgba(255, 255, 255, 0.2);
     border-radius: 13px;
-    background: rgba(14, 18, 16, 0.92);
+    background: rgba(14, 18, 16, 0.78);
     box-shadow: 0 9px 28px rgba(0, 0, 0, 0.36);
     color: #f4f7f2;
     pointer-events: none;
-    backdrop-filter: blur(10px);
+    backdrop-filter: blur(14px) saturate(110%);
 }
 
 .stage[data-overlay-placement='bottom-left'] .capsule {
@@ -65,9 +66,7 @@
 }
 
 .header,
-.brand,
-.rail,
-.secondary {
+.brand {
     display: flex;
     align-items: center;
 }
@@ -125,45 +124,6 @@
     white-space: nowrap;
 }
 
-.rail {
-    gap: 5px;
-    color: #839087;
-}
-
-.rail i {
-    display: inline-flex;
-    flex: 1 1 0;
-    align-items: center;
-    gap: 4px;
-    font-size: 9px;
-    font-style: normal;
-    font-weight: 700;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-}
-
-.rail i::before {
-    width: 6px;
-    height: 6px;
-    border: 1px solid currentColor;
-    border-radius: 50%;
-    content: '';
-}
-
-.rail i[data-state='active'],
-.rail i[data-state='complete'] {
-    color: #bcefd2;
-}
-
-.rail i[data-state='active']::before,
-.rail i[data-state='complete']::before {
-    background: currentColor;
-}
-
-.rail i[data-state='halted'] {
-    color: #f5bc58;
-}
-
 .status {
     overflow: hidden;
     color: #eef4ef;
@@ -192,33 +152,6 @@
     height: 2px;
     border: 0;
     accent-color: #72e3a6;
-}
-
-.secondary {
-    flex-wrap: wrap;
-    gap: 3px 8px;
-    color: #98a79e;
-    font-size: 10px;
-    line-height: 1.25;
-}
-
-.secondary span + span::before {
-    margin-right: 8px;
-    color: #536158;
-    content: '·';
-}
-
-.applicationName {
-    color: #cbd5ce;
-    font-weight: 700;
-}
-
-.explanation {
-    padding-top: 6px;
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
-    color: #cbd5ce;
-    font-size: 11px;
-    line-height: 1.4;
 }
 
 .evidenceLink {
@@ -317,7 +250,8 @@
         left: auto;
         width: 100%;
         max-width: none;
-        padding: 9px 10px;
+        height: 72px;
+        padding: 8px 10px;
         border: 0;
         border-top: 1px solid rgba(255, 255, 255, 0.16);
         border-radius: 0;
@@ -334,8 +268,7 @@
         font-size: 10px;
     }
 
-    .progressLabel,
-    .secondary {
+    .progressLabel {
         font-size: 9px;
     }
 

--- a/cypress/e2e/reference-demo.cy.js
+++ b/cypress/e2e/reference-demo.cy.js
@@ -104,13 +104,14 @@ describe('shared real-application demo', () => {
                 .should('have.attr', 'data-decoded-frame-index', '1')
                 .then(($player) => $player.find('video')[0].pause())
                 .should('contain.text', 'Evidence')
-                .and('contain.text', 'Application network traffic observed')
                 .find('[data-decoded-frame-index="1"]')
                 .should('be.visible')
                 .then(($target) => {
                     cy.get('@player')
                         .find('[data-overlay-kind="canonical-runtime-state"]')
                         .should('be.visible')
+                        .and('not.contain.text', 'Standard profile')
+                        .and('not.contain.text', 'Independent system check')
                         .and(
                             'have.attr',
                             'aria-label',
@@ -126,8 +127,16 @@ describe('shared real-application demo', () => {
                                 target.top >= capsule.bottom
                             )
                             expect(intersects).to.equal(false)
+                            expect(
+                                Math.round(capsule.height)
+                            ).to.equal(72)
                         })
                 })
+            if (label === 'desktop') {
+                cy.get('@player')
+                    .find('[data-overlay-placement]')
+                    .should('have.attr', 'data-overlay-placement', 'bottom-right')
+            }
             cy.contains('a', 'Qualification pack').should('be.visible')
             cy.get('@player').screenshot(`frappe-exact-target-${label}`)
         })
@@ -145,7 +154,11 @@ describe('shared real-application demo', () => {
             )
         cy.get('@showcase')
             .find('[data-overlay-kind="canonical-runtime-state"]')
-            .should('contain.text', 'OpenEMR')
+            .should(
+                'have.attr',
+                'aria-label',
+                'OpenAdapt verified replay in OpenEMR'
+            )
         cy.get('@showcase').contains('button', 'Guided view').should('be.visible')
         cy.get('@showcase').contains('button', 'Raw footage').click()
         cy.get('@showcase')
@@ -193,8 +206,7 @@ describe('shared real-application demo', () => {
                         'verified-replay/eligible-replay.mp4'
                     )
                 })
-                cy.contains('Local app traffic only · no off-box transmission')
-                    .should('be.visible')
+                cy.contains('Tier 1 SQL').should('be.visible')
                 cy.get('button[data-mode-id="fail_safe_halt"]').click()
                 cy.get('video').should(($video) => {
                     expect($video[0].currentSrc).to.include(

--- a/cypress/e2e/reference-demo.cy.js
+++ b/cypress/e2e/reference-demo.cy.js
@@ -110,8 +110,6 @@ describe('shared real-application demo', () => {
                     cy.get('@player')
                         .find('[data-overlay-kind="canonical-runtime-state"]')
                         .should('be.visible')
-                        .and('not.contain.text', 'Standard profile')
-                        .and('not.contain.text', 'Independent system check')
                         .and(
                             'have.attr',
                             'aria-label',
@@ -127,9 +125,6 @@ describe('shared real-application demo', () => {
                                 target.top >= capsule.bottom
                             )
                             expect(intersects).to.equal(false)
-                            expect(
-                                Math.round(capsule.height)
-                            ).to.equal(72)
                         })
                 })
             if (label === 'desktop') {

--- a/lib/executionOverlayTimeline.js
+++ b/lib/executionOverlayTimeline.js
@@ -620,8 +620,8 @@ export function chooseOverlayPlacement({
         ...(['bottom-left', 'bottom-right'].includes(currentPlacement)
             ? [currentPlacement]
             : []),
-        'bottom-left',
         'bottom-right',
+        'bottom-left',
     ]
     for (const placement of [...new Set(order)]) {
         if (!avoidRegions.some((region) => intersects(candidates[placement], region))) {

--- a/tests/executionOverlayTimeline.test.js
+++ b/tests/executionOverlayTimeline.test.js
@@ -165,7 +165,7 @@ test('capsule placement is event-stable and presentation facts require exact bou
         capsuleWidth: 300,
         capsuleHeight: 90,
     }
-    assert.equal(chooseOverlayPlacement(dimensions), 'bottom-left')
+    assert.equal(chooseOverlayPlacement(dimensions), 'bottom-right')
     assert.equal(
         chooseOverlayPlacement({
             ...dimensions,
@@ -176,9 +176,9 @@ test('capsule placement is event-stable and presentation facts require exact bou
     assert.equal(
         chooseOverlayPlacement({
             ...dimensions,
-            avoidRegions: [{ left: 10, top: 350, width: 310, height: 90 }],
+            avoidRegions: [{ left: 480, top: 350, width: 310, height: 90 }],
         }),
-        'bottom-right'
+        'bottom-left'
     )
     assert.equal(
         chooseOverlayPlacement({


### PR DESCRIPTION
## What

- make the shared Guided-view status capsule compact, translucent, and a stable 72px high
- place it at bottom-right by default and move it left only when the decoded-frame target would be obscured
- keep mobile status outside the media stage
- move profile, runtime, verification-tier, and network detail out of the video overlay while preserving those facts in the adjacent proof card and evidence viewer

## Why

The prior overlay occupied too much of the real application footage and changed size as the workflow advanced. This keeps the application readable while preserving the essential live state: phase, progress, and current status.

## Verification

- `npm test` (131/131)
- `node scripts/verify-reference-presentations.mjs`
- `npm run build`
- focused Chrome Cypress suite for all shared demo routes, desktop/mobile target avoidance, Guided/Raw, VERIFIED/HALTED, and keyboard controls (11/11)

