### PR TITLE
fix: keep mobile nav above Safari browser chrome

### DIFF
--- a/components/NavHeader.module.css
+++ b/components/NavHeader.module.css
@@ -227,8 +227,17 @@
 @media (max-width: 1200px) {
     .headerMenuOpen {
         position: fixed;
-        inset: 0 0 auto;
+        inset: 0;
         width: 100%;
+        height: 100vh;
+        height: 100dvh;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+    }
+
+    .headerMenuOpen .inner {
+        flex: 0 0 60px;
     }
 
     .links {
@@ -251,15 +260,20 @@
 
     .mobilePanel {
         display: flex;
+        flex: 1 1 auto;
+        min-height: 0;
         flex-direction: column;
         max-height: calc(100vh - 60px);
+        max-height: calc(100dvh - 60px);
         overscroll-behavior: contain;
         overflow-y: auto;
         overflow-x: hidden;
+        -webkit-overflow-scrolling: touch;
         scrollbar-gutter: stable;
+        scroll-padding-bottom: calc(24px + env(safe-area-inset-bottom));
         background: var(--panel);
         border-bottom: 1px solid var(--hairline);
-        padding: 6px 16px 12px;
+        padding: 6px 16px calc(24px + env(safe-area-inset-bottom));
     }
 
     .mobileLink {

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -367,6 +367,9 @@ describe('public product truth', () => {
             expect($menu[0].scrollHeight).to.be.greaterThan(
                 $menu[0].clientHeight
             )
+            expect($menu[0].getBoundingClientRect().bottom).to.be.at.most(
+                $menu[0].ownerDocument.defaultView.visualViewport.height
+            )
         })
         cy.document().then((document) => {
             expect(document.documentElement.scrollWidth).to.be.at.most(375)


### PR DESCRIPTION
## What changed
- size the open mobile menu to the dynamic viewport rather than Safari's large static viewport
- make the link panel the sole scroll container and reserve home-indicator safe-area clearance
- retain a 100vh fallback for older browsers

## Verification
- npm test: 153/153
- production build passed
- basic Cypress suite: 17/17, including bottom-link reachability