### PR TITLE
fix: keep guided overlay status clear of progress

### DIFF
--- a/components/EvidenceMediaPlayer.module.css
+++ b/components/EvidenceMediaPlayer.module.css
@@ -37,10 +37,12 @@
     z-index: 2;
     bottom: 10px;
     display: grid;
+    grid-template-rows: max-content max-content 2px;
+    align-content: center;
     gap: 5px;
     box-sizing: border-box;
     width: min(260px, calc(100% - 20px));
-    height: 72px;
+    min-height: 72px;
     min-width: 0;
     padding: 8px 10px;
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -250,7 +252,7 @@
         left: auto;
         width: 100%;
         max-width: none;
-        height: 72px;
+        min-height: 72px;
         padding: 8px 10px;
         border: 0;
         border-top: 1px solid rgba(255, 255, 255, 0.16);

--- a/cypress/e2e/reference-demo.cy.js
+++ b/cypress/e2e/reference-demo.cy.js
@@ -118,6 +118,12 @@ describe('shared real-application demo', () => {
                         .then(($capsule) => {
                             const target = $target[0].getBoundingClientRect()
                             const capsule = $capsule[0].getBoundingClientRect()
+                            const status = $capsule[0]
+                                .querySelector('strong')
+                                .getBoundingClientRect()
+                            const progress = $capsule[0]
+                                .querySelector('progress')
+                                .getBoundingClientRect()
                             const intersects = !(
                                 target.right <= capsule.left ||
                                 target.left >= capsule.right ||
@@ -125,6 +131,7 @@ describe('shared real-application demo', () => {
                                 target.top >= capsule.bottom
                             )
                             expect(intersects).to.equal(false)
+                            expect(status.bottom).to.be.at.most(progress.top)
                         })
                 })
             if (label === 'desktop') {


### PR DESCRIPTION
## Summary
- replace the fixed overlay height with a stable minimum height so enlarged text cannot be clipped
- give the header, status label, and progress track separate grid rows
- assert the status label never overlaps the progress track in the existing desktop/mobile browser test

## Validation
- `npm test` (153 passing)
- `npm run verify:presentations`
- `npm run build`
- `npx cypress run --browser electron --config baseUrl=http://127.0.0.1:3017,video=false --spec cypress/e2e/reference-demo.cy.js` (11 passing)
- desktop and mobile screenshots visually reviewed