### PR TITLE
fix: reconcile cross-surface claim with qualification evidence (accurate, not downgraded)

### DIFF
--- a/components/InstallSection.js
+++ b/components/InstallSection.js
@@ -47,7 +47,9 @@ export default function InstallSection() {
                 One command installs the OpenAdapt launcher and governed
                 workflow compiler. The same CLI records, compiles, and replays
                 across browser, Windows, macOS, Linux, RDP, and Citrix under one
-                governed loop. No account or hosted service is required.
+                governed loop; browser runs in production today, and the desktop
+                and remote surfaces run through customer-controlled
+                qualification. No account or hosted service is required.
             </p>
 
             <div className={styles.codeContainer}>

--- a/components/MastHead.js
+++ b/components/MastHead.js
@@ -50,10 +50,13 @@ export default function Home({ githubStats }) {
                                 Automate the UI-only work your APIs can&rsquo;t reach.
                             </h1>
                             <p className="mt-0 mb-4 mx-auto max-w-2xl font-sans font-normal text-base md:text-lg text-ink-2">
-                                OpenAdapt compiles demonstrations into governed
-                                workflows across browser, desktop, RDP, and
-                                Citrix. It verifies consequential results and
-                                halts when it cannot prove the intended outcome.
+                                OpenAdapt compiles demonstrations into one
+                                governed loop across browser, desktop, RDP, and
+                                Citrix. Browser runs in production today;
+                                desktop, RDP, and Citrix run through
+                                customer-controlled qualification. It verifies
+                                consequential results and halts when it cannot
+                                prove the intended outcome.
                             </p>
                             <p className={styles.fitLine}>
                                 Verified business effects · fail-closed execution ·

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -269,7 +269,7 @@ export default function Pricing({ hostedOffer = null }) {
                         priceDetail={
                             hostedOffer?.cadence || LAUNCH_PRICE_CADENCE
                         }
-                        description="Run approved workflows with history, evidence, usage, and governed updates in one managed control plane."
+                        description="For developers and teams evaluating browser workflows on non-regulated data: run approved workflows with history, evidence, usage, and governed updates in one managed control plane. Regulated data and production SLAs are scoped separately through qualification."
                         features={[
                             'Managed execution, evidence, usage, and workflow updates',
                             'Separate from enterprise qualification',

--- a/components/ProductStatus.js
+++ b/components/ProductStatus.js
@@ -47,6 +47,21 @@ export default function ProductStatus() {
                     accessibility elements, and remote visual anchors are never
                     treated as interchangeable.
                 </p>
+                <p className="mx-auto mt-3 max-w-3xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
+                    Browser runs in production today; desktop, RDP, and Citrix
+                    run through customer-controlled qualification. Each surface
+                    carries its own measured acceptance evidence, published per
+                    surface in the{' '}
+                    <a
+                        href="https://docs.openadapt.ai/get-started/what-works-today/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-accent underline"
+                    >
+                        qualification evidence
+                    </a>
+                    .
+                </p>
 
                 <div className="mt-8 rounded-2xl border border-hairline bg-ground p-5 md:p-7">
                     <div className="mt-6 grid gap-4 md:grid-cols-3">

--- a/cypress/e2e/public-surface-coherence.cy.js
+++ b/cypress/e2e/public-surface-coherence.cy.js
@@ -153,10 +153,12 @@ describe('public surface coherence', () => {
                 )
             })
         // The refresh failed, so the committed snapshot survives and is
-        // labelled honestly as a snapshot rather than a fresh fetch.
+        // labelled honestly as last-known counts rather than a fresh fetch. The
+        // committed fallback carries no real observation time, so it shows a
+        // stable label instead of a drifting "snapshot from Nd ago".
         cy.get('[data-testid="footer-repository-source"]').should(
             'contain.text',
-            'GitHub · snapshot'
+            'GitHub · last-known counts'
         )
     })
 })

--- a/tests/repositoryStatsView.test.js
+++ b/tests/repositoryStatsView.test.js
@@ -55,8 +55,13 @@ test('sourceLabel reports an unreachable-GitHub value as "last updated <rel>"', 
     assert.equal(label, 'GitHub · last updated 5m ago')
 })
 
-test('sourceLabel reports the committed snapshot as "snapshot from <rel>"', () => {
-    const label = sourceLabel(
+test('sourceLabel reports the committed snapshot as a stable "last-known counts"', () => {
+    // The committed fallback's timestamp is its authoring time, not a real
+    // GitHub observation, so its label must NOT drift with age. A growing
+    // "snapshot from Nd ago" is what made the footer read inconsistently stale
+    // across pages (fresh "updated 5m ago" on the home page versus an
+    // ever-growing snapshot age everywhere else).
+    const threeDaysAgo = sourceLabel(
         {
             stars: 1648,
             forks: 258,
@@ -66,7 +71,18 @@ test('sourceLabel reports the committed snapshot as "snapshot from <rel>"', () =
         },
         NOW
     )
-    assert.equal(label, 'GitHub · snapshot from 3d ago')
+    const eightDaysAgo = sourceLabel(
+        {
+            stars: 1648,
+            forks: 258,
+            observedAt: new Date(ago(8 * 24 * 60 * 60 * 1000)).toISOString(),
+            source: 'snapshot',
+            stale: true,
+        },
+        NOW
+    )
+    assert.equal(threeDaysAgo, 'GitHub · last-known counts')
+    assert.equal(eightDaysAgo, 'GitHub · last-known counts')
 })
 
 test('sourceLabel never prints NaN when the timestamp is missing', () => {
@@ -78,7 +94,10 @@ test('sourceLabel never prints NaN when the timestamp is missing', () => {
         sourceLabel({ source: 'stale', stale: true }, NOW),
         'GitHub · last-known counts'
     )
-    assert.equal(sourceLabel({ source: 'snapshot' }, NOW), 'GitHub · snapshot')
+    assert.equal(
+        sourceLabel({ source: 'snapshot' }, NOW),
+        'GitHub · last-known counts'
+    )
 })
 
 test('sourceLabel always begins with the honest "GitHub" attribution', () => {

--- a/utils/repositoryStatsView.js
+++ b/utils/repositoryStatsView.js
@@ -29,7 +29,16 @@ function formatRelativeTime(observedAtMs, now = Date.now()) {
 //   - github : a live count observed this session (updated <rel> ago)
 //   - stale  : GitHub was unreachable on the last refresh; show when the last
 //              real count was observed (last updated <rel> ago)
-//   - snapshot: no live count yet; show the committed snapshot's age
+//   - snapshot: no live count yet; the committed fallback's timestamp is its
+//              authoring time, not a real GitHub observation, so it gets a
+//              STABLE "last-known counts" label rather than a relative age.
+//              Rendering a drifting "snapshot from Nd ago" here is what made the
+//              footer read inconsistently stale across pages: the home page
+//              seeds a fresh build-time observation ("updated 5m ago") while
+//              every other page seeds this committed fallback, so a growing
+//              "8d ago" looked like a contradiction. A stable fallback label
+//              keeps the two honest and consistent until the client poll
+//              resolves both to the same live "updated <rel> ago".
 function sourceLabel(stats, now = Date.now()) {
     const rel = formatRelativeTime(Date.parse(stats && stats.observedAt), now)
     if (stats && stats.source === 'github' && !stats.stale) {
@@ -38,7 +47,7 @@ function sourceLabel(stats, now = Date.now()) {
     if (stats && stats.source === 'stale') {
         return rel ? `GitHub · last updated ${rel}` : 'GitHub · last-known counts'
     }
-    return rel ? `GitHub · snapshot from ${rel}` : 'GitHub · snapshot'
+    return 'GitHub · last-known counts'
 }
 
 module.exports = { formatRelativeTime, sourceLabel }


### PR DESCRIPTION
## Problem

A diligent buyer read two live URLs that contradicted each other:

- **Hero (over-claim):** \"OpenAdapt compiles demonstrations into governed workflows **across browser, desktop, RDP, and Citrix**\" — unqualified present tense.
- **Qualification evidence (maximally hedged):** `status.json` / docs `what-works-today` record **browser** as the managed/production substrate and Windows/macOS/Linux/RDP/Citrix as customer-controlled, with bounded per-surface acceptance evidence (Citrix explicitly `ica_hdx_accepted: false`, etc.).

Reading both, a buyer downgraded *everything*. Per the founder's rule, this PR does **not** downgrade the cross-surface story. It keeps the surface-neutral architecture claim and makes the strongest version **accurate**, so hero → matrix tell **one** story.

## Before → after (no claim weakened, only made accurate + consistent)

**Hero (`components/MastHead.js`)**

- Before: \"OpenAdapt compiles demonstrations into governed workflows across browser, desktop, RDP, and Citrix. It verifies consequential results and halts when it cannot prove the intended outcome.\"
- After: \"OpenAdapt compiles demonstrations into **one governed loop** across browser, desktop, RDP, and Citrix. **Browser runs in production today; desktop, RDP, and Citrix run through customer-controlled qualification.** It verifies consequential results and halts when it cannot prove the intended outcome.\"

The cross-surface claim is retained in full; the added sentence is the honest mechanism (the same customer-controlled-qualification framing already used in the docs and `status.json`), not a hedge.

**Install section (`components/InstallSection.js`)** — same production-vs-qualification framing applied to the present-tense \"records, compiles, and replays across browser, Windows, macOS, Linux, RDP, and Citrix\" line.

**On-page cross-surface matrix (`components/ProductStatus.js`)** — added the same framing plus a link to the per-surface **qualification evidence**, so a reader moving hero → matrix sees the per-surface acceptance status as the *measured backing* for the same architecture, not a reversal.

## Smaller live fixes (in scope)

- **Footer staleness** (`utils/repositoryStatsView.js`): the committed fallback snapshot carries an authoring-time timestamp, not a real GitHub observation, so it rendered an ever-growing **\"snapshot from Nd ago\"** while the home page (fresh build-time fetch) showed **\"updated 5m ago\"** — inconsistent staleness across pages. The pure-snapshot state now renders a stable, honest **\"GitHub · last-known counts\"**; live/stale states keep their accurate relative time. Unit test + cypress contract updated.
- **Cloud \"who it is for\"** (`components/Pricing.js`): added one honest sentence — *for developers and teams evaluating browser workflows on non-regulated data; regulated data and production SLAs are scoped separately through qualification* — consistent with the no-SLA / no-regulated / \$500-mo ladder. No pricing numbers or intake/checkout forms touched.

## Out of scope (untouched)

Case-study files, `/contribute`, pricing intake/checkout forms, pricing numbers, and the trust-center SOC 2 statement. The `openadapt-ops` docs (`index.md`, `what-works-today.md`, `deployment-matrix.md`) already use this exact browser-production / others-customer-controlled framing, so no docs change was needed.

## Verification

- `npm run build` green (prebuild ran the full `node --test` suite — **131/131 pass** — plus presentation verification, then `next build` succeeded).
- Footer label unit test and the public-surface cypress contract updated to the new stable snapshot label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM