### PR TITLE
docs: disclose opt-in microphone narration capture

### DIFF
--- a/data/trustProviderInventory.mjs
+++ b/data/trustProviderInventory.mjs
@@ -10,9 +10,10 @@ export const trustDataFlows = Object.freeze([
         id: 'customer-controlled-execution',
         title: 'Customer-controlled execution',
         summary:
-            'Browser, native, RDP, and Citrix recordings, screenshots, input events, live observations, bundles, and machine evidence stay in infrastructure controlled by the customer. OpenAdapt Cloud receives only an explicitly admitted sanitized derivative or schema-minimized control-plane metadata unless the deployment authorizes another destination.',
+            'Browser, native, RDP, and Citrix recordings, screenshots, input events, live observations, bundles, and machine evidence stay in infrastructure controlled by the customer. Optional microphone narration is off by default and transcribed locally; waveform retention is separately opt-in, while transcripts remain sensitive customer-controlled capture data. OpenAdapt Cloud receives only an explicitly admitted sanitized derivative or schema-minimized control-plane metadata unless the deployment authorizes another destination.',
         dataClasses: Object.freeze([
             'raw recordings and input events',
+            'optional local narration transcripts and retained waveforms',
             'live runtime frames and identity evidence',
             'compiled bundles, reports, and checkpoints',
         ]),

--- a/pages/security.js
+++ b/pages/security.js
@@ -208,6 +208,10 @@ const flowZones = [
                 'Persisted step / heal frames',
                 'Redacted through Presidio image scrubbing when image scrubbing is enabled, and implied whenever scrubbing is pinned on.',
             ],
+            [
+                'Microphone narration (opt-in, off by default)',
+                'When explicitly enabled, capture transcribes narration locally and refuses before opening the microphone if no local backend is available. Waveform retention is separately opt-in; transcripts remain sensitive local capture data and are not automatically scrubbed. Control: filesystem + retention.',
+            ],
         ],
     },
     {

--- a/pages/terms-of-service.js
+++ b/pages/terms-of-service.js
@@ -48,6 +48,16 @@ const TermsOfService = () => {
                 hosted policy.
             </p>
             <p className={styles.paragraph}>
+                Recording can include the screen, keyboard, mouse, and optional
+                microphone narration. Narration is off by default and requires an
+                explicit operator action. It is transcribed locally, capture
+                refuses before opening the microphone when no local transcription
+                backend is available, and waveform retention is a separate
+                opt-in. Audio and transcripts are sensitive operator-controlled
+                artifacts; the standard hosted artifact-ingest path does not
+                accept narration audio or capture databases.
+            </p>
+            <p className={styles.paragraph}>
                 The hosted subscription includes managed execution for approved
                 browser workflows. Workflows that require Windows UIA, native
                 macOS, RDP, Citrix, private-network access, or a regulated runtime


### PR DESCRIPTION
## Summary

- disclose the released, opt-in microphone narration path without treating it as a permanent CLI-only capability
- add narration to the shared customer-controlled data-flow inventory rendered by both Privacy and Security
- state the local transcription, fail-before-open, explicit waveform-retention, and standard hosted-ingest boundaries concisely
- remove the original static-copy test and categorical claim that Desktop can never reuse capture

## Evidence

`openadapt-capture` v1.2.1 includes the fail-closed audio contract from PR #51:

- narration is off by default and requires explicit operator action
- transcription is local-only
- the command refuses before opening the microphone when no local backend exists
- retaining the waveform is a separate opt-in
- transcripts remain sensitive customer-controlled capture data

The standard hosted artifact-ingest path does not accept narration audio or capture databases. The copy does not preclude future governed Desktop integration.

## Verification

- `npm test` (180/180)
- `npm run build`
- `git diff --check`

This branch is rebased on the shared trust-provider inventory from #320 and changes only its customer-controlled data lane, one trust-center row, and one Terms paragraph.
