### PR TITLE
ci: skip non-deploying website builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,18 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'LICENSE*'
+      - 'NOTICE*'
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'LICENSE*'
+      - 'NOTICE*'
 
 permissions:
   contents: read

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,10 @@
 [build]
   command = "npm run build"
   publish = ".next"
+  # Netlify evaluates this diff before allocating build compute. A zero exit
+  # skips repository-only changes; a non-zero exit builds. Build hooks bypass
+  # ignore commands, so the paper-refresh hook still deploys when requested.
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- components data generated hooks lib netlify pages public scripts styles utils .nvmrc jsconfig.json next.config.js package.json package-lock.json postcss.config.js tailwind.config.js netlify.toml"
 
 [build.environment]
   # Cache buster - change this to force fresh build
@@ -18,10 +22,10 @@
 # rendered URL per PR, which the GitHub Actions `build-and-e2e` job (headless
 # `next build` + Cypress) cannot.
 #
-# `ignore` runs before each build: exit 0 cancels the build, non-zero proceeds.
-# The production context has no `ignore`, so pushes to main always build and
-# deploy. Branch-deploy stays skipped: per-branch deploys are lower value than
-# PR previews and would still spend minutes with no reviewer attached.
+# The global `ignore` above retains production and PR previews whenever a
+# deployable input changes. Branch-deploy stays skipped: per-branch deploys are
+# lower value than PR previews and would still spend minutes with no reviewer
+# attached.
 [context.branch-deploy]
   ignore = "exit 0"
 


### PR DESCRIPTION
## Summary

- skip GitHub CI for documentation-only repository changes
- let Netlify skip a build when no deployable input changed
- retain previews and production deploys for pages, components, public assets, server functions, data, scripts, dependencies, and build configuration
- preserve build-hook deploys and continue suppressing unreviewed branch deploys

## Why

The latest 100 Netlify deploys consumed about 94 build minutes, including previews and repeated production builds. Netlify previously built every commit regardless of whether it could change the deployed site. This uses Netlify's documented pre-build diff gate; a diff error fails open to a real build.

## Validation

- `npm test` (153 passing)
- `actionlint .github/workflows/ci.yml`
- parsed `netlify.toml`
- `git diff --check`

No customer-facing source changed.
