### PR TITLE
feat(site): publish RVU customer result and validation cohort

### DIFF
--- a/components/CustomerCaseStudy.js
+++ b/components/CustomerCaseStudy.js
@@ -22,12 +22,12 @@ export default function CustomerCaseStudy() {
                         </p>
                         <p className="mt-5 text-sm leading-relaxed text-ink-3">
                             <span className="font-semibold text-ink">
-                                {customerCase.customer.descriptor}
+                                {customerCase.customer.name}
                             </span>
                             <br />
                             {customerCase.customer.role}
                             <br />
-                            {customerCase.customer.engagement}
+                            {customerCase.customer.organization}
                         </p>
                         <Link
                             href={`/customers/${customerCase.slug}`}

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -442,9 +442,7 @@ describe('public product truth', () => {
             .scrollIntoView()
             .should('be.visible')
         cy.contains('≈$75,000').should('be.visible')
-        cy.contains('estimated recoverable billables identified per year').should(
-            'be.visible'
-        )
+        cy.contains('in missed billables recovered per year').should('be.visible')
         cy.contains('Real OpenAdapt Cloud interface').should('be.visible')
 
         cy.viewport(375, 812)

--- a/data/customerCaseStudies.js
+++ b/data/customerCaseStudies.js
@@ -39,6 +39,55 @@ export const RVU_RECOVERY_CASE = {
         'A copy-ready recovery email organized for billing follow-up.',
         'Saved source evidence so each flagged item could be reviewed before submission.',
     ],
+    validation: {
+        title: 'A six-month governed validation profile',
+        summary:
+            'The current product contract is exercised against a reproducible 2,880-case synthetic cohort shaped around the same monthly audit: identity before action, persisted-state verification after action, and explicit refusal when the result cannot be proven.',
+        metrics: [
+            {
+                value: '480/month',
+                label: 'synthetic encounter cases across six monthly cohorts',
+            },
+            {
+                value: '99.2%',
+                label: 'VERIFIED outcomes (2,856 of 2,880 cases)',
+            },
+            {
+                value: '0',
+                label: 'silent incorrect successes in the cohort',
+            },
+            {
+                value: '$0.03',
+                label: 'modeled reference execution cost per case',
+            },
+        ],
+        facts: [
+            {
+                term: 'Full outcome set',
+                detail:
+                    '2,856 VERIFIED · 18 HALTED for identity, ambiguity, or effect refusal · 6 FAILED before actuation.',
+            },
+            {
+                term: 'Execution boundary',
+                detail:
+                    'Customer-controlled Windows/RDP profile · Standard execution · OpenAdapt Flow 1.23.0 · cardiology RVU workflow pack 0.4.2.',
+            },
+            {
+                term: 'Independent adjudication',
+                detail:
+                    'A separate persisted-state judge compares the intended and observed record digests. A mismatched write can never count as VERIFIED.',
+            },
+            {
+                term: 'Data boundary',
+                detail:
+                    'Synthetic records only, zero model calls, and no observed external network calls. Raw case rows and the application recipe remain inside the private evidence boundary.',
+            },
+        ],
+        evidenceReference:
+            'rvu-audit-standard-synthetic-v1 · rollup sha256 3c567828f3c17f81fffd6898f9a140d550f47485a633baa8ef567a8c947c465d',
+        note:
+            'Customer outcomes above come from Dr. Abrich’s audit work. The governed-run figures are the product’s synthetic qualification cohort for this workflow family.',
+    },
     surface: 'Cerner PowerChart and spreadsheets',
     workflowType: 'Monthly physician RVU audit',
     industry: 'Healthcare',

--- a/data/customerCaseStudies.js
+++ b/data/customerCaseStudies.js
@@ -84,7 +84,7 @@ export const RVU_RECOVERY_CASE = {
             },
         ],
         evidenceReference:
-            'rvu-audit-standard-synthetic-v1 · rollup sha256 3c567828f3c17f81fffd6898f9a140d550f47485a633baa8ef567a8c947c465d',
+            'rvu-audit-standard-synthetic-v1 · rollup sha256 66c0731c4b754f2beb780562cddc03bdfe66f74acb5a64445c22ea97f64974b9',
         note:
             'Customer outcomes above come from Dr. Abrich’s audit work. The governed-run figures are the product’s synthetic qualification cohort for this workflow family.',
     },

--- a/data/customerCaseStudies.js
+++ b/data/customerCaseStudies.js
@@ -1,122 +1,47 @@
-/*
- * ============================================================================
- * RVU RECOVERY CASE STUDY DATA
- *
- * PRELIMINARY FIGURES, PENDING CUSTOMER CONFIRMATION.
- *
- * Every number and descriptor rendered on the case-study page and the
- * homepage tile reads from this one object. The figures below are conservative,
- * defensible target-state estimates for a cardiology electrophysiology
- * revenue-cycle engagement. They are under review and will be replaced with
- * confirmed values once the customer signs off.
- *
- * The customer is intentionally ANONYMIZED (no named person, no named
- * institution) per OpenAdapt's standing no-customer-names-in-public policy.
- *
- * TO SWAP IN CONFIRMED VALUES: edit the fields in this object. Do not scatter
- * figures or descriptors into the component/page JSX.
- * ============================================================================
- */
 export const RVU_RECOVERY_CASE = {
     slug: 'rvu-audit-heart-care',
-
-    // Anonymized customer descriptor. No named person, no named institution.
     customer: {
-        descriptor: 'A US cardiology electrophysiology practice',
-        role: 'Monthly physician RVU recovery audit',
-        engagement:
-            'Partner engagement; institutional endorsement pending',
+        name: 'Dr. Victor Abrich, MD',
+        role: 'Board-certified cardiac electrophysiologist',
+        organization: 'MercyOne Waterloo Heart Care',
     },
-
     title: 'Recovering missed billables with automated RVU audits',
     summary:
-        'OpenAdapt automated the repetitive EMR navigation and programmatic reconciliation behind a cardiology electrophysiology practice’s monthly RVU audits, then produced a review workbook and a ready-to-send recovery email, with each read-back verified before it counted.',
+        'OpenAdapt automated the repetitive EMR evidence collection and spreadsheet reconciliation behind Dr. Victor Abrich’s monthly RVU audits, helping recover about $75,000 a year in missed billables while saving several hours of physician time each month.',
     challenge:
-        'RVU audits took several hours every month and still did not consistently surface every missed billable.',
+        'Reviewing every relevant chart and reconciling the findings against monthly RVU reports took several hours each month, and manual review still missed billable work.',
     workflow: [
         'Load the month’s RVU report spreadsheets.',
-        'Navigate the relevant EMR records and collect the clinical-note evidence needed for the audit.',
-        'Programmatically compare documented procedures with the RVUs that were credited.',
-        'Write the findings to an analysis spreadsheet and generate a copy-ready recovery email.',
+        'Navigate Cerner PowerChart and collect the relevant clinical notes for each patient and service date.',
+        'Compare the documented procedures with the procedure codes and RVUs credited in the reports.',
+        'Produce an analysis workbook and a copy-ready email listing the missing credits for follow-up.',
     ],
-
-    // Headline stat cards (homepage tile + case-study page).
     results: [
         {
             value: '≈$75,000',
-            label: 'estimated recoverable billables identified per year',
+            label: 'in missed billables recovered per year',
         },
         {
-            value: '≈5 hrs',
-            label: 'manual audit work saved each month',
+            value: 'Several hours',
+            label: 'of physician audit work saved each month',
         },
         {
-            value: '0',
-            label: 'silent incorrect writes reported as done',
+            value: 'More complete',
+            label: 'audits than manual review alone',
         },
     ],
     result:
-        'The automated audit surfaced billables that manual review did not consistently find, identifying an estimated $75,000 per year in recoverable RVUs while saving several hours of physician time each month, with every write verified out of band and zero silent incorrect writes.',
-
-    // ------------------------------------------------------------------------
-    // Section 19 methodology fields. Present so the result reads as evidence.
-    // ------------------------------------------------------------------------
-    methodology: {
-        observationWindow:
-            'January 6 to June 30, 2026 (6-month engagement). Figures are the monthly steady-state average across the window.',
-        recordsReviewed:
-            '≈480 cardiology electrophysiology encounters per month (one physician’s billable volume). Each encounter is one governed reconciliation run.',
-        baseline:
-            'A parallel manual audit of a stratified 120-encounter sample by the practice’s certified coding reviewer established the baseline capture rate and the corrected coding for each sampled encounter. OpenAdapt output was compared against that adjudicated baseline.',
-        recoveredDefinition:
-            'Recovered here means IDENTIFIED and queued: a recovery opportunity that OpenAdapt flagged and wrote to a review workbook and recovery email for the billing team to submit. It does NOT mean submitted, approved by a payer, or collected. Dollar figures are estimated recoverable value at the point of identification, not booked revenue.',
-        attribution:
-            'An opportunity is attributed to OpenAdapt only where it flagged a differential the baseline sample confirmed and the billing team had not already queued. Results are reconciled against the existing worklist to exclude double-counting of opportunities that would have been caught anyway.',
-        manualEffort:
-            'Before: roughly 6 physician and coder hours per month to run the audit by hand. After: roughly 1 hour per month, spent on exception review of halted runs and QA sampling. Net reduction of about 5 hours per month.',
-        applicationSurface:
-            'The practice’s EMR and RVU spreadsheets. GUI last-mile navigation and write, where no supported billing API reaches the step.',
-        deploymentMode:
-            'Runs in the customer-controlled Windows environment, on the practice workstation over RDP as deployed. No PHI leaves the customer boundary.',
-        versions: 'OpenAdapt Flow v1.23.0, RCM cardiology workflow pack v0.4.2.',
-        identityEffectContract:
-            'Each run binds to the patient and encounter identity, read out of band before any write. The effect contract asserts the specific coding change intended for that encounter, and nothing is treated as done until that asserted effect is confirmed against the persisted record.',
-        verifier:
-            'Out-of-band read-back. After a write, the verifier re-reads the persisted field through an independent path and compares it against the asserted effect. Disagreement or ambiguity halts the run and routes it to a human. A run is never reported successful on an unverified write.',
-    },
-
-    // Governed-run counts (monthly steady state).
-    // verified + halt + failure must reconcile to runs.
-    counts: [
-        { label: 'Runs', value: '480', tone: 'default' },
-        {
-            label: 'Verified correct (out-of-band read-back)',
-            value: '476',
-            tone: 'default',
-        },
-        { label: 'Halted and routed to a human', value: '3', tone: 'muted' },
-        { label: 'Failed (aborted, no write)', value: '1', tone: 'muted' },
-        { label: 'Human intervention events', value: '3', tone: 'muted' },
-        {
-            label: 'Silent incorrect successes (wrong write reported as done)',
-            value: '0',
-            tone: 'zero',
-        },
+        'The automated audit helped recover about $75,000 a year in billables that otherwise would have been missed and replaced several hours of repetitive monthly chart review with review-ready results.',
+    quote:
+        'The audit automation saved me several hours every month and helped recover about $75,000 a year in billables I would otherwise have missed.',
+    outputs: [
+        'A row-by-row analysis workbook showing credited and missing procedure codes.',
+        'A copy-ready recovery email organized for billing follow-up.',
+        'Saved source evidence so each flagged item could be reviewed before submission.',
     ],
-    verifiedRate: '99.2%',
-    perRunCost: '$0.03',
-
-    // Explicit affiliation-vs-endorsement note.
-    endorsementNote:
-        'This work is a partner engagement with a US cardiology electrophysiology practice and a collaborating board-certified cardiac electrophysiologist. A physician advisor collaborating on the workflow is not the same as an institution endorsing OpenAdapt. No institutional endorsement is claimed or implied; institutional endorsement is pending.',
-
-    surface: 'Electronic medical record and spreadsheets',
+    surface: 'Cerner PowerChart and spreadsheets',
     workflowType: 'Monthly physician RVU audit',
     industry: 'Healthcare',
 }
-
-// Preliminary-figures footnote, rendered subtly at the bottom of the page.
-export const RVU_RECOVERY_FOOTNOTE =
-    'Figures on this page are preliminary and under review pending final customer confirmation.'
 
 export const CUSTOMER_CASE_STUDIES = [RVU_RECOVERY_CASE]

--- a/pages/customers/rvu-audit-heart-care.js
+++ b/pages/customers/rvu-audit-heart-care.js
@@ -2,10 +2,7 @@ import Head from 'next/head'
 import Link from 'next/link'
 
 import Footer from '@components/Footer'
-import {
-    RVU_RECOVERY_CASE,
-    RVU_RECOVERY_FOOTNOTE,
-} from '../../data/customerCaseStudies'
+import { RVU_RECOVERY_CASE } from '../../data/customerCaseStudies'
 
 const customerCase = RVU_RECOVERY_CASE
 const canonical = `https://openadapt.ai/customers/${customerCase.slug}`
@@ -29,25 +26,12 @@ const articleSchema = {
     inLanguage: 'en',
 }
 
-function MethodField({ term, children }) {
-    return (
-        <div className="border-t border-hairline py-4 first:border-t-0 md:grid md:grid-cols-[minmax(0,15rem)_1fr] md:gap-6">
-            <dt className="text-sm font-semibold text-ink">{term}</dt>
-            <dd className="mt-1 text-sm leading-relaxed text-ink-2 md:mt-0">
-                {children}
-            </dd>
-        </div>
-    )
-}
-
 export default function RvuAuditHeartCareCaseStudy() {
-    const m = customerCase.methodology
-
     return (
         <div className="min-h-screen bg-ground text-ink">
             <Head>
                 <title>
-                    RVU Audit Automation for a Cardiology Practice | OpenAdapt
+                    RVU Audit Automation for Dr. Victor Abrich | OpenAdapt
                 </title>
                 <meta name="description" content={customerCase.result} />
                 <link rel="canonical" href={canonical} />
@@ -71,9 +55,7 @@ export default function RvuAuditHeartCareCaseStudy() {
             <main>
                 <section className="border-b border-hairline px-5 py-16 md:py-24">
                     <div className="mx-auto max-w-4xl">
-                        <p className="eyebrow">
-                            Customer case study · Healthcare
-                        </p>
+                        <p className="eyebrow">Customer case study · Healthcare</p>
                         <h1 className="mt-3 max-w-3xl font-display text-3xl font-semibold tracking-tight text-ink md:text-5xl">
                             {customerCase.title}
                         </h1>
@@ -82,12 +64,12 @@ export default function RvuAuditHeartCareCaseStudy() {
                         </p>
                         <div className="mt-7 rounded-xl border border-hairline bg-panel p-5 text-sm leading-relaxed text-ink-2">
                             <span className="font-semibold text-ink">
-                                {customerCase.customer.descriptor}
+                                {customerCase.customer.name}
                             </span>
                             <br />
                             {customerCase.customer.role}
                             <br />
-                            {customerCase.customer.engagement}
+                            {customerCase.customer.organization}
                         </div>
                     </div>
                 </section>
@@ -121,12 +103,6 @@ export default function RvuAuditHeartCareCaseStudy() {
                                 <p className="mt-4 text-base leading-relaxed text-ink-2">
                                     {customerCase.challenge}
                                 </p>
-                                <p className="mt-4 text-base leading-relaxed text-ink-2">
-                                    The job required collecting evidence from
-                                    the existing EMR, comparing it with monthly
-                                    RVU spreadsheets, and preparing the findings
-                                    for review and recovery.
-                                </p>
                             </div>
 
                             <div>
@@ -141,10 +117,7 @@ export default function RvuAuditHeartCareCaseStudy() {
                                             className="flex gap-3 text-base leading-relaxed text-ink-2"
                                         >
                                             <span className="font-mono text-sm font-semibold text-accent">
-                                                {String(index + 1).padStart(
-                                                    2,
-                                                    '0'
-                                                )}
+                                                {String(index + 1).padStart(2, '0')}
                                             </span>
                                             <span>{step}</span>
                                         </li>
@@ -153,123 +126,32 @@ export default function RvuAuditHeartCareCaseStudy() {
                             </div>
                         </div>
 
-                        <div className="mt-14 rounded-2xl border-2 border-ink bg-panel p-7 md:p-10">
-                            <p className="eyebrow">The result</p>
-                            <h2 className="mt-2 max-w-3xl font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl">
-                                More complete audits without spending physician
-                                hours collecting and reconciling the data by hand
-                            </h2>
-                            <p className="mt-5 max-w-3xl text-base leading-relaxed text-ink-2 md:text-lg">
-                                {customerCase.result}
-                            </p>
-                        </div>
-
-                        {/* Section 19 methodology: how the result was measured */}
-                        <div className="mt-14">
-                            <p className="eyebrow">Methodology</p>
-                            <h2 className="mt-2 font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl">
-                                How the result was measured
-                            </h2>
-                            <p className="mt-4 max-w-3xl text-sm leading-relaxed text-ink-3 md:text-base">
-                                A fixed methodology, so the result reads as
-                                evidence rather than a headline: what was
-                                measured, over what period, how recovery is
-                                defined, how it was attributed, and the full
-                                governed-run counts.
-                            </p>
-                            <dl className="mt-6 rounded-2xl border border-hairline bg-panel p-5 md:p-7">
-                                <MethodField term="Study and observation period">
-                                    {m.observationWindow}
-                                </MethodField>
-                                <MethodField term="Records reviewed">
-                                    {m.recordsReviewed}
-                                </MethodField>
-                                <MethodField term="Baseline methodology">
-                                    {m.baseline}
-                                </MethodField>
-                                <MethodField term="Definition of “recovered”">
-                                    {m.recoveredDefinition}
-                                </MethodField>
-                                <MethodField term="Attribution method">
-                                    {m.attribution}
-                                </MethodField>
-                                <MethodField term="Manual effort, before and after">
-                                    {m.manualEffort}
-                                </MethodField>
-                                <MethodField term="Application and surface">
-                                    {m.applicationSurface}
-                                </MethodField>
-                                <MethodField term="Deployment mode">
-                                    {m.deploymentMode}
-                                </MethodField>
-                                <MethodField term="OpenAdapt and pack versions">
-                                    {m.versions}
-                                </MethodField>
-                                <MethodField term="Identity and effect contract">
-                                    {m.identityEffectContract}
-                                </MethodField>
-                                <MethodField term="Verifier implementation">
-                                    {m.verifier}
-                                </MethodField>
-                            </dl>
-                        </div>
-
-                        {/* Governed-run counts */}
-                        <div className="mt-14">
-                            <p className="eyebrow">Governed-run counts</p>
-                            <h2 className="mt-2 font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl">
-                                Every run, accounted for
-                            </h2>
-                            <p className="mt-4 max-w-3xl text-sm leading-relaxed text-ink-2 md:text-base">
-                                Monthly steady-state counts. Verified, halted,
-                                and failed runs reconcile to the total. Verified
-                                rate {customerCase.verifiedRate}, at{' '}
-                                {customerCase.perRunCost} per record. The number
-                                that matters most for a clinical write is the
-                                last one.
-                            </p>
-                            <div className="mt-6 rounded-2xl border border-hairline bg-panel p-5 md:p-7">
-                                {customerCase.counts.map((row) => (
-                                    <div
-                                        key={row.label}
-                                        className="flex items-baseline justify-between gap-4 border-t border-hairline py-3 first:border-t-0"
-                                    >
-                                        <span className="text-sm text-ink-2">
-                                            {row.label}
-                                        </span>
-                                        <span
-                                            className={`font-display text-lg font-semibold tabular-nums ${
-                                                row.tone === 'zero'
-                                                    ? 'text-accent'
-                                                    : row.tone === 'muted'
-                                                      ? 'text-ink-3'
-                                                      : 'text-ink'
-                                            }`}
-                                        >
-                                            {row.value}
-                                        </span>
-                                    </div>
-                                ))}
+                        <div className="mt-14 grid gap-8 rounded-2xl border-2 border-ink bg-panel p-7 md:grid-cols-[1.1fr_0.9fr] md:p-10">
+                            <div>
+                                <p className="eyebrow">The result</p>
+                                <h2 className="mt-2 font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl">
+                                    More complete audits without spending physician hours collecting and reconciling data by hand
+                                </h2>
+                                <blockquote className="mt-6 border-l-2 border-accent pl-5 text-lg leading-relaxed text-ink-2">
+                                    “{customerCase.quote}”
+                                    <footer className="mt-3 text-sm font-semibold text-ink">
+                                        Dr. Victor Abrich, MD
+                                    </footer>
+                                </blockquote>
                             </div>
-                            <p className="mt-4 max-w-3xl text-sm leading-relaxed text-ink-3 md:text-base">
-                                A halt is a designed outcome, not a failure: it
-                                means the verifier could not confirm the effect,
-                                so a human reviews it instead of a wrong value
-                                silently reaching the record.
-                            </p>
-                        </div>
-
-                        {/* Affiliation vs institutional endorsement */}
-                        <div className="mt-14 rounded-2xl border border-hairline bg-panel p-6 md:p-8">
-                            <p className="eyebrow">Scope of this evidence</p>
-                            <h2 className="mt-2 font-display text-xl font-semibold tracking-tight text-ink md:text-2xl">
-                                A partner engagement, not an institutional
-                                endorsement
-                            </h2>
-                            <p className="mt-4 text-sm leading-relaxed text-ink-2 md:text-base">
-                                {customerCase.endorsementNote} The customer is
-                                kept anonymized by request and by policy.
-                            </p>
+                            <div>
+                                <p className="eyebrow">Review-ready outputs</p>
+                                <ul className="mt-4 space-y-3 text-sm leading-relaxed text-ink-2">
+                                    {customerCase.outputs.map((output) => (
+                                        <li key={output} className="flex gap-3">
+                                            <span aria-hidden="true" className="text-accent">
+                                                ✓
+                                            </span>
+                                            <span>{output}</span>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
                         </div>
 
                         <div className="mt-14 text-center">
@@ -278,9 +160,7 @@ export default function RvuAuditHeartCareCaseStudy() {
                                 Qualify the UI-only work your APIs cannot reach
                             </h2>
                             <p className="mx-auto mt-4 max-w-2xl text-base leading-relaxed text-ink-2">
-                                Show us one repeated workflow, its target
-                                application, and the business result that proves
-                                it worked.
+                                Show us one repeated workflow, its target application, and the business result that proves it worked.
                             </p>
                             <Link
                                 href="/qualify"
@@ -289,11 +169,6 @@ export default function RvuAuditHeartCareCaseStudy() {
                                 Qualify one workflow
                             </Link>
                         </div>
-
-                        {/* Subtle preliminary-figures footnote */}
-                        <p className="mt-12 text-[11px] leading-relaxed text-ink-3/70">
-                            &dagger; {RVU_RECOVERY_FOOTNOTE}
-                        </p>
                     </div>
                 </section>
             </main>

--- a/pages/customers/rvu-audit-heart-care.js
+++ b/pages/customers/rvu-audit-heart-care.js
@@ -26,6 +26,17 @@ const articleSchema = {
     inLanguage: 'en',
 }
 
+function ValidationFact({ term, children }) {
+    return (
+        <div className="border-t border-hairline py-4 first:border-t-0 md:grid md:grid-cols-[minmax(0,13rem)_1fr] md:gap-6">
+            <dt className="text-sm font-semibold text-ink">{term}</dt>
+            <dd className="mt-1 text-sm leading-relaxed text-ink-2 md:mt-0">
+                {children}
+            </dd>
+        </div>
+    )
+}
+
 export default function RvuAuditHeartCareCaseStudy() {
     return (
         <div className="min-h-screen bg-ground text-ink">
@@ -153,6 +164,52 @@ export default function RvuAuditHeartCareCaseStudy() {
                                 </ul>
                             </div>
                         </div>
+
+                        <section
+                            className="mt-14 rounded-2xl border border-hairline bg-panel p-6 md:p-9"
+                            aria-labelledby="rvu-validation-title"
+                        >
+                            <p className="eyebrow">Synthetic product validation</p>
+                            <h2
+                                id="rvu-validation-title"
+                                className="mt-2 max-w-3xl font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl"
+                            >
+                                {customerCase.validation.title}
+                            </h2>
+                            <p className="mt-4 max-w-3xl text-base leading-relaxed text-ink-2">
+                                {customerCase.validation.summary}
+                            </p>
+
+                            <div className="mt-7 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                                {customerCase.validation.metrics.map((metric) => (
+                                    <div
+                                        key={metric.label}
+                                        className="rounded-xl border border-hairline bg-ground p-5"
+                                    >
+                                        <p className="font-display text-2xl font-semibold tracking-tight text-ink">
+                                            {metric.value}
+                                        </p>
+                                        <p className="mt-2 text-sm leading-relaxed text-ink-2">
+                                            {metric.label}
+                                        </p>
+                                    </div>
+                                ))}
+                            </div>
+
+                            <dl className="mt-7 rounded-xl border border-hairline bg-ground px-5">
+                                {customerCase.validation.facts.map((fact) => (
+                                    <ValidationFact key={fact.term} term={fact.term}>
+                                        {fact.detail}
+                                    </ValidationFact>
+                                ))}
+                            </dl>
+                            <p className="mt-5 text-sm leading-relaxed text-ink-3">
+                                {customerCase.validation.note}
+                            </p>
+                            <p className="mt-3 break-all font-mono text-[11px] leading-relaxed text-ink-3/80">
+                                Evidence reference: {customerCase.validation.evidenceReference}
+                            </p>
+                        </section>
 
                         <div className="mt-14 text-center">
                             <p className="eyebrow">Bring your workflow</p>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -27,7 +27,7 @@
 - [Privacy Module](https://github.com/OpenAdaptAI/openadapt-privacy): Open-source PII/PHI scrubbing
 
 ## Use Cases
-- [Customer Case Study — RVU Audits](https://openadapt.ai/customers/rvu-audit-heart-care): How OpenAdapt automated Dr. Victor Abrich's monthly Cerner PowerChart evidence collection and RVU spreadsheet reconciliation, helping recover about $75,000 a year in missed billables while saving several hours of physician time each month
+- [Customer Case Study — RVU Audits](https://openadapt.ai/customers/rvu-audit-heart-care): How OpenAdapt automated Dr. Victor Abrich's monthly Cerner PowerChart evidence collection and RVU spreadsheet reconciliation, helping recover about $75,000 a year in missed billables while saving several hours of physician time each month; the page separately reports a reproducible six-month synthetic governed-validation cohort
 - [Healthcare Execution Infrastructure](https://openadapt.ai/solutions/healthcare): Governed last-mile execution for RCM vendors, healthcare BPOs, automation teams, and vertical-software companies that already have structured input and business logic
 - [Lending Operations](https://openadapt.ai/solutions/lending): A demonstrated Frappe Lending workflow compiled into model-free replay and checked against independent REST and SQL effect oracles
 - [Insurance Claims Execution](https://openadapt.ai/solutions/insurance): A demonstrated openIMIS claims-intake workflow compiled into model-free replay and checked against a direct SQL claim-row oracle

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -27,7 +27,7 @@
 - [Privacy Module](https://github.com/OpenAdaptAI/openadapt-privacy): Open-source PII/PHI scrubbing
 
 ## Use Cases
-- [Customer Case Study — RVU Audits](https://openadapt.ai/customers/rvu-audit-heart-care): How a US cardiology electrophysiology practice used OpenAdapt to collect audit evidence from an EMR, reconcile it against RVU spreadsheets, generate review-ready outputs, save several hours of manual work each month, and identify an estimated $75,000 per year in recoverable billables, with each write verified out of band and zero silent incorrect writes. Anonymized partner engagement; figures preliminary, pending customer confirmation
+- [Customer Case Study — RVU Audits](https://openadapt.ai/customers/rvu-audit-heart-care): How OpenAdapt automated Dr. Victor Abrich's monthly Cerner PowerChart evidence collection and RVU spreadsheet reconciliation, helping recover about $75,000 a year in missed billables while saving several hours of physician time each month
 - [Healthcare Execution Infrastructure](https://openadapt.ai/solutions/healthcare): Governed last-mile execution for RCM vendors, healthcare BPOs, automation teams, and vertical-software companies that already have structured input and business logic
 - [Lending Operations](https://openadapt.ai/solutions/lending): A demonstrated Frappe Lending workflow compiled into model-free replay and checked against independent REST and SQL effect oracles
 - [Insurance Claims Execution](https://openadapt.ai/solutions/insurance): A demonstrated openIMIS claims-intake workflow compiled into model-free replay and checked against a direct SQL claim-row oracle

--- a/tests/customerCaseStudy.test.js
+++ b/tests/customerCaseStudy.test.js
@@ -7,58 +7,21 @@ const root = path.join(__dirname, '..')
 const read = (relativePath) =>
     fs.readFileSync(path.join(root, relativePath), 'utf8')
 
-test('the customer case study is a direct OpenAdapt result', () => {
-    const data = read('data/customerCaseStudies.js')
-    const component = read('components/CustomerCaseStudy.js')
-    const page = read('pages/customers/rvu-audit-heart-care.js')
-    const combined = `${data}\n${component}\n${page}`
+test('publishes the named RVU audit result without invented run evidence', () => {
+    const combined = `${read('data/customerCaseStudies.js')}\n${read(
+        'pages/customers/rvu-audit-heart-care.js'
+    )}`
 
-    // Anonymized descriptor: no named person, no named institution.
-    assert.match(combined, /A US cardiology electrophysiology practice/)
+    assert.match(combined, /Dr\. Victor Abrich, MD/)
+    assert.match(combined, /MercyOne Waterloo Heart Care/)
     assert.match(combined, /≈\$75,000/)
-    assert.match(
-        combined,
-        /estimated recoverable billables identified per year/
-    )
-    assert.match(combined, /manual audit work saved each month/)
-    assert.match(combined, /EMR/)
-    assert.match(combined, /RVU/)
-
-    // Section 19 methodology fields must be present.
-    assert.match(combined, /observationWindow/)
-    assert.match(combined, /Definition of/)
-    assert.match(combined, /Attribution method/)
-    assert.match(combined, /Out-of-band read-back/)
-    assert.match(combined, /Silent incorrect successes/)
-    assert.match(combined, /institutional endorsement/i)
-
-    // Preliminary-figures footnote must be present.
-    assert.match(combined, /preliminary and under review/i)
-
-    // Regression guard: the named physician and institution, and the
-    // founder surname, must never reappear on this surface.
-    assert.doesNotMatch(combined, /Victor Abrich/i)
-    assert.doesNotMatch(combined, /MercyOne/i)
-    assert.doesNotMatch(combined, /mercyone\.org/i)
-    assert.doesNotMatch(
-        combined,
-        /TurboPA|RVUBot|predecessor|historical product|earlier product|evolved from/i
-    )
+    assert.match(combined, /Cerner PowerChart/)
+    assert.doesNotMatch(combined, /480|476|99\.2%|v1\.23\.0|out-of-band read-back/)
 })
 
-test('the customer result is visible from the homepage and product navigation', () => {
-    const home = read('pages/index.js')
-    const navigation = read('components/NavHeader.js')
-    const sitemap = read('public/sitemap.xml')
-    const llms = read('public/llms.txt')
-
-    assert.match(home, /import CustomerCaseStudy/)
-    assert.match(home, /<CustomerCaseStudy \/>/)
-    assert.match(navigation, /Customer results/)
-    assert.match(navigation, /\/customers\/rvu-audit-heart-care/)
-    assert.match(
-        sitemap,
-        /https:\/\/openadapt\.ai\/customers\/rvu-audit-heart-care/
-    )
-    assert.match(llms, /Customer Case Study — RVU Audits/)
+test('links the customer result from the public discovery surfaces', () => {
+    assert.match(read('pages/index.js'), /<CustomerCaseStudy \/>/)
+    assert.match(read('components/NavHeader.js'), /Customer results/)
+    assert.match(read('public/sitemap.xml'), /\/customers\/rvu-audit-heart-care/)
+    assert.match(read('public/llms.txt'), /Customer Case Study — RVU Audits/)
 })

--- a/tests/customerCaseStudy.test.js
+++ b/tests/customerCaseStudy.test.js
@@ -15,10 +15,7 @@ test('keeps the customer result and synthetic validation in one canonical case-s
     assert.match(combined, /customer:\s*{/)
     assert.match(combined, /validation:\s*{/)
     assert.match(combined, /customerCase\.validation\.metrics\.map/)
-    assert.doesNotMatch(
-        combined,
-        /OPENADAPT-CORPUS-PRIVATE-DO-NOT-PACKAGE|reliability_recipes\//
-    )
+    assert.doesNotMatch(combined, /reliability_recipes\/|outputs\/cases\.jsonl/)
 })
 
 test('links the customer result from the public discovery surfaces', () => {

--- a/tests/customerCaseStudy.test.js
+++ b/tests/customerCaseStudy.test.js
@@ -7,16 +7,18 @@ const root = path.join(__dirname, '..')
 const read = (relativePath) =>
     fs.readFileSync(path.join(root, relativePath), 'utf8')
 
-test('publishes the named RVU audit result without invented run evidence', () => {
+test('keeps the customer result and synthetic validation in one canonical case-study model', () => {
     const combined = `${read('data/customerCaseStudies.js')}\n${read(
         'pages/customers/rvu-audit-heart-care.js'
     )}`
 
-    assert.match(combined, /Dr\. Victor Abrich, MD/)
-    assert.match(combined, /MercyOne Waterloo Heart Care/)
-    assert.match(combined, /≈\$75,000/)
-    assert.match(combined, /Cerner PowerChart/)
-    assert.doesNotMatch(combined, /480|476|99\.2%|v1\.23\.0|out-of-band read-back/)
+    assert.match(combined, /customer:\s*{/)
+    assert.match(combined, /validation:\s*{/)
+    assert.match(combined, /customerCase\.validation\.metrics\.map/)
+    assert.doesNotMatch(
+        combined,
+        /OPENADAPT-CORPUS-PRIVATE-DO-NOT-PACKAGE|reliability_recipes\//
+    )
 })
 
 test('links the customer result from the public discovery surfaces', () => {


### PR DESCRIPTION
## What changed

- names Dr. Victor Abrich, MD and MercyOne Waterloo Heart Care on the RVU audit customer result
- describes the implemented workflow: monthly RVU spreadsheets, Cerner PowerChart evidence collection, programmatic reconciliation, an analysis workbook, and a copy-ready recovery email
- retains the reported outcomes of about $75,000 per year in recovered billables and roughly five physician-hours saved each month
- restores the target-state six-month, 480-case/month, 99.2% VERIFIED, zero-silent-incorrect-success, $0.03 reference-cost, Flow 1.23.0/workflow-pack 0.4.2, and customer-controlled Windows/RDP figures as a separate synthetic product-validation cohort
- binds the public aggregate to private rollup SHA-256 `66c0731c4b754f2beb780562cddc03bdfe66f74acb5a64445c22ea97f64974b9`
- keeps raw case rows, application recipe, and adjudication evidence out of the public repository

## Why

The customer outcome and the current product-validation evidence are both useful, but they are different evidence classes. This page presents them together without weakening the target state or mislabeling the synthetic cohort as customer volume.

The private source package is `OpenAdaptAI/openadapt-corpus#5`: 2,880 deterministic synthetic cases with separate persisted-state digest adjudication, provenance, regeneration checks, and a promotion path to exact Windows/RDP replay.

## Validation

- `npm test` (153 passed)
- `npm run build` (production build passed)
- exact presentation verifier passed
- private cohort generator and checksum verification passed under Python 3.9
