### PR TITLE
fix: footer license line reflects the open-core boundary

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -413,8 +413,9 @@ export default function Footer({
                             All rights reserved.
                         </p>
                         <p className={styles.license}>
-                            Our software is open source and licensed under the
-                            MIT License.
+                            The local runtime and safety tooling are open
+                            source, licensed under the MIT License. OpenAdapt
+                            Cloud is a commercial service.
                         </p>
                     </div>
                     <div className={styles.social} aria-label="Social links">


### PR DESCRIPTION
## Summary

Roadmap Section 22 (licensing boundary), website surface.

The footer's legal line said "Our software is open source and licensed under the MIT License", which overstates the boundary: OpenAdapt Cloud (the hosted control plane) is proprietary/commercial. It now reads:

> The local runtime and safety tooling are open source, licensed under the MIT License. OpenAdapt Cloud is a commercial service.

## Scope

- Minimal diff: only the license paragraph text in `components/Footer.js` changes (3 insertions, 2 deletions).
- The GitHub stats widget and all other footer behavior are untouched.
- `node --test tests/footerStructure.test.js` passes unchanged (6/6); the existing `licensed under the MIT License` assertion still matches.

DO NOT MERGE without maintainer review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM