### PR TITLE
fix: make local install substrate-aware

### DIFF
--- a/components/InstallSection.js
+++ b/components/InstallSection.js
@@ -4,7 +4,7 @@ import { faCopy, faCheck, faTerminal } from '@fortawesome/free-solid-svg-icons';
 import styles from './InstallSection.module.css';
 import { track, EVENTS } from 'utils/analytics';
 
-const INSTALL_COMMAND = 'pip install openadapt';
+const INSTALL_COMMAND = "pip install 'openadapt[browser]'";
 
 function CopyButton({ text, className, onCopied }) {
     const [copied, setCopied] = useState(false);
@@ -99,16 +99,17 @@ export default function InstallSection() {
                     Try the whole loop right now against the bundled demo app,
                     which runs in the browser: record, compile, inspect, certify,
                     replay, and induce known test drift. No account or cloud
-                    service. Once it is
-                    installed, your workflow data stays on your machine. One
-                    heads-up on first run: the first <code>demo-record</code> or{' '}
+                    service. Once it is installed, your workflow data stays on
+                    your machine. The browser extra is not part of native, RDP,
+                    or Citrix-only installs. On first web use,{' '}
+                    <code>demo-record</code> or{' '}
                     <code>replay</code> downloads a bundled Chromium (~150&nbsp;MB)
                     once, so that step takes a few minutes, and on Linux you may
                     need <code>playwright install-deps</code> first.
                 </p>
                 <div className={styles.commandGrid}>
                     <div className={styles.commandItem}>
-                        <code>pip install openadapt</code>
+                        <code>pip install 'openadapt[browser]'</code>
                         <span>Install OpenAdapt</span>
                     </div>
                     <div className={styles.commandItem}>

--- a/data/templates.js
+++ b/data/templates.js
@@ -24,7 +24,7 @@ const FLOW_REPO = 'https://github.com/OpenAdaptAI/openadapt-flow'
 // The canonical end-user quickstart enters through the flagship OpenAdapt
 // package while source links below continue to point to the engine repository.
 const DEMO_QUICKSTART = [
-    { cmd: 'pip install openadapt', what: 'Install the OpenAdapt launcher and governed workflow compiler.' },
+    { cmd: "pip install 'openadapt[browser]'", what: 'Install the OpenAdapt launcher, compiler, and browser capability.' },
     { cmd: 'openadapt flow demo-record --out rec', what: 'Serve the bundled MockMed clinic app locally and record the canonical triage demonstration.' },
     { cmd: 'openadapt flow compile rec --out bundle --name triage-note', what: 'Compile the recording into a deterministic, locally executable bundle.' },
     { cmd: 'openadapt flow lint bundle', what: 'Report the bundle’s coverage gaps — expected: it finds the demo’s unarmed irreversible final click.' },
@@ -33,7 +33,7 @@ const DEMO_QUICKSTART = [
 ]
 
 const RECORD_YOUR_OWN = [
-    { cmd: 'pip install openadapt', what: 'Install the OpenAdapt launcher and governed workflow compiler.' },
+    { cmd: "pip install 'openadapt[browser]'", what: 'Install the OpenAdapt launcher, compiler, and browser capability.' },
     { cmd: 'openadapt flow record --url https://your.app --out rec', what: 'Open a headed browser on your app and demonstrate the workflow once; Ctrl-C to finish.' },
     { cmd: 'openadapt flow compile rec --out bundle --name my-task', what: 'Compile the recording into a deterministic bundle with auto-classified risk per step.' },
     { cmd: 'openadapt flow lint bundle && openadapt flow certify bundle --policy permissive', what: 'Surface coverage gaps, then gate the bundle against a policy before it ever deploys.' },

--- a/pages/start.js
+++ b/pages/start.js
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import Footer from '@components/Footer'
 import { EVENTS, track } from 'utils/analytics'
 
-const INSTALL = 'python -m pip install --upgrade openadapt'
+const INSTALL = "python -m pip install --upgrade 'openadapt[browser]'"
 const QUICKSTART = 'openadapt quickstart'
 
 function Command({ command, event }) {
@@ -112,9 +112,10 @@ export default function StartPage() {
                                 />
                             </div>
                             <p className="mt-5 text-xs leading-relaxed text-ink-3">
-                                Requires Python 3.10–3.12 on Windows, macOS, or
-                                Linux. The first run downloads Chromium once
-                                (about 150 MB), so it can take a few minutes.
+                                Requires Python 3.10–3.12. The browser extra is
+                                only for this web tutorial; its first web action
+                                downloads matching Chromium once. Native, RDP,
+                                and Citrix installs do not need it.
                             </p>
                             <div className="mt-auto pt-6">
                                 <a
@@ -193,6 +194,12 @@ export default function StartPage() {
                                     See the app
                                 </Link>
                             </div>
+                            <p className="mt-4 text-xs leading-relaxed text-ink-3">
+                                Desktop opens without a browser download.
+                                Chromium is added only if you choose a browser
+                                workflow; native, RDP, and Citrix work stays on
+                                its own substrate path.
+                            </p>
                         </article>
                     </div>
 

--- a/public/install.sh
+++ b/public/install.sh
@@ -2,6 +2,7 @@
 # OpenAdapt installer — https://openadapt.ai
 #
 #   curl -fsSL https://openadapt.ai/install.sh | sh
+#   curl -fsSL https://openadapt.ai/install.sh | sh -s -- browser
 #
 # Installs uv (a fast Python toolchain) if you don't have it, then installs
 # OpenAdapt as a persistent `openadapt` command. Safe to re-run: it upgrades
@@ -30,8 +31,21 @@ if ! command -v uv >/dev/null 2>&1; then
     exit 1
 fi
 
-info "Installing OpenAdapt…"
-uv tool install --upgrade openadapt
+case "${1:-}" in
+    "")
+        package='openadapt'
+        ;;
+    browser)
+        package='openadapt[browser]'
+        ;;
+    *)
+        err "Unknown capability '$1'. Use no argument, or: browser"
+        exit 2
+        ;;
+esac
+
+info "Installing OpenAdapt${1:+ with browser support}…"
+uv tool install --upgrade "$package"
 
 # Make sure the installed `openadapt` command is on PATH in future shells.
 uv tool update-shell >/dev/null 2>&1 || true

--- a/tests/templatesGallery.test.js
+++ b/tests/templatesGallery.test.js
@@ -35,7 +35,7 @@ test('registry entries are complete, unique, and search-titled', () => {
         assert.ok(t.quickstart.length >= 3, `${t.slug}: CLI quickstart`)
         assert.equal(
             t.quickstart[0].cmd,
-            'pip install openadapt',
+            "pip install 'openadapt[browser]'",
             `${t.slug}: quickstart starts from the flagship package`
         )
         assert.ok(


### PR DESCRIPTION
## Summary
- make browser tutorials install `openadapt[browser]` explicitly
- keep the default install script lightweight and add an opt-in `browser` mode
- explain that Desktop starts without downloading Chromium
- keep native/RDP/Citrix paths out of browser provisioning

## Verification
- 153 frontend tests passed
- production Next.js build passed
- install script syntax checked and both base/browser modes exercised with a stubbed tool installer

## Rollout dependency
Merge/deploy after the launcher browser extra is published. The companion Flow release supplies the base-size reduction.