### PR TITLE
Present Desktop and CLI as equal local starts

### DIFF
--- a/components/DesktopPreview.js
+++ b/components/DesktopPreview.js
@@ -321,6 +321,7 @@ const WINDOWS_INSTALLER_STEPS = [
 export default function DesktopPreview() {
     return (
         <div
+            id="desktop-preview"
             className="mx-auto max-w-4xl px-4 py-12"
             data-testid="desktop-preview"
         >

--- a/cypress/e2e/public-surface-coherence.cy.js
+++ b/cypress/e2e/public-surface-coherence.cy.js
@@ -1,4 +1,23 @@
 describe('public surface coherence', () => {
+    it('offers CLI and Desktop as equal local entry paths before Cloud', () => {
+        cy.visit('/start')
+
+        cy.get('[role="list"][aria-label="Local ways to run OpenAdapt"]')
+            .find('[role="listitem"]')
+            .should('have.length', 2)
+        cy.contains('a', 'Download Desktop').should(
+            'have.attr',
+            'href',
+            '/download#desktop-builds'
+        )
+        cy.contains('a', 'Open the CLI walkthrough').should(
+            'have.attr',
+            'href',
+            'https://docs.openadapt.ai/get-started/'
+        )
+        cy.contains('Optional after local success').should('be.visible')
+    })
+
     it('routes buyers and developers to the intended entry points', () => {
         cy.viewport(1280, 1000)
         // Keep this homepage visit self-contained. Without an immediate

--- a/cypress/e2e/public-surface-coherence.cy.js
+++ b/cypress/e2e/public-surface-coherence.cy.js
@@ -5,17 +5,17 @@ describe('public surface coherence', () => {
         cy.get('[role="list"][aria-label="Local ways to run OpenAdapt"]')
             .find('[role="listitem"]')
             .should('have.length', 2)
-        cy.contains('a', 'Download Desktop').should(
+        cy.get('[data-testid="local-desktop-download"]').should(
             'have.attr',
             'href',
             '/download#desktop-builds'
         )
-        cy.contains('a', 'Open the CLI walkthrough').should(
+        cy.get('[data-testid="local-cli-walkthrough"]').should(
             'have.attr',
             'href',
             'https://docs.openadapt.ai/get-started/'
         )
-        cy.contains('Optional after local success').should('be.visible')
+        cy.get('[data-testid="local-next-steps"]').should('be.visible')
     })
 
     it('routes buyers and developers to the intended entry points', () => {

--- a/pages/start.js
+++ b/pages/start.js
@@ -51,7 +51,7 @@ export default function StartPage() {
                 <title>Run OpenAdapt Locally for Free | OpenAdapt</title>
                 <meta
                     name="description"
-                    content="Install OpenAdapt and complete your first local record, compile, certify, and replay loop with no account, model API, or Cloud service."
+                    content="Run OpenAdapt locally through the native Desktop app or CLI, with no account, model API, or Cloud service required."
                 />
                 <link rel="canonical" href="https://openadapt.ai/start" />
                 <meta
@@ -60,93 +60,174 @@ export default function StartPage() {
                 />
                 <meta
                     property="og:description"
-                    content="Reach a real local OpenAdapt run in two copy-and-paste commands, then inspect the workflow and its run evidence."
+                    content="Choose the native Desktop app or CLI and complete the same local record, compile, qualify, run, and evidence lifecycle."
                 />
                 <meta property="og:url" content="https://openadapt.ai/start" />
             </Head>
 
             <section className="border-b border-hairline px-5 py-16 md:py-24">
                 <div className="mx-auto max-w-4xl">
-                    <p className="eyebrow">Free local quickstart · MIT licensed</p>
+                    <p className="eyebrow">Free local start · MIT licensed</p>
                     <h1 className="mt-3 max-w-3xl font-display text-3xl font-semibold tracking-tight md:text-5xl">
-                        Get to your first local run in two commands.
+                        Start locally with Desktop or the CLI.
                     </h1>
                     <p className="mt-5 max-w-2xl text-base leading-relaxed text-ink-2 md:text-lg">
-                        The quickstart records a bundled synthetic tutorial,
-                        compiles it into an inspectable workflow, applies its
-                        explicit demo policy, and replays it locally. No account,
-                        target application, model API, or Cloud service is needed.
+                        Both paths use the same local compiler and governed
+                        runtime. Choose the visual Desktop cockpit or the
+                        scriptable command line. Neither requires a Cloud account
+                        or model API.
                     </p>
 
-                    <div className="mt-10 grid gap-8 md:grid-cols-[1fr_0.85fr]">
-                        <div>
-                            <div>
+                    <div
+                        className="mt-10 grid gap-5 md:grid-cols-2"
+                        role="list"
+                        aria-label="Local ways to run OpenAdapt"
+                    >
+                        <article
+                            className="flex h-full flex-col rounded-2xl border border-hairline bg-panel p-5 md:p-6"
+                            role="listitem"
+                        >
+                            <p className="eyebrow">Command line</p>
+                            <h2 className="mt-2 font-display text-2xl font-semibold tracking-tight">
+                                OpenAdapt CLI
+                            </h2>
+                            <p className="mt-3 text-sm leading-relaxed text-ink-2">
+                                Run the complete local tutorial, inspect every
+                                artifact, and script the same lifecycle in a
+                                terminal or CI environment.
+                            </p>
+
+                            <div className="mt-6">
                                 <p className="eyebrow">1 · Install</p>
                                 <Command
                                     command={INSTALL}
                                     event={EVENTS.LOCAL_QUICKSTART_INSTALL_COPIED}
                                 />
                             </div>
-                            <div className="mt-7">
+                            <div className="mt-5">
                                 <p className="eyebrow">2 · Run the whole loop</p>
                                 <Command
                                     command={QUICKSTART}
                                     event={EVENTS.LOCAL_QUICKSTART_RUN_COPIED}
                                 />
                             </div>
-                            <p className="mt-5 text-sm leading-relaxed text-ink-3">
+                            <p className="mt-5 text-xs leading-relaxed text-ink-3">
                                 Requires Python 3.10–3.12 on Windows, macOS, or
                                 Linux. The first run downloads Chromium once
                                 (about 150 MB), so it can take a few minutes.
                             </p>
-                        </div>
+                            <div className="mt-auto pt-6">
+                                <a
+                                    className="inline-block text-sm underline underline-offset-4"
+                                    href="https://docs.openadapt.ai/get-started/"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    onClick={() =>
+                                        track(EVENTS.DOCS_CLICK, {
+                                            location: 'local_quickstart',
+                                        })
+                                    }
+                                >
+                                    Open the CLI walkthrough
+                                </a>
+                            </div>
+                        </article>
 
-                        <aside className="rounded-2xl border border-hairline bg-panel p-5 md:p-6">
-                            <p className="eyebrow">What you get</p>
-                            <ol className="mt-4 grid gap-4 text-sm leading-relaxed text-ink-2">
+                        <article
+                            className="flex h-full flex-col rounded-2xl border border-hairline bg-panel p-5 md:p-6"
+                            role="listitem"
+                        >
+                            <p className="eyebrow">Native app · Beta</p>
+                            <h2 className="mt-2 font-display text-2xl font-semibold tracking-tight">
+                                OpenAdapt Desktop
+                            </h2>
+                            <p className="mt-3 text-sm leading-relaxed text-ink-2">
+                                Record, compile, inspect, qualify, run, and review
+                                evidence from the visual cockpit. It packages the
+                                same governed workflow engine behind a native app.
+                            </p>
+                            <ol className="mt-6 grid gap-4 text-sm leading-relaxed text-ink-2">
                                 <li>
-                                    <strong className="text-ink">Recording</strong>
+                                    <strong className="text-ink">
+                                        1 · Choose your installer
+                                    </strong>
                                     <br />
-                                    The demonstrated interaction and retained
-                                    target evidence.
+                                    Available for Windows, macOS, and Linux.
                                 </li>
                                 <li>
                                     <strong className="text-ink">
-                                        Workflow bundle
+                                        2 · Follow first-run setup
                                     </strong>
                                     <br />
-                                    The readable program OpenAdapt compiled.
+                                    Grant the local permissions needed to capture
+                                    your demonstration.
                                 </li>
                                 <li>
-                                    <strong className="text-ink">Run report</strong>
+                                    <strong className="text-ink">
+                                        3 · Run the visual workflow
+                                    </strong>
                                     <br />
-                                    The actions, evidence, result, and any halt
-                                    reason.
+                                    Review the compiled graph, policy, result, and
+                                    retained evidence in one place.
                                 </li>
                             </ol>
-                            <a
-                                className="mt-5 inline-block text-sm underline underline-offset-4"
-                                href="https://docs.openadapt.ai/get-started/"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                onClick={() =>
-                                    track(EVENTS.DOCS_CLICK, {
-                                        location: 'local_quickstart',
-                                    })
-                                }
-                            >
-                                Open the full walkthrough
-                            </a>
-                        </aside>
+                            <div className="mt-auto flex flex-wrap gap-3 pt-7">
+                                <Link
+                                    className="btn-ink"
+                                    href="/download#desktop-builds"
+                                    onClick={() =>
+                                        track(EVENTS.DOWNLOAD_CLICK, {
+                                            surface: 'local_start',
+                                            platform: 'chooser',
+                                        })
+                                    }
+                                >
+                                    Download Desktop
+                                </Link>
+                                <Link
+                                    className="btn-ghost-ink"
+                                    href="/download#desktop-preview"
+                                >
+                                    See the app
+                                </Link>
+                            </div>
+                        </article>
                     </div>
+
+                    <aside className="mt-5 rounded-2xl border border-hairline bg-ground p-5 md:p-6">
+                        <p className="eyebrow">One local product</p>
+                        <h2 className="mt-2 font-display text-xl font-semibold tracking-tight">
+                            Whichever path you choose, the result is portable.
+                        </h2>
+                        <div className="mt-5 grid gap-4 text-sm leading-relaxed text-ink-2 sm:grid-cols-3">
+                            <p>
+                                <strong className="text-ink">Recording</strong>
+                                <br />
+                                The demonstration and retained target evidence.
+                            </p>
+                            <p>
+                                <strong className="text-ink">
+                                    Workflow bundle
+                                </strong>
+                                <br />
+                                The inspectable program OpenAdapt compiled.
+                            </p>
+                            <p>
+                                <strong className="text-ink">Run evidence</strong>
+                                <br />
+                                The result, contract evidence, and any halt reason.
+                            </p>
+                        </div>
+                    </aside>
                 </div>
             </section>
 
             <section className="border-b border-hairline bg-panel px-5 py-16 md:py-20">
                 <div className="mx-auto max-w-4xl">
-                    <p className="eyebrow">After your first run</p>
+                    <p className="eyebrow">Optional after local success</p>
                     <h2 className="mt-2 max-w-2xl font-display text-2xl font-semibold tracking-tight md:text-3xl">
-                        Connect Cloud or qualify the real work.
+                        Keep running locally, connect Cloud, or qualify the real
+                        work.
                     </h2>
                     <div className="mt-7 grid gap-5 md:grid-cols-2">
                         <article className="rounded-2xl border border-hairline bg-ground p-5 md:p-6">

--- a/pages/start.js
+++ b/pages/start.js
@@ -118,6 +118,7 @@ export default function StartPage() {
                             </p>
                             <div className="mt-auto pt-6">
                                 <a
+                                    data-testid="local-cli-walkthrough"
                                     className="inline-block text-sm underline underline-offset-4"
                                     href="https://docs.openadapt.ai/get-started/"
                                     target="_blank"
@@ -173,6 +174,7 @@ export default function StartPage() {
                             </ol>
                             <div className="mt-auto flex flex-wrap gap-3 pt-7">
                                 <Link
+                                    data-testid="local-desktop-download"
                                     className="btn-ink"
                                     href="/download#desktop-builds"
                                     onClick={() =>
@@ -222,7 +224,10 @@ export default function StartPage() {
                 </div>
             </section>
 
-            <section className="border-b border-hairline bg-panel px-5 py-16 md:py-20">
+            <section
+                className="border-b border-hairline bg-panel px-5 py-16 md:py-20"
+                data-testid="local-next-steps"
+            >
                 <div className="mx-auto max-w-4xl">
                     <p className="eyebrow">Optional after local success</p>
                     <h2 className="mt-2 max-w-2xl font-display text-2xl font-semibold tracking-tight md:text-3xl">


### PR DESCRIPTION
## What changed

- presents OpenAdapt CLI and OpenAdapt Desktop as equal local entry paths
- makes their shared local recording, workflow, and evidence outputs explicit
- moves Cloud below local success as an optional handoff
- links Desktop visitors to the authoritative platform chooser and app gallery

## Why

The previous page was a CLI quickstart with Desktop available only on a separate download route. This makes the two interfaces visibly equivalent while keeping installer provenance and signing guidance centralized on `/download`.

## Verification

- `npm test` (153/153)
- `npm run build`
- `npx cypress run --config baseUrl=http://127.0.0.1:3015 --spec cypress/e2e/public-surface-coherence.cy.js` (5/5)
