### PR TITLE
fix: unify public trust provider inventory

### DIFF
--- a/components/TrustProviderInventory.js
+++ b/components/TrustProviderInventory.js
@@ -1,0 +1,98 @@
+import {
+    trustDataFlowById,
+    trustDataFlows,
+    trustProviders,
+} from '../data/trustProviderInventory.mjs'
+
+const laneNames = (provider) =>
+    provider.lanes.map((laneId) => trustDataFlowById[laneId].title).join('; ')
+
+export default function TrustProviderInventory({ compact = false }) {
+    return (
+        <div className="space-y-6">
+            <div className={`grid gap-4 ${compact ? '' : 'md:grid-cols-2'}`}>
+                {trustDataFlows.map((lane) => (
+                    <article
+                        key={lane.id}
+                        className="rounded-xl border border-hairline bg-panel p-5"
+                    >
+                        <h3 className="font-display text-base font-semibold text-ink">
+                            {lane.title}
+                        </h3>
+                        <p className="mt-2 text-sm leading-relaxed text-ink-2">
+                            {lane.summary}
+                        </p>
+                        {!compact && (
+                            <ul className="mt-3 list-disc space-y-1 pl-5 text-sm text-ink-2">
+                                {lane.dataClasses.map((dataClass) => (
+                                    <li key={dataClass}>{dataClass}</li>
+                                ))}
+                            </ul>
+                        )}
+                    </article>
+                ))}
+            </div>
+
+            <div className="overflow-x-auto rounded-xl border border-hairline bg-panel">
+                <table className="w-full min-w-[820px] border-collapse text-left text-sm">
+                    <caption className="sr-only">
+                        OpenAdapt service providers, purposes, data classes, and
+                        product data-flow lanes
+                    </caption>
+                    <thead className="font-mono text-[10px] uppercase tracking-[0.12em] text-ink-3">
+                        <tr>
+                            <th
+                                scope="col"
+                                className="border-b border-hairline px-4 py-3"
+                            >
+                                Provider
+                            </th>
+                            <th
+                                scope="col"
+                                className="border-b border-hairline px-4 py-3"
+                            >
+                                Purpose and data
+                            </th>
+                            <th
+                                scope="col"
+                                className="border-b border-hairline px-4 py-3"
+                            >
+                                Product lane
+                            </th>
+                            <th
+                                scope="col"
+                                className="border-b border-hairline px-4 py-3"
+                            >
+                                Activation
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {trustProviders.map((provider) => (
+                            <tr key={provider.id} className="align-top">
+                                <th
+                                    scope="row"
+                                    className="border-b border-hairline px-4 py-3 font-medium text-ink"
+                                >
+                                    {provider.name}
+                                </th>
+                                <td className="border-b border-hairline px-4 py-3 text-ink-2">
+                                    <span className="text-ink">
+                                        {provider.purpose}
+                                    </span>{' '}
+                                    {provider.data}
+                                </td>
+                                <td className="border-b border-hairline px-4 py-3 text-ink-2">
+                                    {laneNames(provider)}
+                                </td>
+                                <td className="border-b border-hairline px-4 py-3 text-ink-2">
+                                    {provider.configured}
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    )
+}

--- a/data/trustProviderInventory.mjs
+++ b/data/trustProviderInventory.mjs
@@ -1,0 +1,152 @@
+/**
+ * Canonical public inventory for OpenAdapt data-flow lanes and service
+ * providers. Security and Privacy render this same data so a provider or
+ * boundary cannot be updated on one trust surface while silently drifting on
+ * the other.
+ */
+
+export const trustDataFlows = Object.freeze([
+    Object.freeze({
+        id: 'customer-controlled-execution',
+        title: 'Customer-controlled execution',
+        summary:
+            'Browser, native, RDP, and Citrix recordings, screenshots, input events, live observations, bundles, and machine evidence stay in infrastructure controlled by the customer. OpenAdapt Cloud receives only an explicitly admitted sanitized derivative or schema-minimized control-plane metadata unless the deployment authorizes another destination.',
+        dataClasses: Object.freeze([
+            'raw recordings and input events',
+            'live runtime frames and identity evidence',
+            'compiled bundles, reports, and checkpoints',
+        ]),
+    }),
+    Object.freeze({
+        id: 'managed-authoring',
+        title: 'Managed browser authoring and execution',
+        summary:
+            'This is a separate hosted lane. During an approved managed browser session, raw frames and input events are processed by the managed runner and may be stored in private service storage for compilation. Capture and compilation do not sanitize that recording. Workloads whose live screens necessarily expose restricted data use a qualified customer-controlled boundary.',
+        dataClasses: Object.freeze([
+            'raw managed-browser frames and input events',
+            'managed compilation inputs and outputs',
+            'live observations and run evidence for approved workloads',
+        ]),
+    }),
+    Object.freeze({
+        id: 'hosted-control-plane',
+        title: 'Hosted control plane',
+        summary:
+            'The control plane operates accounts, organizations, access, billing, approved artifacts, workflow configuration, run status, usage, audit records, transactional invitations, product analytics, and bounded operational error reporting. Customer-controlled runtime screenshots and report bodies are not deliberately attached to analytics or error events; error messages and stacks are pattern-scrubbed and truncated but must still be treated as potentially sensitive.',
+        dataClasses: Object.freeze([
+            'account, organization, access, and billing records',
+            'approved artifacts, run status, usage, and audit metadata',
+            'bounded product events and scrubbed operational errors',
+        ]),
+    }),
+    Object.freeze({
+        id: 'marketing-site',
+        title: 'Public website and sales journey',
+        summary:
+            'The public site handles page visits, site-wide interaction autocapture when configured, bounded CTA and conversion events, contact forms, booking, checkout entry, and public repository metadata. It is not a workflow-runtime or customer-evidence surface.',
+        dataClasses: Object.freeze([
+            'page paths, interaction autocapture, bounded CTA events, and campaign attribution',
+            'contact and qualification form submissions',
+            'booking, checkout entry, and public repository metadata',
+        ]),
+    }),
+])
+
+export const trustProviders = Object.freeze([
+    Object.freeze({
+        id: 'netlify',
+        name: 'Netlify',
+        purpose: 'Hosts the public website and Cloud web application and processes public website form submissions.',
+        data: 'Network and request data; form fields a visitor intentionally submits; application delivery logs.',
+        lanes: Object.freeze(['hosted-control-plane', 'marketing-site']),
+        configured: 'Current hosting path',
+    }),
+    Object.freeze({
+        id: 'supabase',
+        name: 'Supabase',
+        purpose: 'Provides hosted authentication, the tenant-scoped database, and private object storage.',
+        data: 'Account and organization records, approved artifacts, reports, and private managed-authoring recordings. Customer-controlled live runtime frames are outside this lane.',
+        lanes: Object.freeze(['managed-authoring', 'hosted-control-plane']),
+        configured: 'Current hosted-service path',
+    }),
+    Object.freeze({
+        id: 'modal',
+        name: 'Modal',
+        purpose: 'Runs approved managed browser recording and execution compute, and hosted compilation when that path is explicitly enabled.',
+        data: 'Managed-session frames and input events, compilation inputs, live observations, and bounded execution outputs for the selected managed workflow.',
+        lanes: Object.freeze(['managed-authoring']),
+        configured: 'Selected managed workflows',
+    }),
+    Object.freeze({
+        id: 'stripe',
+        name: 'Stripe',
+        purpose: 'Provides Checkout, payment processing, billing, and subscription state.',
+        data: 'Payment and billing details entered in Stripe plus customer, subscription, price, and entitlement references used by OpenAdapt Cloud.',
+        lanes: Object.freeze(['hosted-control-plane', 'marketing-site']),
+        configured: 'Paid hosted-service path',
+    }),
+    Object.freeze({
+        id: 'resend',
+        name: 'Resend',
+        purpose: 'Delivers transactional organization-invitation email when configured.',
+        data: 'Invitee email, organization name, role, inviter display identity, and the non-secret sign-in link. No workflow payload or runtime evidence.',
+        lanes: Object.freeze(['hosted-control-plane']),
+        configured: 'Environment-gated',
+    }),
+    Object.freeze({
+        id: 'posthog',
+        name: 'PostHog',
+        purpose: 'Measures the public acquisition funnel and privacy-bounded Cloud activation outcomes when configured.',
+        data: 'The website sends public-page views, site-wide click/interaction autocapture, and named CTA/conversion events; optional website replay is off by default and masks inputs when enabled. Cloud disables autocapture and replay and sends scrubbed paths, opaque user/organization IDs, organization business name, role/admin flags, enums, counts, and durations. Cloud does not identify users by email or deliberately attach screenshots, record contents, or report bodies.',
+        lanes: Object.freeze(['hosted-control-plane', 'marketing-site']),
+        configured: 'Environment-gated; Do-Not-Track respected',
+    }),
+    Object.freeze({
+        id: 'ga4',
+        name: 'Google Analytics 4',
+        purpose: 'Measures route page views across the public site and Cloud, plus selected public-site conversions, when configured.',
+        data: 'Route/page and bounded campaign or conversion metadata. Google signals and ad-personalization signals are disabled; no workflow payload or runtime evidence.',
+        lanes: Object.freeze(['hosted-control-plane', 'marketing-site']),
+        configured: 'Optional; Do-Not-Track respected',
+    }),
+    Object.freeze({
+        id: 'meta',
+        name: 'Meta Pixel',
+        purpose: 'Measures public-site page views and lead, contact, or booking conversions during an explicitly configured campaign.',
+        data: 'Public marketing page and bounded conversion events; never product runtime or customer evidence data.',
+        lanes: Object.freeze(['marketing-site']),
+        configured: 'Optional campaign path; Do-Not-Track respected',
+    }),
+    Object.freeze({
+        id: 'sentry-compatible',
+        name: 'Sentry-compatible error service (GlitchTip)',
+        purpose: 'Receives bounded server error and operational anomaly events from OpenAdapt Cloud when configured.',
+        data: 'Route name, pattern-scrubbed and truncated error message/stack text, opaque run/organization/workflow IDs, and numeric counts. Callers are required not to attach request or response bodies, headers, cookies, query strings, screenshots, or report bodies. Pattern scrubbing is defense in depth, not proof that arbitrary error text is de-identified.',
+        lanes: Object.freeze(['hosted-control-plane']),
+        configured: 'Environment-gated',
+    }),
+    Object.freeze({
+        id: 'calcom',
+        name: 'Cal.com',
+        purpose: 'Provides the public booking flow.',
+        data: 'Booking details entered by the visitor and optional name/email prefill the visitor already supplied.',
+        lanes: Object.freeze(['marketing-site']),
+        configured: 'Current booking path',
+    }),
+    Object.freeze({
+        id: 'github',
+        name: 'GitHub',
+        purpose: 'Hosts public source, releases, advisories, and repository metadata used by the website.',
+        data: 'Public repository and release data plus ordinary network/request data when a visitor follows a GitHub link.',
+        lanes: Object.freeze(['marketing-site']),
+        configured: 'Current open-source path',
+    }),
+])
+
+export const trustDataFlowById = Object.freeze(
+    Object.fromEntries(trustDataFlows.map((lane) => [lane.id, lane]))
+)
+
+export function providersForLane(laneId) {
+    return trustProviders.filter((provider) => provider.lanes.includes(laneId))
+}

--- a/pages/privacy-policy.js
+++ b/pages/privacy-policy.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import Head from 'next/head'
+import TrustProviderInventory from '@components/TrustProviderInventory'
 import styles from '@styles/LegalPages.module.css'
 
 const CONTACT_EMAIL = 'hello@openadapt.ai'
@@ -20,10 +21,12 @@ const PrivacyPolicy = () => {
             </Head>
             <h1 className={styles.heading}>Privacy Notice</h1>
             <p className={styles.paragraph}>
-                <strong>Effective July 17, 2026.</strong> This Notice describes how
-                MLDSAI Inc. collects, uses, stores, and shares information through
-                the OpenAdapt website, open-source software interactions, and
-                hosted service.
+                <strong>
+                    Effective July 17, 2026. Last updated July 27, 2026.
+                </strong>{' '}
+                This Notice describes how MLDSAI Inc. collects, uses, stores, and
+                shares information through the OpenAdapt website, open-source
+                software interactions, and hosted service.
             </p>
             <p className={styles.paragraph}>
                 MLDSAI Inc. (&quot;OpenAdapt,&quot; &quot;we,&quot; or
@@ -95,20 +98,15 @@ const PrivacyPolicy = () => {
 
             <h2 className={styles.subheading}>4. Current Service Providers</h2>
             <p className={styles.paragraph}>
-                Current product paths use Netlify for website hosting and forms;
-                Supabase for hosted authentication, database, and private object
-                storage; Modal for managed browser recording and run compute, plus
-                optional hosted compilation only when explicitly enabled; Stripe
-                for Checkout, billing, and subscription state;
-                PostHog for launch-funnel analytics when configured; Cal.com for
-                booking; and GitHub for source links, repository widgets, and
-                public repository data. These providers can receive network and
-                service data needed for the selected interaction and process it
-                under their own terms and privacy policies, potentially outside
-                the visitor&apos;s province or country depending on provider and
-                project configuration. A customer-controlled deployment can use a
-                different approved provider set documented in its scope.
+                The inventory below separates customer-controlled execution from
+                managed authoring, the hosted control plane, and the public sales
+                journey. Providers receive only the data needed for the selected
+                lane, process it under their own terms and privacy policies, and
+                may process it outside the visitor&apos;s province or country. A
+                qualified customer-controlled deployment can use a different
+                approved provider set documented in its scope.
             </p>
+            <TrustProviderInventory compact />
 
             <h2 className={styles.subheading}>5. Website Forms, Booking, and Analytics</h2>
             <p className={styles.paragraph}>
@@ -121,12 +119,19 @@ const PrivacyPolicy = () => {
                 billing details when a visitor enters enabled Checkout.
             </p>
             <p className={styles.paragraph}>
-                If a PostHog key is configured, the site sends page views and named
-                launch-funnel clicks. The current code disables autocapture,
-                persistent browser storage, and session recording and does not send
-                form contents, emails, or free text to PostHog. Without a PostHog
-                key, that analytics path is a no-op. Analytics data is
-                marketing-site data, not workflow runtime data.
+                If a PostHog key is configured, the public site sends page views,
+                bounded CTA events, and autocaptured interactions across the public
+                site using in-memory persistence. Public-site session replay is
+                off by default and masks all input text if explicitly enabled.
+                OpenAdapt Cloud uses a stricter PostHog path: autocapture and replay
+                are disabled, page URLs are stripped of query strings and hashes,
+                and product events use opaque identifiers, organization business
+                name, role/admin flags, enums, counts, and durations. Cloud does not
+                identify users to PostHog by email or deliberately attach
+                screenshots, record contents, or report bodies. Optional GA4 and
+                Meta measurement are environment-gated, and all three browser
+                analytics paths honor Do-Not-Track. Analytics is never workflow
+                execution evidence.
             </p>
 
             <h2 className={styles.subheading}>6. Retention and Deletion Boundaries</h2>

--- a/pages/security.js
+++ b/pages/security.js
@@ -2,6 +2,8 @@ import Head from 'next/head'
 import Link from 'next/link'
 
 import Footer from '@components/Footer'
+import TrustProviderInventory from '@components/TrustProviderInventory'
+import statusManifest from '../public/status.json'
 
 const REPO_URL = 'https://github.com/OpenAdaptAI/openadapt-flow'
 const ADVISORY_URL =
@@ -14,10 +16,10 @@ const LIMITS_URL =
     'https://github.com/OpenAdaptAI/openadapt-flow/blob/main/docs/LIMITS.md'
 const RELEASES_URL =
     'https://github.com/OpenAdaptAI/openadapt-desktop/blob/main/RELEASES.md'
-const NATIVE_RELEASE_URL =
-    'https://github.com/OpenAdaptAI/openadapt-desktop/releases/tag/desktop-v0.13.1'
-const CONTROL_OVERLAY_URL =
-    'https://github.com/OpenAdaptAI/openadapt-desktop/blob/desktop-v0.13.1/docs/CONTROL_OVERLAY.md'
+const DESKTOP_VERSION = statusManifest.versions.desktop
+const DESKTOP_RELEASE_TAG = `desktop-v${DESKTOP_VERSION}`
+const NATIVE_RELEASE_URL = `https://github.com/OpenAdaptAI/openadapt-desktop/releases/tag/${DESKTOP_RELEASE_TAG}`
+const CONTROL_OVERLAY_URL = `https://github.com/OpenAdaptAI/openadapt-desktop/blob/${DESKTOP_RELEASE_TAG}/docs/CONTROL_OVERLAY.md`
 // Security reports go through GitHub private advisories or hello@openadapt.ai.
 // There is no security@openadapt.ai mailbox today — do not advertise one.
 const CONTACT_EMAIL = 'hello@openadapt.ai'
@@ -66,7 +68,7 @@ const summary = [
         note: 'Local retention is operator-owned; hosted retention, legal holds, tenant erasure, and deletion receipts are policy-governed.',
     },
     {
-        area: 'Subprocessors',
+        area: 'Service providers',
         anchor: 'subprocessors',
         status: 'yes',
         note: 'Named and current. No default model provider.',
@@ -343,45 +345,11 @@ const reviewPolicies = [
     ],
 ]
 
-const subprocessors = [
-    [
-        'Netlify',
-        'Website hosting and form submissions',
-        'Marketing site, contact/update forms',
-    ],
-    [
-        'Supabase',
-        'Hosted authentication, database, and private object storage',
-        'Hosted service accounts and artifacts',
-    ],
-    [
-        'Modal',
-        'Managed browser recording and run compute; optional hosted compilation only when explicitly enabled',
-        'Hosted service runtime',
-    ],
-    [
-        'Stripe',
-        'Checkout, billing, and subscription state',
-        'Hosted service billing',
-    ],
-    [
-        'PostHog',
-        'Launch-funnel analytics when a key is configured (autocapture, persistence, and session recording disabled)',
-        'Marketing site only',
-    ],
-    ['Cal.com', 'Meeting booking', 'Marketing site booking flow'],
-    [
-        'GitHub',
-        'Source links, repository widgets, and public repository data',
-        'Marketing site + open source',
-    ],
-]
-
 const releaseIntegrity = [
     {
         title: 'Build provenance & attestations',
         status: 'yes',
-        body: 'The PyPI engine publishes wheel and sdist with PEP 740 publish attestations. Desktop Beta 0.13.1 publishes a SHA256SUMS manifest and GitHub build-provenance attestations for every installer, metadata file, and SBOM. Provenance answers "was this built from our source by our CI"; it is not the same as code signing.',
+        body: `The PyPI engine publishes wheel and sdist with PEP 740 publish attestations. Desktop Beta ${DESKTOP_VERSION} publishes a SHA256SUMS manifest and GitHub build-provenance attestations for every installer, metadata file, and SBOM. Provenance answers "was this built from our source by our CI"; it is not the same as code signing.`,
         evidenceUrl: NATIVE_RELEASE_URL,
         evidenceLabel: 'Inspect the public checksums and attestations',
     },
@@ -393,14 +361,14 @@ const releaseIntegrity = [
     {
         title: 'Software bill of materials (SBOM)',
         status: 'yes',
-        body: 'Desktop Beta 0.13.1 publishes a CycloneDX JSON SBOM generated from the exact smoke-tested installer set. The release workflow rejects an empty or malformed SBOM before publication, includes its hash in SHA256SUMS, and attests the SBOM alongside the installers.',
+        body: `Desktop Beta ${DESKTOP_VERSION} publishes a CycloneDX JSON SBOM generated from the exact smoke-tested installer set. The release workflow rejects an empty or malformed SBOM before publication, includes its hash in SHA256SUMS, and attests the SBOM alongside the installers.`,
         evidenceUrl: NATIVE_RELEASE_URL,
         evidenceLabel: 'Download the public CycloneDX SBOM',
     },
     {
         title: 'Execution control overlay',
         status: 'yes',
-        body: 'Desktop Beta 0.13.1 provides a separate native status surface outside the target application. During active observation and execution it is click-through, non-focusable, and excluded from capture before it becomes visible; controls appear only at a safe paused or terminal boundary. Overlay presentation state is never used as target-resolution or verification evidence.',
+        body: `Desktop Beta ${DESKTOP_VERSION} provides a separate native status surface outside the target application. During active observation and execution it is click-through, non-focusable, and excluded from capture before it becomes visible; controls appear only at a safe paused or terminal boundary. Overlay presentation state is never used as target-resolution or verification evidence.`,
         evidenceUrl: CONTROL_OVERLAY_URL,
         evidenceLabel: 'Inspect the released overlay contract',
     },
@@ -903,12 +871,12 @@ export default function SecurityPage() {
                     </div>
                 </div>
 
-                {/* Subprocessors */}
+                {/* Service providers */}
                 <div
                     id="subprocessors"
                     className="mt-14 scroll-mt-20 border-t border-hairline pt-10"
                 >
-                    <p className="eyebrow">Subprocessors</p>
+                    <p className="eyebrow">Service providers</p>
                     <h2 className="mt-2 font-display text-2xl font-semibold tracking-tight text-ink">
                         The third parties in our current product paths
                     </h2>
@@ -919,37 +887,8 @@ export default function SecurityPage() {
                         use a different approved provider set documented in its
                         scope.
                     </p>
-                    <div className="mt-6 overflow-x-auto rounded-xl border border-hairline bg-panel">
-                        <table className="w-full min-w-[680px] border-collapse text-left text-sm">
-                            <thead className="font-mono text-[10px] uppercase tracking-[0.12em] text-ink-3">
-                                <tr>
-                                    <th className="border-b border-hairline px-4 py-3">
-                                        Provider
-                                    </th>
-                                    <th className="border-b border-hairline px-4 py-3">
-                                        Purpose
-                                    </th>
-                                    <th className="border-b border-hairline px-4 py-3">
-                                        Where used
-                                    </th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {subprocessors.map(([name, purpose, where]) => (
-                                    <tr key={name} className="align-top">
-                                        <th className="border-b border-hairline px-4 py-3 font-medium text-ink">
-                                            {name}
-                                        </th>
-                                        <td className="border-b border-hairline px-4 py-3 text-ink-2">
-                                            {purpose}
-                                        </td>
-                                        <td className="border-b border-hairline px-4 py-3 text-ink-2">
-                                            {where}
-                                        </td>
-                                    </tr>
-                                ))}
-                            </tbody>
-                        </table>
+                    <div className="mt-6">
+                        <TrustProviderInventory />
                     </div>
                     <p className="mt-4 text-sm leading-relaxed text-ink-2">
                         <strong className="text-ink">

--- a/tests/legalTruth.test.js
+++ b/tests/legalTruth.test.js
@@ -43,29 +43,43 @@ test('owner-approved legal documents are operative and consistently linked', () 
     assert.doesNotMatch(terms, /the Privacy Policy/)
 })
 
-test('privacy page names current providers and exact model-call posture', () => {
+test('shared trust inventory names current providers and exact model-call posture', async () => {
     const privacy = read('pages/privacy-policy.js')
+    const { trustProviders } = await import(
+        '../data/trustProviderInventory.mjs'
+    )
+    const providers = new Map(
+        trustProviders.map((provider) => [provider.id, provider])
+    )
 
-    for (const provider of [
-        'Netlify',
-        'Supabase',
-        'Modal',
-        'Stripe',
-        'PostHog',
-        'Cal.com',
-        'GitHub',
+    for (const providerId of [
+        'netlify',
+        'supabase',
+        'modal',
+        'stripe',
+        'resend',
+        'posthog',
+        'ga4',
+        'meta',
+        'sentry-compatible',
+        'calcom',
+        'github',
     ]) {
-        assert.match(privacy, new RegExp(provider.replace('.', '\\.')))
+        assert.ok(providers.has(providerId), `missing provider ${providerId}`)
     }
+    assert.deepEqual(providers.get('modal').lanes, ['managed-authoring'])
+    assert.ok(
+        providers.get('posthog').data.includes('does not identify users by email')
+    )
+    assert.ok(
+        providers
+            .get('sentry-compatible')
+            .data.includes('not proof that arbitrary error text is de-identified')
+    )
     assert.match(privacy, /Healthy deterministic replay makes no model calls/)
     assert.match(privacy, /Model-assisted[\s\S]*repair is optional and off by default/)
     assert.match(privacy, /does not bypass identity,[\s\S]*policy checks/)
-    assert.match(
-        privacy,
-        /Modal for managed browser recording and run compute,[\s\S]*optional hosted compilation only when explicitly enabled/
-    )
     assert.doesNotMatch(privacy, /ensuring the security|do not share your email/i)
-    assert.doesNotMatch(read('pages/_app.js'), /googletagmanager|google-analytics/i)
     assert.match(privacy, /is accountable for the practices described here/i)
 })
 

--- a/tests/trustProviderInventory.test.js
+++ b/tests/trustProviderInventory.test.js
@@ -1,0 +1,57 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+test('trust inventory is closed, internally referential, and lane-queryable', async () => {
+    const {
+        providersForLane,
+        trustDataFlowById,
+        trustDataFlows,
+        trustProviders,
+    } = await import('../data/trustProviderInventory.mjs')
+
+    const laneIds = new Set(trustDataFlows.map((lane) => lane.id))
+    const providerIds = new Set(trustProviders.map((provider) => provider.id))
+
+    assert.equal(laneIds.size, trustDataFlows.length)
+    assert.equal(providerIds.size, trustProviders.length)
+    assert.deepEqual(Object.keys(trustDataFlowById).sort(), [...laneIds].sort())
+
+    for (const lane of trustDataFlows) {
+        assert.ok(lane.title)
+        assert.ok(lane.summary)
+        assert.ok(lane.dataClasses.length > 0)
+    }
+
+    for (const provider of trustProviders) {
+        assert.ok(provider.name)
+        assert.ok(provider.purpose)
+        assert.ok(provider.data)
+        assert.ok(provider.configured)
+        assert.ok(provider.lanes.length > 0)
+        for (const laneId of provider.lanes) assert.ok(laneIds.has(laneId))
+    }
+
+    assert.deepEqual(
+        providersForLane('customer-controlled-execution'),
+        [],
+        'customer-controlled execution must not silently acquire an OpenAdapt provider'
+    )
+    assert.ok(providersForLane('managed-authoring').length > 0)
+    assert.ok(providersForLane('hosted-control-plane').length > 0)
+    assert.ok(providersForLane('marketing-site').length > 0)
+})
+
+test('sensitive managed data and bounded telemetry stay in separate provider contracts', async () => {
+    const { trustProviders } = await import(
+        '../data/trustProviderInventory.mjs'
+    )
+    const byId = Object.fromEntries(
+        trustProviders.map((provider) => [provider.id, provider])
+    )
+
+    assert.deepEqual(byId.modal.lanes, ['managed-authoring'])
+    assert.ok(byId.supabase.lanes.includes('managed-authoring'))
+    assert.ok(!byId.posthog.lanes.includes('managed-authoring'))
+    assert.ok(!byId['sentry-compatible'].lanes.includes('managed-authoring'))
+    assert.ok(!byId.resend.lanes.includes('managed-authoring'))
+})


### PR DESCRIPTION
## Summary

- introduce one structured provider and data-flow inventory shared by Security and Privacy
- distinguish customer-controlled execution, managed authoring, hosted control-plane, and public-site data lanes
- document current PostHog, GA4, Meta, Resend, Modal, Supabase, and Sentry-compatible/GlitchTip paths
- derive Desktop release and overlay evidence links from the canonical status manifest

## Verification

- npm test (180/180)
- npx next build
- git diff --check
- independent accuracy and accessibility review: no remaining findings