### PR TITLE
feat(site): comparison pages, partners program, remote-mode diagram, intake polish (Sections 18+21)

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -171,6 +171,7 @@ const CONNECT_COLUMN = [
     BLOG_LINK,
     byLabel('Discord'),
     { label: 'GitHub', href: OPENADAPT_REPOSITORY_URL },
+    { label: 'Contribute workflows', href: '/contribute' },
 ]
 
 export default function Footer({
@@ -359,6 +360,11 @@ export default function Footer({
                             <ul className={styles.columnList}>
                                 <li>
                                     <FooterLink href="/about">About</FooterLink>
+                                </li>
+                                <li>
+                                    <FooterLink href="/partners">
+                                        Partners &amp; OEM
+                                    </FooterLink>
                                 </li>
                                 <li>
                                     <FooterLink href={CLOUD_APP_URL}>

--- a/components/NavHeader.js
+++ b/components/NavHeader.js
@@ -26,6 +26,7 @@ const SOLUTIONS_LINKS = [
     { label: 'Healthcare', href: '/solutions/healthcare' },
     { label: 'Lending', href: '/solutions/lending' },
     { label: 'Insurance', href: '/solutions/insurance' },
+    { label: 'Partners & OEM', href: '/partners' },
 ]
 
 const PRODUCT_LINKS = [

--- a/components/PartnerInquiryForm.js
+++ b/components/PartnerInquiryForm.js
@@ -1,0 +1,251 @@
+import { useState } from 'react'
+import Link from 'next/link'
+
+import { trackEmailCapture } from 'utils/conversion'
+
+// Dedicated intake for the partner program.
+//
+// Posts to the durable Netlify Forms lead path (`/form.html`) under its own
+// form name, `partner-inquiry`, so partner leads land in their own Netlify
+// submissions bucket instead of the generic `contact` queue. The hidden form
+// definition lives in public/form.html; Netlify's build-time bots read it
+// from there. The `track` selector mirrors the partner tracks on /partners.
+// Lead data always travels in the POST body, never in a URL.
+
+export const PARTNER_TRACKS = [
+    { value: 'vertical_oem', label: 'Vertical software / OEM' },
+    { value: 'rcm_bpo', label: 'RCM or BPO operator' },
+    { value: 'integration_services', label: 'Integration / services' },
+    { value: 'msp_deployment', label: 'MSP / deployment' },
+]
+
+const INITIAL_FORM = {
+    name: '',
+    email: '',
+    company: '',
+    role: '',
+    track: '',
+    systems: '',
+    message: '',
+    botField: '',
+}
+
+const fieldClass =
+    'rounded-lg border border-ink/30 bg-panel px-3 py-2 text-ink placeholder-ink-3/60 focus:border-accent focus:outline-none'
+
+export default function PartnerInquiryForm() {
+    const [form, setForm] = useState(INITIAL_FORM)
+    const [isSubmitting, setIsSubmitting] = useState(false)
+    const [isSubmitted, setIsSubmitted] = useState(false)
+    const [error, setError] = useState('')
+
+    const handleChange = (event) => {
+        const { name, value } = event.target
+        setForm((prev) => ({ ...prev, [name]: value }))
+    }
+
+    const handleSubmit = async (event) => {
+        event.preventDefault()
+        setError('')
+        setIsSubmitting(true)
+
+        try {
+            const formData = new URLSearchParams()
+            formData.set('form-name', 'partner-inquiry')
+            formData.set('name', form.name)
+            formData.set('email', form.email)
+            formData.set('company', form.company)
+            formData.set('role', form.role)
+            formData.set('track', form.track)
+            formData.set('systems', form.systems)
+            formData.set('message', form.message)
+            formData.set('bot-field', form.botField)
+
+            const response = await fetch('/form.html', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                },
+                body: formData.toString(),
+            })
+
+            if (!response.ok) {
+                throw new Error(
+                    `Form submission failed with status ${response.status}`
+                )
+            }
+
+            // Qualified-lead conversion: partner interest captured. Carries
+            // first-touch utm_* attribution; never any form contents.
+            trackEmailCapture({ location: 'partner_inquiry_form' })
+            setIsSubmitted(true)
+        } catch (submitError) {
+            console.error(submitError)
+            setError(
+                'Submission failed. Please email hello@openadapt.ai directly.'
+            )
+        } finally {
+            setIsSubmitting(false)
+        }
+    }
+
+    return (
+        <div className="rounded-2xl border border-hairline bg-panel p-6 md:p-8">
+            {!isSubmitted ? (
+                <form
+                    className="space-y-4"
+                    onSubmit={handleSubmit}
+                    data-netlify="true"
+                    netlify-honeypot="bot-field"
+                    method="POST"
+                    name="partner-inquiry"
+                >
+                    <input
+                        type="hidden"
+                        name="form-name"
+                        value="partner-inquiry"
+                    />
+                    <p className="hidden">
+                        <label>
+                            Do not fill this out if you are human:{' '}
+                            <input
+                                name="bot-field"
+                                value={form.botField}
+                                onChange={handleChange}
+                            />
+                        </label>
+                    </p>
+
+                    <div className="grid gap-4 md:grid-cols-2">
+                        <label className="flex flex-col gap-2 text-sm">
+                            Name *
+                            <input
+                                type="text"
+                                name="name"
+                                required
+                                value={form.name}
+                                onChange={handleChange}
+                                className={fieldClass}
+                                placeholder="Your Name"
+                                autoComplete="name"
+                            />
+                        </label>
+                        <label className="flex flex-col gap-2 text-sm">
+                            Work email *
+                            <input
+                                type="email"
+                                name="email"
+                                required
+                                value={form.email}
+                                onChange={handleChange}
+                                className={fieldClass}
+                                placeholder="name@company.com"
+                                autoComplete="email"
+                            />
+                        </label>
+                        <label className="flex flex-col gap-2 text-sm">
+                            Company *
+                            <input
+                                type="text"
+                                name="company"
+                                required
+                                value={form.company}
+                                onChange={handleChange}
+                                className={fieldClass}
+                                placeholder="Acme Inc"
+                                autoComplete="organization"
+                            />
+                        </label>
+                        <label className="flex flex-col gap-2 text-sm">
+                            Role
+                            <input
+                                type="text"
+                                name="role"
+                                value={form.role}
+                                onChange={handleChange}
+                                className={fieldClass}
+                                placeholder="VP Partnerships"
+                                autoComplete="organization-title"
+                            />
+                        </label>
+                    </div>
+
+                    <label className="flex flex-col gap-2 text-sm">
+                        Partner track *
+                        <select
+                            name="track"
+                            required
+                            value={form.track}
+                            onChange={handleChange}
+                            className={fieldClass}
+                        >
+                            <option value="">Select a track</option>
+                            {PARTNER_TRACKS.map((track) => (
+                                <option key={track.value} value={track.value}>
+                                    {track.label}
+                                </option>
+                            ))}
+                        </select>
+                    </label>
+
+                    <label className="flex flex-col gap-2 text-sm">
+                        Systems of record or verticals you serve
+                        <input
+                            type="text"
+                            name="systems"
+                            value={form.systems}
+                            onChange={handleChange}
+                            className={fieldClass}
+                            placeholder="EMRs, practice management, loan origination, claims"
+                        />
+                    </label>
+
+                    <label className="flex flex-col gap-2 text-sm">
+                        What would you want to build or operate together?
+                        <textarea
+                            name="message"
+                            rows={4}
+                            value={form.message}
+                            onChange={handleChange}
+                            className={fieldClass}
+                            placeholder="Customer base, deployment constraints, timelines, questions"
+                        />
+                    </label>
+
+                    {error && (
+                        <p
+                            role="alert"
+                            className="rounded-lg border border-red-800/40 bg-red-100 px-3 py-2 text-sm text-red-900"
+                        >
+                            {error}
+                        </p>
+                    )}
+
+                    <p className="text-xs leading-relaxed text-ink-3">
+                        Applying shares only the details above so we can
+                        evaluate fit. See the{' '}
+                        <Link href="/privacy-policy" className="text-accent">
+                            Privacy Notice
+                        </Link>{' '}
+                        for how we handle contact details.
+                    </p>
+                    <button
+                        type="submit"
+                        disabled={isSubmitting}
+                        className="btn-ink disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                        {isSubmitting ? 'Submitting...' : 'Apply to partner'}
+                    </button>
+                </form>
+            ) : (
+                <div className="rounded-xl border border-accent/40 bg-accent/10 px-4 py-4">
+                    <p className="text-sm text-accent">
+                        Thanks. Your partner application is in review. We
+                        evaluate applications individually and will reply by
+                        email.
+                    </p>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/components/RemoteModesFigure.js
+++ b/components/RemoteModesFigure.js
@@ -1,0 +1,184 @@
+import Link from 'next/link'
+
+// The two remote execution modes, side by side, as a styled HTML/CSS figure.
+//
+// Honesty contract (kept in sync with public/status.json): the external lane
+// is qualified today against a deterministic no-DOM stand-in for the Citrix
+// Workspace window contract plus a real FreeRDP round trip for RDP; a real
+// ICA/HDX environment is qualified per customer before consequential use.
+// Neither panel claims universal production coverage.
+
+function DownArrow({ label }) {
+    return (
+        <div className="flex flex-col items-center gap-1 py-2">
+            <svg
+                viewBox="0 0 24 32"
+                width="18"
+                height="24"
+                aria-hidden="true"
+                focusable="false"
+                className="text-ink-3"
+            >
+                <path
+                    d="M12 2v22m0 0l-7-7m7 7l7-7"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                />
+            </svg>
+            {label && (
+                <span className="text-center text-xs leading-snug text-ink-3">
+                    {label}
+                </span>
+            )}
+        </div>
+    )
+}
+
+function Box({ title, detail, tone = 'default' }) {
+    const toneClass =
+        tone === 'accent'
+            ? 'border-accent/60 bg-accent/10'
+            : tone === 'dashed'
+              ? 'border-dashed border-ink/40 bg-ground'
+              : 'border-hairline bg-panel'
+    return (
+        <div className={`rounded-xl border ${toneClass} px-4 py-3`}>
+            <p className="text-sm font-semibold text-ink">{title}</p>
+            {detail && (
+                <p className="mt-1 text-xs leading-relaxed text-ink-2">
+                    {detail}
+                </p>
+            )}
+        </div>
+    )
+}
+
+export default function RemoteModesFigure() {
+    return (
+        <section
+            id="remote-modes"
+            className="border-b border-hairline bg-panel px-5 py-16 md:py-20"
+            aria-labelledby="remote-modes-heading"
+        >
+            <div className="mx-auto max-w-5xl">
+                <p className="eyebrow text-center">Remote execution modes</p>
+                <h2
+                    id="remote-modes-heading"
+                    className="mx-auto mt-2 max-w-2xl text-center font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl"
+                >
+                    Two ways into managed Citrix, RDP, and VDI estates
+                </h2>
+                <p className="mx-auto mt-3 max-w-3xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
+                    Where policy permits software inside the managed session,
+                    the runner executes in-session. Where it does not, the
+                    external lane drives the local remote-desktop client
+                    window from outside, so nothing is installed in the remote
+                    environment. Both modes keep the same identity, policy,
+                    verification, and halt contracts.
+                </p>
+
+                <figure className="mt-10">
+                    <div className="grid gap-6 md:grid-cols-2">
+                        <div className="rounded-2xl border border-hairline bg-ground p-5 md:p-6">
+                            <h3 className="font-display text-lg font-semibold text-ink">
+                                In-session
+                            </h3>
+                            <p className="mt-1 text-sm leading-relaxed text-ink-2">
+                                The runner is installed inside the managed
+                                session, when your policy permits it.
+                            </p>
+                            <div className="mt-5">
+                                <div className="rounded-2xl border-2 border-ink/50 bg-panel p-4">
+                                    <p className="text-xs font-semibold uppercase tracking-wide text-ink-3">
+                                        Managed session (Citrix / RDP / VDI)
+                                    </p>
+                                    <div className="mt-3 space-y-0">
+                                        <Box
+                                            title="OpenAdapt runner"
+                                            detail="Runs beside the application with native accessibility and visual evidence."
+                                            tone="accent"
+                                        />
+                                        <DownArrow label="native control and evidence" />
+                                        <Box
+                                            title="Target application"
+                                            detail="The system-of-record UI inside the session."
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+                            <p className="mt-4 text-xs leading-relaxed text-ink-3">
+                                Requires software inside the session image, so
+                                it fits estates where you control the image or
+                                policy allows an installed agent.
+                            </p>
+                        </div>
+
+                        <div className="rounded-2xl border border-hairline bg-ground p-5 md:p-6">
+                            <h3 className="font-display text-lg font-semibold text-ink">
+                                External black-box
+                            </h3>
+                            <p className="mt-1 text-sm leading-relaxed text-ink-2">
+                                The runner drives the local Citrix or RDP
+                                client window. Zero install inside the remote
+                                session.
+                            </p>
+                            <div className="mt-5">
+                                <div className="rounded-2xl border-2 border-ink/50 bg-panel p-4">
+                                    <p className="text-xs font-semibold uppercase tracking-wide text-ink-3">
+                                        Your workstation
+                                    </p>
+                                    <div className="mt-3 space-y-0">
+                                        <Box
+                                            title="OpenAdapt runner (outside the session)"
+                                            detail="Operates through pixels, keyboard, and mouse with a two-phase lease: re-resolve on a fresh frame, refuse if anything changed before delivery."
+                                            tone="accent"
+                                        />
+                                        <DownArrow label="pixels, keyboard, mouse" />
+                                        <Box
+                                            title="Local Citrix / RDP client window"
+                                            detail="The vendor client you already run."
+                                        />
+                                    </div>
+                                </div>
+                                <DownArrow label="the vendor's own remote protocol" />
+                                <Box
+                                    title="Managed session (remote)"
+                                    detail="Untouched: no agent, driver, or install inside the session."
+                                    tone="dashed"
+                                />
+                            </div>
+                            <p className="mt-4 text-xs leading-relaxed text-ink-3">
+                                Fits locked-down estates where nothing may be
+                                installed in the managed environment.
+                            </p>
+                        </div>
+                    </div>
+                    <figcaption className="mx-auto mt-6 max-w-3xl text-center text-xs leading-relaxed text-ink-3">
+                        Status, stated plainly: the external lane is qualified
+                        today against a deterministic no-DOM stand-in for the
+                        Citrix Workspace window contract and a real FreeRDP
+                        round trip for RDP. A real ICA/HDX environment is
+                        qualified per customer before consequential use. Per
+                        surface results are published in the{' '}
+                        <a
+                            href="https://docs.openadapt.ai/get-started/what-works-today/"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-accent"
+                        >
+                            qualification evidence
+                        </a>
+                        , and machine-readable status in{' '}
+                        <Link href="/status.json" className="text-accent">
+                            status.json
+                        </Link>
+                        .
+                    </figcaption>
+                </figure>
+            </div>
+        </section>
+    )
+}

--- a/components/WorkflowQualificationForm.js
+++ b/components/WorkflowQualificationForm.js
@@ -32,6 +32,8 @@ const INITIAL_FORM = {
     timeline: '',
     budget: '',
     reusePotential: '',
+    leadSegment: '',
+    privacyConsent: '',
     botField: '',
 }
 
@@ -71,8 +73,11 @@ export default function WorkflowQualificationForm({ compact = false }) {
 
     const handleChange = (event) => {
         markStarted()
-        const { name, value } = event.target
-        setForm((current) => ({ ...current, [name]: value }))
+        const { name, value, type, checked } = event.target
+        // The consent checkbox stores 'yes' or '' so every field serializes
+        // uniformly into the POST body (never into a URL).
+        const next = type === 'checkbox' ? (checked ? 'yes' : '') : value
+        setForm((current) => ({ ...current, [name]: next }))
     }
 
     const handleSubmit = async (event) => {
@@ -152,6 +157,7 @@ export default function WorkflowQualificationForm({ compact = false }) {
             name="workflow-qualification"
             data-netlify="true"
             netlify-honeypot="bot-field"
+            method="POST"
             onSubmit={handleSubmit}
             className="space-y-7"
         >
@@ -209,6 +215,13 @@ export default function WorkflowQualificationForm({ compact = false }) {
                         <option value="personal">Personal information</option>
                         <option value="regulated">Regulated or clinical data</option>
                         <option value="restricted">Highly restricted</option>
+                    </SelectField>
+                    <SelectField label="Which best describes you *" name="leadSegment" value={form.leadSegment} onChange={handleChange}>
+                        <option value="enterprise_operator">Enterprise operator automating our own workflows</option>
+                        <option value="oem_vertical">Vertical software vendor / OEM</option>
+                        <option value="bpo_services">BPO, RCM, or services provider</option>
+                        <option value="developer">Developer or technical evaluator</option>
+                        <option value="community">Community / open-source user</option>
                     </SelectField>
                 </div>
             </fieldset>
@@ -332,6 +345,25 @@ export default function WorkflowQualificationForm({ compact = false }) {
                     {error}
                 </p>
             )}
+
+            <label className="flex items-start gap-3 text-sm leading-relaxed text-ink-2">
+                <input
+                    type="checkbox"
+                    name="privacyConsent"
+                    required
+                    checked={form.privacyConsent === 'yes'}
+                    onChange={handleChange}
+                    className="mt-1 h-4 w-4 shrink-0 accent-accent"
+                />
+                <span>
+                    I consent to OpenAdapt processing the details above to
+                    review this workflow and respond, as described in the{' '}
+                    <Link href="/privacy-policy" className="text-accent">
+                        Privacy Notice
+                    </Link>
+                    . *
+                </span>
+            </label>
 
             <div className="flex flex-wrap items-center gap-4">
                 <button

--- a/cypress/e2e/lead-privacy.cy.js
+++ b/cypress/e2e/lead-privacy.cy.js
@@ -1,0 +1,99 @@
+// Lead data must never appear in a URL. This drives the real qualification
+// form end to end with a stubbed Netlify endpoint and asserts the lead
+// fields travel only in the POST body while the page URL stays clean.
+
+const LEAD = {
+    name: 'Privacy Probe',
+    email: 'privacy-probe@example.com',
+    company: 'Probe Ops LLC',
+    role: 'Operations Lead',
+    application: 'Legacy Billing Console',
+    operators: '4 billing specialists',
+    workflow:
+        'Read a structured eligibility response, enter approved fields into the legacy application, reopen the record, and confirm the persisted values.',
+}
+
+const SELECTS = {
+    environment: 'browser',
+    dataSensitivity: 'ordinary',
+    leadSegment: 'enterprise_operator',
+    monthlyVolume: '1000_4999',
+    manualTime: '5_15',
+    errorConsequence: 'financial',
+    inputStructure: 'mostly_structured',
+    stability: 'stable_quarter',
+    writeApi: 'unavailable',
+    verifier: 'independent_interface',
+    testEnvironment: 'possible',
+    reusePotential: 'one_site',
+    buyerAuthority: 'champion',
+    timeline: '30_60',
+    budget: 'under_15000',
+}
+
+describe('lead privacy', () => {
+    it('submits qualification leads in a POST body and never in a URL', () => {
+        cy.intercept('POST', '/form.html', {
+            statusCode: 200,
+            body: '',
+        }).as('leadSubmit')
+
+        cy.visit('/qualify')
+
+        cy.get('form[name="workflow-qualification"]').within(() => {
+            for (const [field, value] of Object.entries(LEAD)) {
+                cy.get(`[name="${field}"]`).type(value, { delay: 0 })
+            }
+            for (const [field, value] of Object.entries(SELECTS)) {
+                cy.get(`select[name="${field}"]`).select(value)
+            }
+            cy.get('input[name="privacyConsent"]').check()
+            cy.get('button[type="submit"]').click()
+        })
+
+        cy.wait('@leadSubmit').then(({ request }) => {
+            // The submission target carries no query string.
+            const requestUrl = new URL(request.url)
+            expect(requestUrl.pathname).to.equal('/form.html')
+            expect(requestUrl.search).to.equal('')
+
+            // The lead fields travel in the encoded body, including the new
+            // consent and segment captures.
+            const body = new URLSearchParams(request.body)
+            expect(body.get('form-name')).to.equal('workflow-qualification')
+            expect(body.get('email')).to.equal(LEAD.email)
+            expect(body.get('leadSegment')).to.equal('enterprise_operator')
+            expect(body.get('privacyConsent')).to.equal('yes')
+            expect(body.get('qualificationTier')).to.be.oneOf([
+                'priority',
+                'review',
+                'community',
+            ])
+        })
+
+        // The form reached its submitted state without the browser URL
+        // picking up any lead value.
+        cy.contains('Submission received').should('be.visible')
+        cy.url().should((url) => {
+            expect(url.endsWith('/qualify')).to.equal(true)
+            for (const value of [
+                LEAD.email,
+                encodeURIComponent(LEAD.email),
+                LEAD.name,
+                encodeURIComponent(LEAD.name),
+            ]) {
+                expect(url).to.not.include(value)
+            }
+        })
+    })
+
+    it('requires the privacy consent checkbox before submitting', () => {
+        cy.visit('/qualify')
+        cy.get('input[name="privacyConsent"]')
+            .should('have.attr', 'required')
+        cy.get('input[name="privacyConsent"]').should('not.be.checked')
+        cy.get('form[name="workflow-qualification"]')
+            .contains('a', 'Privacy Notice')
+            .should('have.attr', 'href', '/privacy-policy')
+    })
+})

--- a/data/comparisons.js
+++ b/data/comparisons.js
@@ -1,0 +1,199 @@
+// Canonical content for the /compare/<slug> alternative pages.
+//
+// Honesty rules (enforced by tests/comparisonPages.test.js):
+// - Credit each alternative for its real strengths in its own section.
+// - Differentiate OpenAdapt only on what is real today: independent
+//   out-of-band business-effect verification, explicit transaction outcomes,
+//   the external zero-install remote execution lane, customer-controlled
+//   sensitive data, deterministic zero-model-call healthy runs, the open MIT
+//   local runtime, and published qualification evidence.
+// - Never differentiate on recording demos, visual targeting, Citrix
+//   awareness, or self-healing: those capabilities are widely available.
+// - Never state competitor pricing beyond well-known published figures, and
+//   phrase those as "published pricing starts around ...".
+
+export const OPENADAPT_DIFFERENTIATORS = [
+    {
+        title: 'Independent business-effect verification',
+        body: 'A run is judged by an out-of-band check of the system of record, such as a read-only API call, a SQL query, or re-reading the persisted record, not by the acting session declaring itself successful.',
+    },
+    {
+        title: 'Explicit transaction outcomes',
+        body: 'Every consequential run ends verified or halted with a preserved run report. There is no silent third state where the workflow looked finished but the record never changed.',
+    },
+    {
+        title: 'Deterministic healthy runs',
+        body: 'A compiled workflow replays deterministically with zero model calls on healthy runs. Model spend is reserved for compilation and reviewable repair.',
+    },
+    {
+        title: 'External zero-install remote lane',
+        body: 'For managed Citrix, RDP, and VDI estates, OpenAdapt can drive the local client window from outside the session, so nothing is installed inside the remote environment. The lane is qualified today against a deterministic stand-in and a real FreeRDP round trip; a real ICA/HDX environment is qualified per customer before consequential use.',
+    },
+    {
+        title: 'Customer-controlled sensitive data',
+        body: 'Recordings, screenshots, and compiled bundles can stay inside your boundary. Local, self-hosted, and customer-controlled deployments are first-class, not an enterprise afterthought.',
+    },
+    {
+        title: 'Open MIT local runtime',
+        body: 'The compiler and governed runtime are MIT-licensed and inspectable. You can audit exactly what runs beside your systems of record.',
+    },
+    {
+        title: 'Published qualification evidence',
+        body: 'Each execution surface ships with bounded, published acceptance evidence, counted effects, refusals, and halts, instead of an unbounded compatibility claim.',
+    },
+]
+
+const QUALIFICATION_EVIDENCE_URL =
+    'https://docs.openadapt.ai/get-started/what-works-today/'
+
+export const COMPARISONS = [
+    {
+        slug: 'uipath',
+        name: 'UiPath',
+        title: 'OpenAdapt vs UiPath',
+        metaDescription:
+            'When UiPath is the right choice, when OpenAdapt is, and how independent effect verification, explicit outcomes, and an open MIT runtime differ from platform RPA.',
+        intro: 'UiPath is the most mature enterprise RPA platform. OpenAdapt is a governed workflow compiler with independent effect verification. They solve overlapping problems from different starting points, and for many teams the honest answer is one, the other, or both.',
+        theirStrengths: {
+            heading: 'Where UiPath is strong',
+            items: [
+                'A mature, widely deployed enterprise platform with a long production track record and deep institutional knowledge in the market.',
+                'Orchestrator provides scheduling, work queues, credential vaults, role-based access, and centralized audit across large robot fleets.',
+                'Mature, long-standing support for automating Citrix and other virtual desktop environments, including dedicated remote-runtime integrations.',
+                'A large marketplace, extensive training through UiPath Academy, and a broad certified-partner and developer ecosystem.',
+                'Attended and unattended robots, a very large activity library, and adjacent products for document understanding and process mining.',
+            ],
+        },
+        chooseThem:
+            'Choose UiPath when you are standardizing hundreds of automations on one enterprise platform, need mature fleet orchestration today, or already have UiPath licenses, developers, and a center of excellence.',
+        chooseUs:
+            'Choose OpenAdapt when the workflows that matter are consequential transactions where you need the system of record independently confirmed after every run, when sensitive data must stay in your boundary on an inspectable MIT runtime, or when you want a zero-install lane into managed remote estates.',
+        honestNote:
+            'Recording a demonstration, visual targeting, and repairing broken selectors are not differentiators in either direction: modern RPA platforms and OpenAdapt all do these. The difference is how a run is judged and what a failure is allowed to look like.',
+    },
+    {
+        slug: 'power-automate',
+        name: 'Microsoft Power Automate',
+        title: 'OpenAdapt vs Microsoft Power Automate',
+        metaDescription:
+            'When Power Automate is the right choice, when OpenAdapt is, and how independent verification and customer-controlled execution differ from ecosystem RPA.',
+        intro: 'Power Automate is the default automation layer of the Microsoft ecosystem, and for Microsoft-centric work it is very hard to beat on integration and price. OpenAdapt is a governed workflow compiler focused on consequential GUI transactions with independent verification.',
+        theirStrengths: {
+            heading: 'Where Power Automate is strong',
+            items: [
+                'Deep, native integration with Microsoft 365, Teams, Excel, SharePoint, Dataverse, and Azure identity.',
+                'Hundreds of prebuilt connectors for cloud flows, so API-first automation often needs no custom code at all.',
+                'Power Automate for desktop is included with Windows 11 for attended local flows, which makes experimentation essentially free.',
+                'Aggressive published pricing for an enterprise suite: premium per-user plans start around $15 per user per month, and hosted RPA bots are in the roughly $215 per bot per month class.',
+                'Centralized administration and governance through the Power Platform admin center for organizations already run on Microsoft tooling.',
+            ],
+        },
+        chooseThem:
+            'Choose Power Automate when the work lives inside the Microsoft ecosystem, when a supported connector already reaches the system you need, or when low per-seat cost across many light automations matters more than transaction-level verification.',
+        chooseUs:
+            'Choose OpenAdapt when the last mile is a non-Microsoft or legacy GUI, when a wrong write is expensive enough that you need the business effect independently verified out of band, when runs must end in an explicit verified-or-halted outcome, or when the runtime must be open, local, and customer-controlled.',
+        honestNote:
+            'If a supported connector or API completes the workflow reliably, use it. OpenAdapt exists for the UI-only remainder where no practical API exists and correctness has to be proved, not assumed.',
+    },
+    {
+        slug: 'computer-use-agents',
+        name: 'computer-use agents',
+        title: 'OpenAdapt vs computer-use agents',
+        metaDescription:
+            'When Claude or OpenAI computer use is the right choice, when OpenAdapt is, and why deterministic replay with independent verification fits repeated consequential work.',
+        intro: 'Computer-use agents from Anthropic and OpenAI point a frontier model at the screen and let it reason its way through a task. That flexibility is real and improving fast. OpenAdapt compiles a demonstration once and replays it deterministically, reserving models for compilation and repair.',
+        theirStrengths: {
+            heading: 'Where computer-use agents are strong',
+            items: [
+                'Genuine flexibility on novel, one-off, or loosely specified tasks, with no per-workflow setup or authoring step.',
+                'They generalize across unfamiliar interfaces and recover from situations no one anticipated in advance.',
+                'Capability improves with every model generation, without any change to your workflow definitions.',
+                'A plain-language instruction is the whole interface, which makes them accessible to anyone who can describe the task.',
+            ],
+        },
+        chooseThem:
+            'Choose a computer-use agent for exploratory, novel, or constantly changing work, for research and triage, or for tasks you will run a handful of times and never again.',
+        chooseUs:
+            'Choose OpenAdapt when the same consequential workflow repeats: healthy runs are deterministic with zero model calls and zero per-run token cost, every run ends verified or halted against an independent check of the system of record, and the runtime is MIT-licensed and can execute entirely inside your boundary.',
+        honestNote:
+            'These approaches are complementary rather than rivals: agent providers themselves recommend human oversight for consequential actions, and OpenAdapt uses models too, at compile and repair time rather than on every healthy run. The question is whether each run should re-reason the task or replay a verified program.',
+    },
+    {
+        slug: 'record-and-replay',
+        name: 'record-and-replay tools',
+        title: 'OpenAdapt vs record-and-replay tools',
+        metaDescription:
+            'When record-and-replay tools, including OpenAI Record & Replay, are the right choice, and what independent verification and explicit outcomes add for consequential work.',
+        intro: 'Recording a demonstration and replaying it is now a mainstream authoring model, from classic macro recorders to OpenAI shipping Record & Replay for repeated tasks. OpenAdapt shares the authoring model, so the real comparison is what happens after the recording, not the recording itself.',
+        theirStrengths: {
+            heading: 'Where record-and-replay tools are strong',
+            items: [
+                'The fastest possible authoring: demonstrate the task once and it becomes repeatable, with no selectors or code.',
+                'Accessible to non-developers, so the people who actually do the work can automate it themselves.',
+                'Replay avoids re-reasoning the task from scratch on every run, which keeps repeat runs fast and cheap.',
+                "OpenAI's Record & Replay brings demonstration-based authoring to a mainstream audience, which validates the model for everyone building on it.",
+            ],
+        },
+        chooseThem:
+            'Choose a lightweight record-and-replay tool for personal productivity, low-stakes repetitive tasks, and workflows where an occasional silent miss costs little.',
+        chooseUs:
+            'Choose OpenAdapt when a replayed action writes to a system of record that matters: the compiled program is reviewable, healthy runs are deterministic with zero model calls, the business effect is verified out of band after the run, ambiguity halts instead of guessing, and the MIT runtime plus your data can stay entirely inside your boundary.',
+        honestNote:
+            'Recording is the commodity; OpenAdapt does not claim to record better. The difference is governance: an independent verifier, an explicit verified-or-halted outcome for every run, and published qualification evidence per execution surface.',
+    },
+    {
+        slug: 'browser-agents',
+        name: 'browser-agent platforms',
+        title: 'OpenAdapt vs browser-agent platforms',
+        metaDescription:
+            'When browser-agent platforms are the right choice, when OpenAdapt is, and how independent verification and customer-controlled execution differ for consequential web work.',
+        intro: 'Browser-agent platforms combine web automation frameworks, language models, and often managed cloud browsers into a fast way to automate web tasks. For prototyping and web-only work they are excellent. OpenAdapt targets repeated, consequential workflows across browser, desktop, and remote surfaces with verification at the center.',
+        theirStrengths: {
+            heading: 'Where browser-agent platforms are strong',
+            items: [
+                'Very fast setup for web tasks: point an agent at a URL and useful behavior often emerges in minutes.',
+                'Managed cloud-browser infrastructure removes the burden of running and scaling browsers yourself.',
+                'Strong fit for scraping, research, monitoring, and other read-heavy web work where a retry is cheap.',
+                'Active open-source and commercial ecosystems iterating quickly on web-agent capability.',
+            ],
+        },
+        chooseThem:
+            'Choose a browser-agent platform for web-only, read-heavy, or exploratory automation, for prototypes, and for workloads where a failed or repeated attempt has little cost.',
+        chooseUs:
+            'Choose OpenAdapt when the workflow also crosses desktop or remote surfaces, when the acting session must not be the judge of its own success, when every consequential run needs an explicit verified-or-halted outcome, or when sensitive data cannot transit a vendor cloud and must run on a customer-controlled MIT runtime.',
+        honestNote:
+            'Most browser-agent stacks judge success in-band: the same session that acted decides whether it worked. OpenAdapt verifies the business effect out of band, against the system of record, after the run.',
+    },
+    {
+        slug: 'hand-rolled-scripts',
+        name: 'hand-rolled scripts',
+        title: 'OpenAdapt vs hand-rolled scripts',
+        metaDescription:
+            'When Playwright, Selenium, or AutoHotkey scripts are the right choice, when OpenAdapt is, and what governance adds beyond a working script.',
+        intro: 'A script written with Playwright, Selenium, AutoHotkey, or PyAutoGUI is free, precise, and completely under your control. Plenty of production automation runs this way for good reasons. OpenAdapt is also open and local; what it adds is the governance around the script you would otherwise build yourself.',
+        theirStrengths: {
+            heading: 'Where hand-rolled scripts are strong',
+            items: [
+                'Zero license cost and no vendor relationship: the whole stack is open source and yours.',
+                'Exact control over every step, wait, and assertion, with the full power of a general-purpose language.',
+                'Mature frameworks, huge communities, and years of accumulated answers for almost any situation.',
+                'For a developer who owns the workflow, a small script is often the fastest and simplest correct answer.',
+            ],
+        },
+        chooseThem:
+            'Keep a hand-rolled script when it already works, a developer owns and maintains it, and its failure modes are understood and affordable.',
+        chooseUs:
+            'Choose OpenAdapt when scripts have become an unowned maintenance burden, when non-developers need to author workflows by demonstration, or when you need what scripts rarely include: independent out-of-band verification of the business effect, an explicit verified-or-halted outcome with a preserved run report, and halts on ambiguity instead of best-effort clicks. The runtime is MIT-licensed, so you trade none of the openness.',
+        honestNote:
+            'OpenAdapt does not claim your script cannot work. It packages the verification, outcome discipline, and audit trail that consequential scripts eventually grow by hand, and it publishes qualification evidence per surface instead of assuming coverage.',
+    },
+]
+
+export const COMPARISON_LINKS = COMPARISONS.map(({ slug, name, title }) => ({
+    slug,
+    name,
+    title,
+    href: `/compare/${slug}`,
+}))
+
+export { QUALIFICATION_EVIDENCE_URL }

--- a/pages/compare.js
+++ b/pages/compare.js
@@ -6,6 +6,7 @@ import { track, EVENTS } from 'utils/analytics'
 import BenchmarkCharts from '@components/BenchmarkCharts'
 import Faq, { faqItems } from '@components/Faq'
 import benchmark from '../data/benchmark.json'
+import { COMPARISON_LINKS } from '../data/comparisons'
 
 const faqSchema = {
     '@context': 'https://schema.org',
@@ -409,6 +410,41 @@ export default function ComparePage() {
                             Review execution and deployment options
                         </Link>
                     </p>
+                </section>
+
+                <section
+                    className="mt-14"
+                    aria-labelledby="specific-alternatives-heading"
+                >
+                    <p className="eyebrow">Specific alternatives</p>
+                    <h2
+                        id="specific-alternatives-heading"
+                        className="mt-2 font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl"
+                    >
+                        Compare OpenAdapt with a specific alternative.
+                    </h2>
+                    <p className="mt-3 max-w-3xl text-sm leading-relaxed text-ink-2 md:text-base">
+                        Each page credits the alternative for what it genuinely
+                        does well, then shows where OpenAdapt differs on
+                        verification, outcomes, deployment, and openness.
+                    </p>
+                    <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                        {COMPARISON_LINKS.map((link) => (
+                            <Link
+                                key={link.slug}
+                                href={link.href}
+                                className="rounded-2xl border border-hairline bg-panel p-5 font-display text-base font-semibold text-ink transition-colors hover:border-ink"
+                                onClick={() =>
+                                    track(EVENTS.COMPARE_CTA_CLICK, {
+                                        cta: `compare_${link.slug}`,
+                                        location: 'compare_alternatives',
+                                    })
+                                }
+                            >
+                                {link.title}
+                            </Link>
+                        ))}
+                    </div>
                 </section>
 
                 <div className="mt-14">

--- a/pages/compare/[slug].js
+++ b/pages/compare/[slug].js
@@ -1,0 +1,235 @@
+import Head from 'next/head'
+import Link from 'next/link'
+
+import Footer from '@components/Footer'
+import {
+    COMPARISONS,
+    COMPARISON_LINKS,
+    OPENADAPT_DIFFERENTIATORS,
+    QUALIFICATION_EVIDENCE_URL,
+} from '../../data/comparisons'
+
+// Targeted alternative pages under /compare/<slug>. The overview table stays
+// on /compare; these pages go deeper on one alternative at a time under the
+// honesty rules documented in data/comparisons.js: credit the alternative's
+// real strengths, differentiate only on what OpenAdapt actually does, and
+// never lean on commoditized capabilities (recording, visual targeting,
+// Citrix awareness, self-healing) as if they were unique.
+
+export async function getStaticPaths() {
+    return {
+        paths: COMPARISONS.map(({ slug }) => ({ params: { slug } })),
+        fallback: false,
+    }
+}
+
+export async function getStaticProps({ params }) {
+    const comparison = COMPARISONS.find(({ slug }) => slug === params.slug)
+    return { props: { comparison } }
+}
+
+export default function ComparisonDetailPage({ comparison }) {
+    const url = `https://openadapt.ai/compare/${comparison.slug}`
+    const webPageSchema = {
+        '@context': 'https://schema.org',
+        '@type': 'WebPage',
+        name: comparison.title,
+        url,
+        description: comparison.metaDescription,
+        isPartOf: {
+            '@type': 'WebSite',
+            name: 'OpenAdapt.AI',
+            url: 'https://openadapt.ai',
+        },
+        inLanguage: 'en',
+    }
+
+    return (
+        <div className="min-h-screen bg-ground text-ink">
+            <Head>
+                <title>{`${comparison.title} | OpenAdapt`}</title>
+                <meta
+                    name="description"
+                    content={comparison.metaDescription}
+                />
+                <link rel="canonical" href={url} />
+                <meta property="og:title" content={comparison.title} />
+                <meta
+                    property="og:description"
+                    content={comparison.metaDescription}
+                />
+                <meta property="og:url" content={url} />
+                <script
+                    type="application/ld+json"
+                    dangerouslySetInnerHTML={{
+                        __html: JSON.stringify(webPageSchema),
+                    }}
+                />
+            </Head>
+
+            <main className="mx-auto max-w-4xl px-4 py-14">
+                <p className="eyebrow">
+                    <Link href="/compare" className="text-accent">
+                        Automation decision guide
+                    </Link>
+                </p>
+                <h1 className="font-display mt-3 max-w-3xl text-3xl font-semibold tracking-tight text-ink md:text-5xl">
+                    {comparison.title}
+                </h1>
+                <p className="mt-5 max-w-3xl text-base leading-relaxed text-ink-2 md:text-lg">
+                    {comparison.intro}
+                </p>
+
+                <section
+                    className="mt-12"
+                    aria-labelledby="their-strengths-heading"
+                >
+                    <h2
+                        id="their-strengths-heading"
+                        className="font-display text-2xl font-semibold tracking-tight text-ink"
+                    >
+                        {comparison.theirStrengths.heading}
+                    </h2>
+                    <ul className="mt-4 space-y-3">
+                        {comparison.theirStrengths.items.map((item) => (
+                            <li
+                                key={item}
+                                className="rounded-xl border border-hairline bg-panel p-4 text-sm leading-relaxed text-ink-2"
+                            >
+                                {item}
+                            </li>
+                        ))}
+                    </ul>
+                </section>
+
+                <section
+                    className="mt-12"
+                    aria-labelledby="openadapt-differs-heading"
+                >
+                    <h2
+                        id="openadapt-differs-heading"
+                        className="font-display text-2xl font-semibold tracking-tight text-ink"
+                    >
+                        What OpenAdapt does differently
+                    </h2>
+                    <p className="mt-3 max-w-3xl text-sm leading-relaxed text-ink-2 md:text-base">
+                        These are the differences that hold up under scrutiny.
+                        Recording demonstrations, visual targeting, virtual
+                        desktop awareness, and selector repair are broadly
+                        available across modern tools and are not claimed here
+                        as unique.
+                    </p>
+                    <div className="mt-6 grid gap-4 sm:grid-cols-2">
+                        {OPENADAPT_DIFFERENTIATORS.map((item) => (
+                            <article
+                                key={item.title}
+                                className="rounded-2xl border border-hairline bg-panel p-5"
+                            >
+                                <h3 className="font-display text-lg font-semibold text-ink">
+                                    {item.title}
+                                </h3>
+                                <p className="mt-2 text-sm leading-relaxed text-ink-2">
+                                    {item.body}
+                                </p>
+                            </article>
+                        ))}
+                    </div>
+                    <p className="mt-4 text-sm leading-relaxed text-ink-3">
+                        Per-surface acceptance results are published in the{' '}
+                        <a
+                            href={QUALIFICATION_EVIDENCE_URL}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-accent"
+                        >
+                            qualification evidence
+                        </a>
+                        .
+                    </p>
+                </section>
+
+                <section
+                    className="mt-12 rounded-2xl border-2 border-ink bg-panel p-6 md:p-8"
+                    aria-labelledby="which-to-choose-heading"
+                >
+                    <h2
+                        id="which-to-choose-heading"
+                        className="font-display text-2xl font-semibold tracking-tight text-ink"
+                    >
+                        Which should you choose?
+                    </h2>
+                    <div className="mt-5 grid gap-6 md:grid-cols-2">
+                        <div>
+                            <h3 className="font-display text-lg font-semibold text-ink">
+                                Choose {comparison.name} when
+                            </h3>
+                            <p className="mt-2 text-sm leading-relaxed text-ink-2">
+                                {comparison.chooseThem}
+                            </p>
+                        </div>
+                        <div>
+                            <h3 className="font-display text-lg font-semibold text-ink">
+                                Choose OpenAdapt when
+                            </h3>
+                            <p className="mt-2 text-sm leading-relaxed text-ink-2">
+                                {comparison.chooseUs}
+                            </p>
+                        </div>
+                    </div>
+                    <p className="mt-6 border-t border-hairline pt-4 text-sm leading-relaxed text-ink-3">
+                        {comparison.honestNote}
+                    </p>
+                </section>
+
+                <section className="mt-12" aria-labelledby="other-compares">
+                    <h2
+                        id="other-compares"
+                        className="font-display text-xl font-semibold tracking-tight text-ink"
+                    >
+                        Other comparisons
+                    </h2>
+                    <ul className="mt-4 flex flex-wrap gap-x-6 gap-y-2 text-sm">
+                        <li>
+                            <Link href="/compare" className="text-accent">
+                                Overview: compare all approaches
+                            </Link>
+                        </li>
+                        {COMPARISON_LINKS.filter(
+                            (link) => link.slug !== comparison.slug
+                        ).map((link) => (
+                            <li key={link.slug}>
+                                <Link href={link.href} className="text-accent">
+                                    {link.title}
+                                </Link>
+                            </li>
+                        ))}
+                    </ul>
+                </section>
+
+                <section className="mt-12 rounded-2xl border border-hairline bg-panel p-6 text-center md:p-8">
+                    <h2 className="font-display text-2xl font-semibold tracking-tight text-ink">
+                        Test the difference on one real workflow.
+                    </h2>
+                    <p className="mx-auto mt-3 max-w-2xl text-sm leading-relaxed text-ink-2 md:text-base">
+                        Bring one repeated, consequential workflow and measure
+                        authoring time, run time, intervention rate, and
+                        incorrect-success rate against your current approach.
+                    </p>
+                    <div className="mt-5 flex flex-wrap justify-center gap-3">
+                        <Link href="/qualify" className="btn-ink">
+                            Qualify one workflow
+                        </Link>
+                        <a
+                            href="https://docs.openadapt.ai/get-started/"
+                            className="btn-ghost-ink"
+                        >
+                            Try the open-source runtime
+                        </a>
+                    </div>
+                </section>
+            </main>
+
+            <Footer />
+        </div>
+    )
+}

--- a/pages/how-it-works.js
+++ b/pages/how-it-works.js
@@ -6,6 +6,7 @@ import DriftOutcomes from '@components/DriftOutcomes'
 import Footer from '@components/Footer'
 import HowItWorksCondensed from '@components/HowItWorksCondensed'
 import ReferenceDemoShowcase from '@components/ReferenceDemoShowcase'
+import RemoteModesFigure from '@components/RemoteModesFigure'
 import Reveal from '@components/Reveal'
 
 // Concepts / method page. The homepage keeps one clear narrative arc, so the
@@ -101,6 +102,10 @@ export default function HowItWorksPage() {
             </Reveal>
             <Reveal>
                 <DriftOutcomes />
+            </Reveal>
+
+            <Reveal>
+                <RemoteModesFigure />
             </Reveal>
 
             <Reveal>

--- a/pages/partners.js
+++ b/pages/partners.js
@@ -1,0 +1,202 @@
+import Head from 'next/head'
+import Link from 'next/link'
+
+import Footer from '@components/Footer'
+import PartnerInquiryForm from '@components/PartnerInquiryForm'
+
+// Partner program v1. Status-honest: this is a program you apply to, with
+// individually reviewed applications, not a self-serve portal, a partner
+// directory, or a certification marketplace. Each track states its commercial
+// model and where the responsibility boundary sits for qualification,
+// support, and workflow packs, so a prospective partner can self-select
+// before applying through the dedicated partner-inquiry intake.
+
+const description =
+    'Partner with OpenAdapt: embed or white-label the governed runtime, operate verified workflows for your clients, or deliver and deploy qualified automations. Apply to the partner program.'
+
+const TRACKS = [
+    {
+        id: 'vertical_oem',
+        title: 'Vertical software / OEM',
+        who: 'Vertical SaaS and software vendors whose customers still re-key data into EMRs, practice management, loan origination, claims, and other systems of record.',
+        model: 'Embed or white-label. Ship governed, verified execution as a feature of your product, under your brand where appropriate, on commercial OEM terms.',
+        boundaries: [
+            'Qualification: each workflow and target application is qualified jointly before consequential use; OpenAdapt provides the qualification tooling and evidence format.',
+            'Support: you own first-line support inside your product; OpenAdapt provides engine-level escalation.',
+            'Packs: you own the vertical workflow packs for your market; OpenAdapt owns the runtime and verification contracts underneath them.',
+        ],
+    },
+    {
+        id: 'rcm_bpo',
+        title: 'RCM and BPO operators',
+        who: 'Revenue-cycle, claims, and back-office operations teams that run high-volume repeated work for their own clients.',
+        model: 'Managed operations. You operate compiled, verified workflows for your clients on customer-controlled or operator-controlled runtimes, and keep the client relationship.',
+        boundaries: [
+            'Qualification: each client workflow is qualified against its exact application and environment before production; you provide the environment access, OpenAdapt provides the method and evidence.',
+            'Support: you own client-facing operations and first-line support; OpenAdapt supports the runtime and verification behavior.',
+            'Packs: workflow definitions built for your clients stay yours; the underlying runtime stays MIT-licensed and inspectable.',
+        ],
+    },
+    {
+        id: 'integration_services',
+        title: 'Integration and services partners',
+        who: 'Automation consultancies and system integrators who scope, build, and hand over workflow automations for clients.',
+        model: 'Services delivery. You run discovery, implementation, and rollout engagements on top of the open runtime and the qualification method.',
+        boundaries: [
+            'Qualification: you run qualification sprints with your clients using the published method; OpenAdapt reviews evidence for consequential go-lives.',
+            'Support: you own the engagement and first-line support; OpenAdapt provides second-line engine support.',
+            'Packs: you can build and reuse implementation accelerators; runtime and verification contract changes land upstream, not in forks.',
+        ],
+    },
+    {
+        id: 'msp_deployment',
+        title: 'MSP and deployment partners',
+        who: 'Managed service providers who own customer infrastructure, including locked-down, private-network, and virtual desktop estates.',
+        model: 'Managed deployment. You deploy and operate the runtime inside customer boundaries, including customer-controlled and self-hosted footprints.',
+        boundaries: [
+            'Qualification: environment readiness (identity, network, remote client, and update policy) is yours; workflow qualification follows the shared method.',
+            'Support: you own environment monitoring and updates rollout; OpenAdapt owns runtime releases and security advisories.',
+            'Packs: deployment runbooks and hardening baselines are shared working material within the program.',
+        ],
+    },
+]
+
+export default function PartnersPage() {
+    return (
+        <div className="min-h-screen bg-ground text-ink">
+            <Head>
+                <title>Partner Program | OpenAdapt</title>
+                <meta name="description" content={description} />
+                <link rel="canonical" href="https://openadapt.ai/partners" />
+                <meta
+                    property="og:title"
+                    content="Partner Program | OpenAdapt"
+                />
+                <meta property="og:description" content={description} />
+                <meta
+                    property="og:url"
+                    content="https://openadapt.ai/partners"
+                />
+            </Head>
+
+            <main className="mx-auto max-w-4xl px-4 py-14">
+                <p className="eyebrow">Partner program</p>
+                <h1 className="font-display mt-3 max-w-3xl text-3xl font-semibold tracking-tight text-ink md:text-5xl">
+                    Bring verified execution to the customers you already
+                    serve.
+                </h1>
+                <p className="mt-5 max-w-3xl text-base leading-relaxed text-ink-2 md:text-lg">
+                    OpenAdapt compiles demonstrated GUI workflows into
+                    deterministic, governed programs and verifies the business
+                    effect out of band. Partners embed it in their products,
+                    operate it for their clients, or deliver and deploy it
+                    inside customer boundaries. The runtime is MIT-licensed;
+                    the partnership adds commercial terms, qualification
+                    method, and support boundaries.
+                </p>
+
+                <section className="mt-12" aria-labelledby="tracks-heading">
+                    <h2
+                        id="tracks-heading"
+                        className="font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl"
+                    >
+                        Four partner tracks
+                    </h2>
+                    <div className="mt-6 space-y-6">
+                        {TRACKS.map((track) => (
+                            <article
+                                key={track.id}
+                                className="rounded-2xl border border-hairline bg-panel p-6 md:p-8"
+                            >
+                                <h3 className="font-display text-xl font-semibold text-ink">
+                                    {track.title}
+                                </h3>
+                                <p className="mt-2 text-sm leading-relaxed text-ink-2">
+                                    {track.who}
+                                </p>
+                                <p className="mt-3 text-sm leading-relaxed text-ink">
+                                    <span className="font-semibold">
+                                        Model:{' '}
+                                    </span>
+                                    {track.model}
+                                </p>
+                                <h4 className="mt-4 font-display text-sm font-semibold uppercase tracking-wide text-ink-3">
+                                    Responsibility boundaries
+                                </h4>
+                                <ul className="mt-2 space-y-2">
+                                    {track.boundaries.map((boundary) => (
+                                        <li
+                                            key={boundary}
+                                            className="text-sm leading-relaxed text-ink-2"
+                                        >
+                                            {boundary}
+                                        </li>
+                                    ))}
+                                </ul>
+                            </article>
+                        ))}
+                    </div>
+                </section>
+
+                <section
+                    className="mt-12 rounded-2xl border border-hairline bg-panel p-6 md:p-8"
+                    aria-labelledby="program-status-heading"
+                >
+                    <p className="eyebrow">Program status</p>
+                    <h2
+                        id="program-status-heading"
+                        className="mt-2 font-display text-2xl font-semibold tracking-tight text-ink"
+                    >
+                        An application-based program, not a self-serve portal.
+                    </h2>
+                    <p className="mt-3 max-w-3xl text-sm leading-relaxed text-ink-2 md:text-base">
+                        We review every application individually and start each
+                        partnership from one concrete customer workflow, not a
+                        logo exchange. There is no self-serve partner portal,
+                        directory listing, or certification marketplace today.
+                        Commercial terms (OEM, operations, and services) are
+                        agreed per partner. Consequential workflows go live
+                        only after qualification on the exact application and
+                        environment, per the published{' '}
+                        <a
+                            href="https://docs.openadapt.ai/get-started/what-works-today/"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-accent"
+                        >
+                            qualification evidence
+                        </a>
+                        .
+                    </p>
+                </section>
+
+                <section
+                    id="apply"
+                    className="mt-12 scroll-mt-8"
+                    aria-labelledby="apply-heading"
+                >
+                    <h2
+                        id="apply-heading"
+                        className="font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl"
+                    >
+                        Apply to the partner program
+                    </h2>
+                    <p className="mt-3 max-w-3xl text-sm leading-relaxed text-ink-2 md:text-base">
+                        Tell us which track fits and what you would build or
+                        operate. If a specific end-customer workflow is already
+                        in view, the fastest path is to also{' '}
+                        <Link href="/qualify" className="text-accent">
+                            qualify that workflow
+                        </Link>
+                        .
+                    </p>
+                    <div className="mt-6">
+                        <PartnerInquiryForm />
+                    </div>
+                </section>
+            </main>
+
+            <Footer />
+        </div>
+    )
+}

--- a/public/form.html
+++ b/public/form.html
@@ -51,8 +51,23 @@
   <input type="text" name="timeline" />
   <input type="text" name="budget" />
   <input type="text" name="reusePotential" />
+  <input type="text" name="leadSegment" />
+  <input type="text" name="privacyConsent" />
   <input type="text" name="qualificationScore" />
   <input type="text" name="qualificationTier" />
+</form>
+
+<form name="partner-inquiry" data-netlify="true" method="POST" netlify netlify-honeypot="bot-field">
+  <input type="hidden" name="form-name" value="partner-inquiry" />
+  <input type="text" name="bot-field" />
+  <input type="text" name="name" />
+  <input type="email" name="email" />
+  <input type="text" name="company" />
+  <input type="text" name="role" />
+  <input type="text" name="track" />
+  <input type="text" name="systems" />
+  <textarea name="message"></textarea>
+  <button type="submit">Apply to partner</button>
 </form>
 
 <form name="contributor-program" data-netlify="true" method="POST" netlify netlify-honeypot="bot-field">

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -14,6 +14,13 @@
 ## Core Concepts
 - [How It Works](https://openadapt.ai/#how-it-works): Record, compile, replay, resolve or halt, then verify and report
 - [Compare Approaches](https://openadapt.ai/compare): When to choose OpenAdapt, traditional RPA, computer-use agents, browser recorders, or a direct API
+- [OpenAdapt vs UiPath](https://openadapt.ai/compare/uipath): Honest comparison with the leading enterprise RPA platform
+- [OpenAdapt vs Microsoft Power Automate](https://openadapt.ai/compare/power-automate): Honest comparison with Microsoft ecosystem RPA
+- [OpenAdapt vs computer-use agents](https://openadapt.ai/compare/computer-use-agents): Deterministic verified replay compared with per-run model agents
+- [OpenAdapt vs record-and-replay tools](https://openadapt.ai/compare/record-and-replay): What governance adds beyond demonstration-based authoring
+- [OpenAdapt vs browser-agent platforms](https://openadapt.ai/compare/browser-agents): Cross-surface verified execution compared with web-agent stacks
+- [OpenAdapt vs hand-rolled scripts](https://openadapt.ai/compare/hand-rolled-scripts): What governed verification adds beyond Playwright or Selenium scripts
+- [Partner Program](https://openadapt.ai/partners): Application-based tracks for vertical software/OEM, RCM and BPO operators, integration/services, and MSP/deployment partners
 - [How It Runs](https://openadapt.ai/#product-status): Governed workflow lifecycle and local, managed cloud, or customer-controlled execution
 - [FAQ](https://openadapt.ai/#faq): How OpenAdapt differs from RPA tools and AI computer-use agents, data locality, licensing
 - [Security and Data Boundaries](https://openadapt.ai/security): Screenshot, model, secret, report, certification, and commercial deployment boundaries

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -139,6 +139,48 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://openadapt.ai/partners</loc>
+    <lastmod>2026-07-26</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://openadapt.ai/compare/uipath</loc>
+    <lastmod>2026-07-26</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://openadapt.ai/compare/power-automate</loc>
+    <lastmod>2026-07-26</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://openadapt.ai/compare/computer-use-agents</loc>
+    <lastmod>2026-07-26</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://openadapt.ai/compare/record-and-replay</loc>
+    <lastmod>2026-07-26</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://openadapt.ai/compare/browser-agents</loc>
+    <lastmod>2026-07-26</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://openadapt.ai/compare/hand-rolled-scripts</loc>
+    <lastmod>2026-07-26</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://openadapt.ai/privacy-policy</loc>
     <lastmod>2026-05-25</lastmod>
     <changefreq>yearly</changefreq>

--- a/tests/comparisonPages.test.js
+++ b/tests/comparisonPages.test.js
@@ -1,0 +1,150 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+const root = path.join(__dirname, '..')
+const read = (relativePath) =>
+    fs.readFileSync(path.join(root, relativePath), 'utf8')
+
+const dataSource = read('data/comparisons.js')
+const detailPage = read('pages/compare/[slug].js')
+const overview = read('pages/compare.js')
+const llms = read('public/llms.txt')
+const sitemap = read('public/sitemap.xml')
+
+// The data module is plain ESM with no JSX, so it can be imported directly.
+const load = () => import('../data/comparisons.js')
+
+const EXPECTED_SLUGS = [
+    'uipath',
+    'power-automate',
+    'computer-use-agents',
+    'record-and-replay',
+    'browser-agents',
+    'hand-rolled-scripts',
+]
+
+test('every targeted comparison page exists with complete, structured content', async () => {
+    const { COMPARISONS } = await load()
+    assert.deepEqual(
+        COMPARISONS.map(({ slug }) => slug).sort(),
+        [...EXPECTED_SLUGS].sort()
+    )
+    for (const comparison of COMPARISONS) {
+        assert.ok(comparison.title.startsWith('OpenAdapt vs'), comparison.slug)
+        assert.ok(comparison.metaDescription.length > 60, comparison.slug)
+        assert.ok(comparison.intro.length > 100, comparison.slug)
+        assert.ok(
+            comparison.theirStrengths.items.length >= 4,
+            `${comparison.slug} credits the alternative with at least four real strengths`
+        )
+        assert.ok(comparison.chooseThem.length > 80, comparison.slug)
+        assert.ok(comparison.chooseUs.length > 80, comparison.slug)
+        assert.ok(comparison.honestNote.length > 80, comparison.slug)
+    }
+})
+
+test('OpenAdapt differentiates only on the real axes, never commoditized ones', async () => {
+    const { OPENADAPT_DIFFERENTIATORS } = await load()
+    const titles = OPENADAPT_DIFFERENTIATORS.map(({ title }) => title)
+    for (const required of [
+        'Independent business-effect verification',
+        'Explicit transaction outcomes',
+        'Deterministic healthy runs',
+        'External zero-install remote lane',
+        'Customer-controlled sensitive data',
+        'Open MIT local runtime',
+        'Published qualification evidence',
+    ]) {
+        assert.ok(titles.includes(required), `differentiator: ${required}`)
+    }
+
+    // Commoditized capabilities must never be claimed as unique. Recording,
+    // visual targeting, Citrix awareness, and self-healing are widely
+    // available; the copy may mention them only to disclaim them. Comments
+    // quote the banned phrases as guidance, so strip them first.
+    const rendered = dataSource
+        .replace(/^\s*\/\/.*$/gm, '')
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+    assert.doesNotMatch(rendered, /self[- ]heal/i)
+    assert.doesNotMatch(rendered, /only (tool|platform|product) that/i)
+    assert.doesNotMatch(rendered, /unique(ly)? (able|capable)/i)
+    assert.match(
+        rendered,
+        /not differentiators|not claimed here|does not claim to record better|commodity/,
+        'copy explicitly disclaims commoditized capabilities'
+    )
+})
+
+test('competitor pricing stays within well-known published figures, hedged', () => {
+    // The only currency figures allowed anywhere in the comparison content
+    // are Power Automate's widely published price points, and each must be
+    // hedged with "around" plus a "published pricing" frame.
+    const dollarFigures = dataSource.match(/\$\d[\d,]*/g) || []
+    assert.deepEqual([...new Set(dollarFigures)].sort(), ['$15', '$215'])
+    assert.match(dataSource, /published pricing/i)
+    assert.match(dataSource, /around \$15 per user per month/)
+    assert.match(dataSource, /\$215 per bot per month/)
+    assert.match(dataSource, /roughly \$215/)
+})
+
+test('external-lane claims carry the honest qualification status', () => {
+    // Mirrors public/status.json: the external lane is qualified against a
+    // deterministic stand-in (and a real FreeRDP round trip); real ICA/HDX
+    // is qualified per customer before consequential use.
+    for (const [label, source] of [
+        ['comparisons data', dataSource],
+        ['remote modes figure', read('components/RemoteModesFigure.js')],
+    ]) {
+        assert.match(source, /stand-in/, `${label} discloses the stand-in`)
+        assert.match(source, /ICA\/HDX/, `${label} names the pending scope`)
+        assert.match(
+            source,
+            /qualified per customer/,
+            `${label} states per-customer qualification`
+        )
+    }
+})
+
+test('detail pages render both sides and route from the overview page', () => {
+    assert.match(detailPage, /getStaticPaths/)
+    assert.match(detailPage, /theirStrengths/)
+    assert.match(detailPage, /What OpenAdapt does differently/)
+    assert.match(detailPage, /Choose \{comparison\.name\} when/)
+    assert.match(detailPage, /Choose OpenAdapt when/)
+    assert.match(detailPage, /honestNote/)
+
+    assert.match(overview, /COMPARISON_LINKS/)
+    assert.match(overview, /Compare OpenAdapt with a specific alternative\./)
+})
+
+test('machine-readable discovery includes every comparison route', () => {
+    for (const slug of EXPECTED_SLUGS) {
+        assert.match(
+            llms,
+            new RegExp(`https://openadapt\\.ai/compare/${slug}`),
+            `llms.txt lists /compare/${slug}`
+        )
+        assert.match(
+            sitemap,
+            new RegExp(`https://openadapt\\.ai/compare/${slug}`),
+            `sitemap lists /compare/${slug}`
+        )
+    }
+})
+
+test('comparison and partner surfaces contain no em dashes', () => {
+    for (const relativePath of [
+        'data/comparisons.js',
+        'pages/compare/[slug].js',
+        'pages/partners.js',
+        'components/PartnerInquiryForm.js',
+        'components/RemoteModesFigure.js',
+    ]) {
+        assert.ok(
+            !read(relativePath).includes('—'),
+            `${relativePath} has no em dashes`
+        )
+    }
+})

--- a/tests/leadPrivacy.test.js
+++ b/tests/leadPrivacy.test.js
@@ -1,0 +1,110 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+const root = path.join(__dirname, '..')
+const read = (relativePath) =>
+    fs.readFileSync(path.join(root, relativePath), 'utf8')
+
+// Lead data must never appear in a URL: not in the fetch target, not in a
+// query string, and not through a native GET fallback if JavaScript fails
+// mid-submit. Complemented by the browser-level check in
+// cypress/e2e/lead-privacy.cy.js.
+
+const LEAD_FORMS = [
+    'components/WorkflowQualificationForm.js',
+    'components/PartnerInquiryForm.js',
+    'components/ContributorProgramForm.js',
+]
+
+test('lead forms submit through a POST body, never a URL', () => {
+    for (const relativePath of LEAD_FORMS) {
+        const source = read(relativePath)
+
+        // The durable Netlify path is always a bare '/form.html' with the
+        // encoded fields in the request body.
+        assert.match(source, /fetch\('\/form\.html'/, relativePath)
+        assert.match(source, /method: 'POST'/, relativePath)
+        assert.match(
+            source,
+            /body: (data|formData)\.toString\(\)/,
+            relativePath
+        )
+
+        // Never a query string on the submission target.
+        assert.doesNotMatch(source, /form\.html\?/, relativePath)
+        assert.doesNotMatch(source, /[?&]email=/, relativePath)
+
+        // Never a client-side navigation that could carry lead fields.
+        assert.doesNotMatch(
+            source,
+            /window\.location\s*=|location\.href\s*=|router\.push\(`[^`]*\$\{/,
+            relativePath
+        )
+
+        // No action attribute: combined with an explicit POST method there
+        // is no native fallback that serializes fields into a query string.
+        assert.doesNotMatch(source, /<form[^>]*\baction=/s, relativePath)
+    }
+
+    // The two forms this change owns also declare method="POST" in markup so
+    // even a JS-less native submit cannot GET lead fields into a URL.
+    for (const relativePath of [
+        'components/WorkflowQualificationForm.js',
+        'components/PartnerInquiryForm.js',
+    ]) {
+        assert.match(read(relativePath), /method="POST"/, relativePath)
+    }
+})
+
+test('qualification analytics events carry no lead fields', () => {
+    const source = read('components/WorkflowQualificationForm.js')
+    // Funnel events send routing metadata only; asserting the exact payloads
+    // keeps emails, names, and workflow text out of analytics URLs.
+    assert.match(
+        source,
+        /track\(EVENTS\.QUALIFICATION_FORM_START, \{ location: [^}]*\}\)/
+    )
+    assert.match(
+        source,
+        /track\(EVENTS\.QUALIFICATION_FORM_SUBMIT, \{\s*tier: qualification\.tier,\s*location: [^}]*\}\)/
+    )
+    assert.doesNotMatch(source, /track\([^)]*form\.email/s)
+    assert.doesNotMatch(source, /track\([^)]*form\.name/s)
+})
+
+test('the qualification intake captures consent and lead segment durably', () => {
+    const source = read('components/WorkflowQualificationForm.js')
+    const definitions = read('public/form.html')
+
+    // Required, privacy-policy-linked consent.
+    assert.match(
+        source,
+        /name="privacyConsent"[\s\S]{0,200}required/,
+        'consent checkbox is required'
+    )
+    assert.match(source, /href="\/privacy-policy"/)
+
+    // Captured lead segment with the five audience values.
+    for (const segment of [
+        'enterprise_operator',
+        'oem_vertical',
+        'bpo_services',
+        'developer',
+        'community',
+    ]) {
+        assert.ok(
+            source.includes(`value="${segment}"`),
+            `lead segment option ${segment}`
+        )
+    }
+
+    // Both fields are registered in the durable Netlify definition, or the
+    // values would be silently dropped from submissions.
+    const qualificationDefinition = definitions
+        .split('name="workflow-qualification"')[1]
+        .split('</form>')[0]
+    assert.match(qualificationDefinition, /name="leadSegment"/)
+    assert.match(qualificationDefinition, /name="privacyConsent"/)
+})

--- a/tests/partnersProgram.test.js
+++ b/tests/partnersProgram.test.js
@@ -1,0 +1,98 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+const root = path.join(__dirname, '..')
+const read = (relativePath) =>
+    fs.readFileSync(path.join(root, relativePath), 'utf8')
+
+const page = read('pages/partners.js')
+const intake = read('components/PartnerInquiryForm.js')
+const formDefinitions = read('public/form.html')
+const nav = read('components/NavHeader.js')
+const footer = read('components/Footer.js')
+
+const TRACK_VALUES = [
+    'vertical_oem',
+    'rcm_bpo',
+    'integration_services',
+    'msp_deployment',
+]
+
+test('partner leads use a dedicated Netlify form, segmented from contact', () => {
+    // The runtime submit and the build-time definition must agree on the
+    // form name, or Netlify silently drops submissions.
+    assert.match(intake, /formData\.set\('form-name', 'partner-inquiry'\)/)
+    assert.match(intake, /fetch\('\/form\.html'/)
+    assert.match(
+        formDefinitions,
+        /<form name="partner-inquiry" data-netlify="true"/
+    )
+    for (const field of [
+        'name',
+        'email',
+        'company',
+        'role',
+        'track',
+        'systems',
+        'message',
+    ]) {
+        assert.ok(
+            new RegExp(`name="${field}"`).test(intake),
+            `intake posts field ${field}`
+        )
+        const partnerDefinition = formDefinitions
+            .split('<form name="partner-inquiry"')[1]
+            .split('</form>')[0]
+        assert.ok(
+            new RegExp(`name="${field}"`).test(partnerDefinition),
+            `form.html registers partner field ${field}`
+        )
+    }
+    assert.match(page, /PartnerInquiryForm/)
+})
+
+test('the track selector matches the tracks presented on the page', () => {
+    for (const value of TRACK_VALUES) {
+        assert.ok(
+            intake.includes(`value: '${value}'`),
+            `intake offers track ${value}`
+        )
+        assert.ok(page.includes(`id: '${value}'`), `page presents ${value}`)
+    }
+})
+
+test('each track states its model and responsibility boundaries', () => {
+    for (const heading of [
+        'Vertical software / OEM',
+        'RCM and BPO operators',
+        'Integration and services partners',
+        'MSP and deployment partners',
+    ]) {
+        assert.ok(page.includes(heading), `track: ${heading}`)
+    }
+    assert.match(page, /model:/)
+    assert.match(page, /boundaries: \[/)
+    assert.match(page, /Responsibility boundaries/)
+    // Every track spells out the three boundary dimensions.
+    assert.equal((page.match(/Qualification:/g) || []).length, 4)
+    assert.equal((page.match(/Support:/g) || []).length, 4)
+    assert.equal((page.match(/Packs:/g) || []).length, 4)
+})
+
+test('the program is status-honest: apply, not self-serve', () => {
+    assert.match(page, /not a self-serve portal/)
+    assert.match(page, /review every application individually/i)
+    assert.doesNotMatch(page, /partner portal today is live|sign up now/i)
+    assert.match(intake, /Apply to partner/)
+})
+
+test('partners is reachable from the primary nav and the footer', () => {
+    assert.ok(nav.includes(`{ label: 'Partners & OEM', href: '/partners' }`))
+    assert.ok(footer.includes('href="/partners"'))
+    // Community path: the footer offers the contribute program.
+    assert.ok(
+        footer.includes(`{ label: 'Contribute workflows', href: '/contribute' }`)
+    )
+})


### PR DESCRIPTION
## What

Targeted public-site work from roadmap Sections 21 and 18 plus small intake enhancements. Builds on the recently merged contribute set (#262), case study (#301), and hero reconciliation (#302). Does not touch the homepage hero/narrative, the case-study page, or /contribute content.

### 1. Comparison pages (Section 21)
Six pages under `/compare/<slug>`, driven by `data/comparisons.js` and rendered by `pages/compare/[slug].js`; the existing `/compare` overview gains a linking section (its existing copy/tests unchanged):
- `/compare/uipath`
- `/compare/power-automate`
- `/compare/computer-use-agents`
- `/compare/record-and-replay`
- `/compare/browser-agents`
- `/compare/hand-rolled-scripts`

Honesty rules are enforced by `tests/comparisonPages.test.js`: each page credits at least four real competitor strengths; OpenAdapt differentiates only on independent out-of-band effect verification, explicit verified-or-halted outcomes, deterministic zero-model-call healthy runs, the external zero-install remote lane (status-hedged), customer-controlled data, the MIT runtime, and published qualification evidence. Recording, visual targeting, Citrix awareness, and self-healing are explicitly disclaimed as commodities. The only competitor dollar figures allowed anywhere are Power Automate's published ~$15/user/mo and ~$215/bot/mo hosted-RPA class, both hedged ("published pricing starts around ...").

### 2. Partners page (Section 18 v1)
`/partners` with four tracks (vertical software/OEM, RCM+BPO operators, integration/services, MSP/deployment). Each track states its model (embed/white-label, managed operations, services delivery, managed deployment) and responsibility boundaries for qualification, support, and packs. Status-honest: application-based program, explicitly "not a self-serve portal". Dedicated Netlify form `partner-inquiry` (track selector, durable POST to `/form.html`, registered in `public/form.html`), same pattern as `contributor-program`. Guarded by `tests/partnersProgram.test.js` (form-name sync, track parity, boundary completeness, status honesty).

### 3. Nav / footer IA
- Nav Solutions dropdown: "Partners & OEM" -> `/partners`
- Footer Company column: "Partners & OEM" -> `/partners`
- Footer Connect column: "Contribute workflows" -> `/contribute` (community path)
Enterprise (`/qualify`, solutions, security) and developers (Developers menu) paths already existed and are unchanged.

### 4. External-vs-in-session diagram (Section 21)
`components/RemoteModesFigure.js` on `/how-it-works`: styled HTML/CSS figure showing in-session (runner inside the managed session, when policy permits) vs external black-box (runner drives the local Citrix/RDP client window; zero install in the remote session). Status caption mirrors `public/status.json`: external lane qualified against a deterministic no-DOM stand-in plus a real FreeRDP round trip; real ICA/HDX qualified per customer before consequential use. Honesty wording is test-enforced.

### 5. Intake polish
On the workflow-qualification form (structure otherwise unchanged):
- Required consent checkbox linking `/privacy-policy`, serialized as `privacyConsent=yes`
- Captured `leadSegment` select (enterprise_operator / oem_vertical / bpo_services / developer / community)
- Both fields registered in the durable `public/form.html` definition
- `method="POST"` on the form element so even a JS-less native submit cannot GET lead fields into a URL
- `tests/leadPrivacy.test.js` (node) + `cypress/e2e/lead-privacy.cy.js` (browser): lead fields travel only in the POST body; the page URL never contains a lead value

Also: sitemap.xml and llms.txt updated with the seven new routes.

## Competitor facts asserted (for founder double-check)
- UiPath: mature enterprise RPA platform; Orchestrator (scheduling, queues, credential vaults, RBAC, audit); long-standing Citrix/virtual-desktop automation support; large marketplace + UiPath Academy + certified-partner ecosystem; attended/unattended robots, document understanding, process mining. No pricing stated.
- Power Automate: deep Microsoft 365/Teams/Excel/SharePoint/Dataverse/Entra integration; hundreds of prebuilt connectors; Power Automate for desktop included with Windows 11 for attended flows; published pricing starts around $15/user/mo premium and hosted RPA bots in the roughly $215/bot/mo class; Power Platform admin center governance.
- Computer-use agents (Anthropic/OpenAI): flexible on novel tasks, no per-workflow setup, model inference per step, probabilistic outcomes, providers recommend human oversight for consequential actions. No pricing stated.
- Record & Replay: named OpenAI's Record & Replay as mainstream validation of demonstration-based authoring; no mechanism, pricing, or scale numbers asserted.
- Browser agents and hand-rolled scripts: category-level only, no named vendors or figures.

## Tests
- `npm test`: 153/153 pass (includes 3 new test files)
- `npm run build` (prebuild tests + verify + next build): green; all 7 new routes prerender
- Full local Cypress suite against the built site: 51/51 pass (includes the 2 new lead-privacy tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM