### PR TITLE
fix: keep Guided view progress monotonic

### DIFF
--- a/components/EvidenceMediaPlayer.js
+++ b/components/EvidenceMediaPlayer.js
@@ -34,6 +34,7 @@ export default function EvidenceMediaPlayer({
     const [visible, setVisible] = useState(false)
     const [currentTime, setCurrentTime] = useState(0)
     const [duration, setDuration] = useState(0)
+    const [ended, setEnded] = useState(false)
     const [motionAllowed, setMotionAllowed] = useState(false)
     const [decodedFrameIndex, setDecodedFrameIndex] = useState(null)
     const [geometryVersion, setGeometryVersion] = useState(0)
@@ -62,7 +63,8 @@ export default function EvidenceMediaPlayer({
     }, [])
 
     useEffect(() => {
-        const shouldPlay = motionAllowed && visible && !manuallyPaused.current
+        const shouldPlay =
+            motionAllowed && visible && !manuallyPaused.current && !ended
         if (media.kind === 'gif') {
             setPlaying(shouldPlay)
             return undefined
@@ -73,13 +75,15 @@ export default function EvidenceMediaPlayer({
         if (shouldPlay) void video.play().catch(() => setPlaying(false))
         else video.pause()
         return undefined
-    }, [media.kind, media.src, motionAllowed, visible])
+    }, [ended, media.kind, media.src, motionAllowed, visible])
 
     useEffect(() => {
         const video = videoRef.current
         if (!video || media.kind !== 'video') return undefined
         setDecodedFrameIndex(null)
         setCurrentTime(0)
+        setEnded(false)
+        manuallyPaused.current = false
         video.load()
         return undefined
     }, [media.kind, media.src])
@@ -110,15 +114,22 @@ export default function EvidenceMediaPlayer({
 
         const video = videoRef.current
         let callbackId
+        let active = true
         const onVideoFrame = (_now, metadata) => {
+            if (!active) return
             setCurrentTime(metadata.mediaTime)
             setDecodedFrameIndex(
                 decodedMediaFrameIndex(metadata.mediaTime, exactPresentation.binding)
             )
-            callbackId = video.requestVideoFrameCallback(onVideoFrame)
+            if (active) {
+                callbackId = video.requestVideoFrameCallback(onVideoFrame)
+            }
         }
         callbackId = video.requestVideoFrameCallback(onVideoFrame)
-        return () => video.cancelVideoFrameCallback?.(callbackId)
+        return () => {
+            active = false
+            video.cancelVideoFrameCallback?.(callbackId)
+        }
     }, [exactPresentation, media.kind, media.src])
 
     const toggle = () => {
@@ -131,6 +142,22 @@ export default function EvidenceMediaPlayer({
         }
         const video = videoRef.current
         if (!video) return
+        if (ended && exactPresentation) {
+            const restartTime = 0
+            manuallyPaused.current = false
+            setEnded(false)
+            video.currentTime = restartTime
+            setCurrentTime(restartTime)
+            setDecodedFrameIndex(
+                decodedMediaFrameIndex(
+                    restartTime,
+                    exactPresentation.binding
+                )
+            )
+            setMotionAllowed(true)
+            void video.play().catch(() => setPlaying(false))
+            return
+        }
         if (video.paused) {
             manuallyPaused.current = false
             setMotionAllowed(true)
@@ -145,8 +172,33 @@ export default function EvidenceMediaPlayer({
         const video = videoRef.current
         if (!video) return
         setPlaying(!video.paused)
-        setCurrentTime(video.currentTime)
+        // requestVideoFrameCallback is the sole automated clock for exact
+        // presentations. Mixing it with timeupdate/seek events can apply an
+        // older media time after a newer decoded frame.
+        if (!exactPresentation || !video.requestVideoFrameCallback) {
+            setCurrentTime(video.currentTime)
+        }
         setDuration(Number.isFinite(video.duration) ? video.duration : 0)
+    }
+
+    const finishVideo = () => {
+        const video = videoRef.current
+        if (!video) return
+        setPlaying(false)
+        if (!exactPresentation) return
+
+        // Guided evidence is a bounded run, not an ambient animation. Hold its
+        // terminal frame until the viewer explicitly chooses Replay so the
+        // visible workflow step never jumps backwards on an implicit loop.
+        const finalTime = Number.isFinite(video.duration)
+            ? video.duration
+            : currentTime
+        manuallyPaused.current = true
+        setEnded(true)
+        setCurrentTime(finalTime)
+        setDecodedFrameIndex(
+            decodedMediaFrameIndex(finalTime, exactPresentation.binding)
+        )
     }
 
     const accessibleModeLabel =
@@ -239,6 +291,9 @@ export default function EvidenceMediaPlayer({
                     ? 'exact-decoded-frame-bound'
                     : 'omitted-without-exact-timeline'
             }
+            data-playback-state={
+                ended ? 'ended' : playing ? 'playing' : 'paused'
+            }
         >
             <div
                 ref={stageRef}
@@ -254,7 +309,7 @@ export default function EvidenceMediaPlayer({
                         ref={videoRef}
                         className={styles.media}
                         muted
-                        loop
+                        loop={!exactPresentation}
                         playsInline
                         preload="metadata"
                         poster={media.poster}
@@ -266,6 +321,7 @@ export default function EvidenceMediaPlayer({
                         onSeeked={syncVideo}
                         onPlay={syncVideo}
                         onPause={syncVideo}
+                        onEnded={finishVideo}
                     >
                         <source src={media.src} type={media.mimeType} />
                         {media.fallbackSrc && (
@@ -346,9 +402,11 @@ export default function EvidenceMediaPlayer({
                 <button
                     type="button"
                     onClick={toggle}
-                    aria-label={playing ? 'Pause' : 'Play'}
+                    aria-label={ended ? 'Replay' : playing ? 'Pause' : 'Play'}
                 >
-                    <span aria-hidden="true">{playing ? 'Ⅱ' : '▶'}</span>
+                    <span aria-hidden="true">
+                        {ended ? '↻' : playing ? 'Ⅱ' : '▶'}
+                    </span>
                 </button>
                 {media.kind === 'video' ? (
                     <>
@@ -362,9 +420,12 @@ export default function EvidenceMediaPlayer({
                             onChange={(event) => {
                                 if (!videoRef.current) return
                                 setDecodedFrameIndex(null)
-                                videoRef.current.currentTime = Number(
+                                const nextTime = Number(
                                     event.currentTarget.value
                                 )
+                                videoRef.current.currentTime = nextTime
+                                setCurrentTime(nextTime)
+                                setEnded(false)
                                 syncVideo()
                             }}
                         />

--- a/cypress/e2e/reference-demo.cy.js
+++ b/cypress/e2e/reference-demo.cy.js
@@ -197,6 +197,34 @@ describe('shared real-application demo', () => {
             .should('have.attr', 'aria-labelledby')
     })
 
+    it('holds a guided run at its terminal step until Replay is chosen', () => {
+        cy.visit('/')
+        cy.get('[data-testid="reference-demo-showcase"]')
+            .first()
+            .find('[data-testid="reference-evidence-player"]')
+            .scrollIntoView()
+            .as('player')
+        cy.get('@player')
+            .find('video')
+            .should('have.prop', 'loop', false)
+            .should(($video) => {
+                expect($video[0].videoWidth).to.be.greaterThan(0)
+                expect($video[0].duration).to.be.greaterThan(0)
+            })
+            .then(($video) => {
+                const video = $video[0]
+                video.pause()
+                video.currentTime = video.duration
+                video.dispatchEvent(new Event('ended'))
+            })
+        cy.get('@player')
+            .should('have.attr', 'data-playback-state', 'ended')
+            .should('contain.text', 'Outcome verified')
+        cy.get('@player').find('progress').should('not.exist')
+        cy.get('@player').find('button[aria-label="Replay"]').click()
+        cy.get('@player').contains(/^Step 1 of \d+$/)
+    })
+
     it('binds openIMIS VERIFIED and HALTED modes to their exact evidence media', () => {
         cy.visit('/solutions/insurance')
         cy.get('[data-testid="reference-demo-showcase"]')

--- a/lib/executionOverlayTimeline.js
+++ b/lib/executionOverlayTimeline.js
@@ -405,6 +405,7 @@ export function parseExecutionOverlayTimeline(value) {
     let previousFrame = -1
     let previousSequence = -1
     let previousMonotonic = -1
+    let previousStep = null
     const events = timeline.events.map((candidate, index) => {
         const event = record(candidate, `execution overlay event ${index}`)
         exactKeys(
@@ -429,6 +430,14 @@ export function parseExecutionOverlayTimeline(value) {
             frame.observed_at_monotonic_ms < previousMonotonic
         ) {
             throw new Error(`execution overlay event ${index} is out of source order`)
+        }
+        if (frame.step.current !== null) {
+            if (previousStep !== null && frame.step.current < previousStep) {
+                throw new Error(
+                    `execution overlay event ${index} regresses workflow progress`
+                )
+            }
+            previousStep = frame.step.current
         }
         const target = frame.target_tracking
         if (

--- a/tests/executionOverlayTimeline.test.js
+++ b/tests/executionOverlayTimeline.test.js
@@ -109,6 +109,15 @@ test('canonical V2 parsing refuses unsafe fields and media/PTS mismatches', asyn
         () => bindExecutionOverlayTimeline(forged, binding()),
         /state_id does not match/
     )
+
+    const regressed = timeline()
+    regressed.events[0].frame.step.current = 2
+    regressed.events[0].frame.state_id =
+        'visible:executing:governed:standard:2:2:no-pause:no-resume:no-stop:no-target'
+    assert.throws(
+        () => bindExecutionOverlayTimeline(regressed, binding()),
+        /regresses workflow progress/
+    )
 })
 
 test('status persists by bounded time while target exists only on its exact frame', async () => {


### PR DESCRIPTION
## What changed
- use decoded video frames as the sole automated clock for exact Guided presentations
- stop exact Guided runs on their terminal evidence frame instead of silently looping back to step 1
- add an explicit Replay control and ignore stale frame callbacks after source changes
- reject public overlay timelines whose visible workflow step regresses

## Verification
- npm test: 153/153
- presentation verification: 4/4 exact assets
- production build passed
- focused reference-demo Cypress spec: 12/12