### PR TITLE
docs: replace stale hosted phase label

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,7 +49,7 @@ NEXT_PUBLIC_META_PIXEL_ID=
 # test price, and exact HTTPS origins for that environment. If any required
 # value is absent or mismatched, the offer is unavailable and checkout returns
 # HTTP 503. There is no request-host or concierge checkout fallback.
-# See docs/HOSTED_PHASE0.md.
+# See docs/HOSTED_CHECKOUT.md.
 
 HOSTED_CHECKOUT_QUALIFIED=false
 

--- a/docs/HOSTED_CHECKOUT.md
+++ b/docs/HOSTED_CHECKOUT.md
@@ -1,4 +1,4 @@
-# Hosted launch runbook
+# Hosted checkout runbook
 
 The website launches the configured Hosted subscription through Stripe
 Checkout only after the production lifecycle has been qualified and the


### PR DESCRIPTION
## What changed

- Rename the still-current hosted checkout runbook from the obsolete `HOSTED_PHASE0.md` filename to `HOSTED_CHECKOUT.md`.
- Update the environment-template reference to the canonical filename.

## Why

The public repository should not imply that the live self-service checkout is still a temporary Phase 0 implementation. The operational contract remains useful and accurate, so this preserves it under a target-state name instead of deleting it.

The root/docs audit found no other report, summary, or point-in-time artifact that was both clearly obsolete and safe to remove. `docs/ANALYTICS.md` remains the current instrumentation runbook.

## Validation

- `npm test` (178/178)
- `git diff --check`
- no remaining `HOSTED_PHASE0` or `DATA_VERIFICATION_REPORT` references
- Netlify's existing ignore rule skips docs-only deploys
