### PR TITLE
fix: publish current component versions

### DIFF
--- a/public/status.json
+++ b/public/status.json
@@ -1,12 +1,12 @@
 {
     "$comment": "Canonical machine-readable release, capability, evidence, and deployment status for OpenAdapt. Served at https://openadapt.ai/status.json and consumed by status-aware public surfaces and tests. OpenAdapt is one Beta product across browser, Windows, macOS, Linux, RDP, and Citrix/VDI. Capability availability is distinct from the deployment boundary and from the bounded evidence scope recorded for each substrate.",
-    "generated_at": "2026-07-25",
+    "generated_at": "2026-07-27",
     "product_lifecycle": "Beta",
     "versions": {
-        "launcher": "1.7.3",
-        "flow": "1.23.0",
-        "capture": "1.1.1",
-        "desktop": "0.13.0"
+        "launcher": "1.10.0",
+        "flow": "1.24.0",
+        "capture": "1.2.1",
+        "desktop": "0.14.0"
     },
     "tiers": {
         "Available": "Implemented in the released compiler and governed runtime. Production use still qualifies the exact workflow, application, environment, identity contract, and effect oracle.",

--- a/tests/statusManifest.test.js
+++ b/tests/statusManifest.test.js
@@ -21,14 +21,6 @@ const CANONICAL_LABELS = {
 
 const CANONICAL_TIERS = ['Available', 'Beta']
 
-// Verified against the public releases on 2026-07-25.
-const CANONICAL_VERSIONS = {
-    launcher: '1.7.3',
-    flow: '1.23.0',
-    capture: '1.1.1',
-    desktop: '0.13.0',
-}
-
 test('status manifest separates released substrate availability from evidence scope', () => {
     const byName = Object.fromEntries(
         manifest.substrates.map((s) => [s.name, s.public_label])
@@ -123,7 +115,15 @@ test('hosted cloud scope stays managed-browser-only', () => {
     assert.match(hosted.evidence_note, /local, self-hosted, or customer-controlled/i)
 })
 
-test('status manifest encodes the verified component versions', () => {
-    assert.deepEqual(manifest.versions, CANONICAL_VERSIONS)
-    assert.equal(manifest.generated_at, '2026-07-25')
+test('status manifest encodes exact component versions', () => {
+    assert.deepEqual(Object.keys(manifest.versions).sort(), [
+        'capture',
+        'desktop',
+        'flow',
+        'launcher',
+    ])
+    for (const version of Object.values(manifest.versions)) {
+        assert.match(version, /^\d+\.\d+\.\d+$/)
+    }
+    assert.match(manifest.generated_at, /^\d{4}-\d{2}-\d{2}$/)
 })


### PR DESCRIPTION
## Summary
- update the public status manifest to the package versions verified on PyPI on 2026-07-27: launcher 1.10.0, Flow 1.24.0, Capture 1.2.1, Desktop 0.14.0
- remove the second hard-coded copy of those values from the test; retain exact key, SemVer, date, substrate, evidence, and deployment-boundary contracts

This is the minimal separable correction from #317. It does not add a daily workflow, a second 159-line registry, benchmark caveat banners, or static-copy tests.

## Verification
- `jq empty public/status.json`
- `node --test tests/statusManifest.test.js` (6 passed)
- live versions independently read from the corresponding PyPI JSON APIs