### PR TITLE
fix(site): fire the /dental lead conversion, and make the offer discoverable without a nav entry

### DIFF
--- a/components/DentalLeadForm.js
+++ b/components/DentalLeadForm.js
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 
 import BookingEmbed from '@components/BookingEmbed'
 
+import { trackBookingClick, trackEmailCapture } from 'utils/conversion'
 import { UTM_KEYS, captureUtmParams } from 'utils/utm'
 
 // Distinct Netlify form name so dental founding-cohort leads are separable
@@ -42,13 +43,13 @@ export default function DentalLeadForm({ sectionId = 'book' }) {
         setIsSubmitting(true)
 
         try {
-            if (typeof window !== 'undefined' && window.gtag) {
-                window.gtag('event', 'submit_form', {
-                    event_category: 'Form',
-                    event_label: DENTAL_FORM_NAME,
-                    value: 1,
-                })
-            }
+            // The canonical E1 "qualified lead" conversion. It must go through
+            // utils/conversion so PostHog, GA4 `generate_lead`, and the Meta
+            // `Lead` standard event all fire with first-touch attribution
+            // attached. A raw gtag call reaches none of them, which leaves the
+            // cost-per-qualified-lead kill criteria blind and gives Meta
+            // nothing to optimize against.
+            trackEmailCapture({ location: 'dental_landing' })
 
             const formData = new URLSearchParams()
             formData.set('form-name', DENTAL_FORM_NAME)
@@ -231,7 +232,15 @@ export default function DentalLeadForm({ sectionId = 'book' }) {
                             </button>
                             <button
                                 type="button"
-                                onClick={() => setIsSubmitted(true)}
+                                onClick={() => {
+                                    // Booking-intent signal, same funnel step
+                                    // as /book; here the scheduler renders in
+                                    // place instead of on a new route.
+                                    trackBookingClick({
+                                        location: 'dental_landing',
+                                    })
+                                    setIsSubmitted(true)
+                                }}
                                 className="btn-ghost-ink"
                             >
                                 Skip form and book now

--- a/components/StructuredData.js
+++ b/components/StructuredData.js
@@ -259,6 +259,57 @@ export function techArticleNode(args) {
 }
 
 /**
+ * A commercially offered service with a published price.
+ *
+ * This is the entity type AI assistants resolve when someone asks "who does X
+ * for Y, and what does it cost". Every field must restate something the page
+ * itself says: the price is the price rendered on the page, and nothing here
+ * may imply customers, results, or availability the offer does not have.
+ *
+ * `availability` is deliberately `LimitedAvailability` for a capacity-bounded
+ * cohort offer — that is the honest schema value, and it is also the true one.
+ */
+export function serviceNode({
+    url,
+    name,
+    description,
+    serviceType,
+    price,
+    priceCurrency = 'USD',
+    billingDuration,
+    availability = 'https://schema.org/LimitedAvailability',
+}) {
+    return {
+        '@type': 'Service',
+        '@id': `${url}#service`,
+        url,
+        name,
+        description,
+        serviceType,
+        provider: { '@id': ORGANIZATION_ID },
+        isRelatedTo: { '@id': SOFTWARE_ID },
+        offers: {
+            '@type': 'Offer',
+            url,
+            price: String(price),
+            priceCurrency,
+            availability,
+            ...(billingDuration
+                ? {
+                      priceSpecification: {
+                          '@type': 'UnitPriceSpecification',
+                          price: String(price),
+                          priceCurrency,
+                          billingDuration,
+                          unitCode: 'MON',
+                      },
+                  }
+                : {}),
+        },
+    }
+}
+
+/**
  * BreadcrumbList. Nothing on this site emits breadcrumbs today, which costs
  * hierarchy signal on the nested /compare/*, /solutions/*, /templates/*, and
  * /customers/* routes.

--- a/data/templates.js
+++ b/data/templates.js
@@ -188,6 +188,18 @@ const templates = [
         quickstart: RECORD_YOUR_OWN,
         source: `${FLOW_REPO}/tree/main/benchmark/openimis_claims`,
         evidence: null,
+        // Optional `managedOffer`: a live, priced, managed version of this
+        // exact workflow. This is the ONLY internal link into /dental, and
+        // that is deliberate (see tests/dentalOffer.test.js). One contextual
+        // link from the template describing the same workflow gives crawlers,
+        // AI assistants, and readers a real internal path to the offer without
+        // promoting a capacity-bounded, zero-customer vertical offer into
+        // site-wide navigation.
+        managedOffer: {
+            href: '/dental',
+            label: 'See the dental founding-cohort offer',
+            detail: 'Would you rather we ran this for you? OpenAdapt offers a managed version of this workflow to single-location dental practices at $500/month.',
+        },
     },
     {
         slug: 'insurance-eligibility-check',

--- a/pages/dental.js
+++ b/pages/dental.js
@@ -4,6 +4,38 @@ import Link from 'next/link'
 import DentalHaltMoment from '@components/DentalHaltMoment'
 import DentalLeadForm from '@components/DentalLeadForm'
 import Footer from '@components/Footer'
+import StructuredData, {
+    organizationNode,
+    serviceNode,
+    webPageNode,
+} from '@components/StructuredData'
+
+const PAGE_URL = 'https://openadapt.ai/dental'
+
+// /dental carries no nav entry by design, so machine discovery does the work
+// a nav link would otherwise do: robots.txt + sitemap.xml + llms.txt reach the
+// page, and this graph tells an assistant answering "who automates dental
+// insurance verification, and what does it cost" exactly what the offer is.
+// Every string restates something rendered on this page; nothing here may
+// imply customers, results, or capacity the offer does not have.
+const SCHEMA_NODES = [
+    organizationNode,
+    webPageNode({
+        url: PAGE_URL,
+        name: 'Automated dental insurance verification',
+        description:
+            'A $500/month founding service for single-location dental practices: up to three approved payer portals and 600 attended, local eligibility checks, with a staff-first exception queue and a signed monthly KPI.',
+    }),
+    serviceNode({
+        url: PAGE_URL,
+        name: 'Dental insurance verification — founding cohort',
+        description:
+            'OpenAdapt compiles a dental practice’s own payer-portal verification workflow from recordings of its own staff, then replays it attended on the practice’s front-desk PC. Anything that does not match halts into a ready-to-finish queue instead of guessing. One location, up to three approved payer portals, up to 600 eligibility checks per month, and a monthly service KPI agreed in writing that refunds the month if missed.',
+        serviceType: 'Dental insurance eligibility verification',
+        price: 500,
+        billingDuration: 1,
+    }),
+]
 
 const OFFER_FACTS = [
     {
@@ -43,6 +75,7 @@ export default function DentalPage() {
                     content="$500/month for one dental practice location: up to 3 approved payer portals and 600 attended, local eligibility checks, backed by a signed monthly service KPI."
                 />
                 <meta property="og:url" content="https://openadapt.ai/dental" />
+                <StructuredData nodes={SCHEMA_NODES} />
             </Head>
 
             {/* Offer hero */}

--- a/pages/templates/[slug].js
+++ b/pages/templates/[slug].js
@@ -214,6 +214,17 @@ export default function TemplatePage({ template, anchorTemplates }) {
                             Read docs
                         </a>
                     </div>
+                    {t.managedOffer && (
+                        <p className="mx-auto mt-6 max-w-2xl border-t border-hairline pt-5 text-sm text-ink-2">
+                            {t.managedOffer.detail}{' '}
+                            <Link
+                                href={t.managedOffer.href}
+                                className="font-medium"
+                            >
+                                {t.managedOffer.label} →
+                            </Link>
+                        </p>
+                    )}
                 </div>
             </div>
 

--- a/tests/dentalOffer.test.js
+++ b/tests/dentalOffer.test.js
@@ -100,3 +100,45 @@ test('dental page is discoverable and routes booking through the canonical embed
     assert.match(page, /sectionId="book"/)
     assert.match(page, /href="#book"/)
 })
+
+/**
+ * The information-architecture decision, pinned because it is exactly the
+ * kind of thing a later "make it more visible" change reverses by accident.
+ *
+ * /dental is a capacity-bounded founding-cohort offer at a published price
+ * with no customers yet. Crawlers and AI assistants reach it through
+ * robots.txt + sitemap.xml + llms.txt + Service/Offer JSON-LD; readers reach
+ * it through the one topically-matched internal link on the dental template.
+ * It is deliberately NOT in the primary nav or the footer: those Solutions
+ * menus hold /solutions/* positioning pages, and a priced vertical offer
+ * sitting beside them on every page would read as an established product line
+ * the company does not yet have.
+ *
+ * Discovery and navigation are separate questions. This test keeps them so.
+ * Changing it is a positioning decision — update the reasoning above with it.
+ */
+test('dental is discoverable to crawlers and AI search without a nav entry', () => {
+    const sitemap = read('public/sitemap.xml')
+    const llms = read('public/llms.txt')
+    const page = read('pages/dental.js')
+    const nav = read('components/NavHeader.js')
+    const footer = read('components/Footer.js')
+    const templates = read('data/templates.js')
+
+    // Machine discovery: sitemap, the llms.txt index, and a Service/Offer
+    // node whose price matches the price rendered on the page.
+    assert.match(sitemap, /<loc>https:\/\/openadapt\.ai\/dental<\/loc>/)
+    assert.match(llms, /https:\/\/openadapt\.ai\/dental/)
+    assert.match(page, /serviceNode\(/)
+    assert.match(page, /price: 500/)
+
+    // Reader discovery: exactly one contextual internal link, from the
+    // template that describes the same workflow.
+    assert.match(templates, /slug: 'dental-insurance-eligibility'/)
+    assert.match(templates, /managedOffer/)
+    assert.match(templates, /href: '\/dental'/)
+
+    // Not in primary nav, not in the footer.
+    assert.doesNotMatch(nav, /\/dental/)
+    assert.doesNotMatch(footer, /\/dental/)
+})

--- a/tests/e1Tracking.test.js
+++ b/tests/e1Tracking.test.js
@@ -84,6 +84,7 @@ test('lead forms and booking surfaces use the fan-out, not inline gtag/fbq', () 
         'components/EmailForm.js',
         'components/ContactBookingSection.js',
         'components/BookingEmbed.js',
+        'components/DentalLeadForm.js',
         'pages/book.js',
     ]
     for (const relativePath of conversionSurfaces) {
@@ -106,6 +107,14 @@ test('lead forms and booking surfaces use the fan-out, not inline gtag/fbq', () 
     )
     assert.match(read('pages/book.js'), /trackBookingClick\(/)
     assert.match(read('components/BookingEmbed.js'), /trackBookingConfirmed\(/)
+
+    // /dental is the paid-campaign landing page: its form submit IS the E1
+    // "qualified lead" the cost-per-lead kill criteria are measured on, and
+    // its in-place booking reveal is the booking-intent signal. It shipped
+    // with a raw gtag call that reached none of the three sinks.
+    const dental = read('components/DentalLeadForm.js')
+    assert.match(dental, /trackEmailCapture\(\{ location: 'dental_landing' \}\)/)
+    assert.match(dental, /trackBookingClick\(\{[\s\S]{0,80}'dental_landing'/)
 })
 
 test('.env.example documents both tracker ids as off-by-default', () => {


### PR DESCRIPTION
## The decision

**Keep `/dental` out of primary nav and the footer. Close the discovery gap directly instead.**

Navigation and discovery are separate questions, and conflating them is how this
one goes wrong. `/dental` was already crawlable, already in `sitemap.xml`, and
already listed in `llms.txt`. What it actually lacked was structured data (it was
one of the ten commercial-intent pages with no JSON-LD at all) and any internal
inbound link — it was an orphan. Neither gap needs a nav entry to fix.

## The tradeoff, resolved

The brief framed this as landing-page purity vs. discoverability. That framing
does not survive contact with the code: `NavHeader` renders from `pages/_app.js`,
so **`/dental` already carries the full primary nav and the "Qualify one workflow"
CTA on every render**, plus the whole footer. There is no nav-free landing page to
protect. The real question is narrower — should `/dental` be a *link inside* that
nav?

No, for three reasons:

1. **Category mismatch.** The Solutions menu holds `/solutions/*` positioning
   pages — horizontal capability framed by industry, each with a pinned reference
   environment and scoped-evidence disclosures. `/dental` is a priced,
   capacity-bounded founding-cohort offer: $500/month, 10 practices, one location,
   three portals, 600 checks, refund on a signed KPI. Putting it beside them
   mis-types it.
2. **Overclaim.** Zero customers. A priced vertical offer in site-wide nav reads
   as an established product line, on every page of the site, with the least
   evidence behind it of anything in that menu.
3. **Wrong traffic.** The page assumes a qualified dental visitor ("bring the payer
   portals you check most"). A visitor arriving from a generic Solutions menu lands
   on an offer they cannot buy.

## What changed

**The conversion path — this is the part that mattered most.**
`DentalLeadForm` was the only lead surface in the repo that hand-rolled
`window.gtag('event', 'submit_form', …)` instead of calling the `utils/conversion`
fan-out. So a `/dental` form submit fired **no** PostHog `email_capture_submitted`,
**no** GA4 `generate_lead`, and **no** Meta `Lead`. The campaign's kill criteria are
cost-per-qualified-lead (`≤ $150` success, `> $300` kill) and Meta optimizes on the
`Lead` standard event — both were blind, on the one page the campaign pays to send
traffic to. `tests/e1Tracking.test.js` already pinned the "lead forms use the fan-out,
not inline gtag/fbq" invariant; `DentalLeadForm` was simply missing from its list.

- Route the submit through `trackEmailCapture({ location: 'dental_landing' })`.
- Track booking intent on "Skip form and book now", which reveals the scheduler in
  place rather than routing to `/book`.
- Add `components/DentalLeadForm.js` to the pinned conversion-surface list.

**Discovery, without a nav link.**
- `Service` + `Offer` + `WebPage` JSON-LD on `/dental`, bound to the shared entity
  graph by `@id`. This is the node an assistant resolves for "who automates dental
  insurance verification and what does it cost". `availability` is
  `LimitedAvailability` — honest and true for a 10-practice cohort. Every string
  restates something the page renders. New generic `serviceNode()` helper; the
  three `/solutions/*` pages can reuse it.
- One contextual internal link, from `/templates/dental-insurance-eligibility` →
  `/dental`, via a new optional `managedOffer` field on the template registry. That
  template is the only other page on the site describing this exact workflow and it
  previously offered readers no path to the managed version of it. It also gives the
  page a real internal crawl path.

## What I deliberately did NOT do

- **No nav entry, no footer entry.** Pinned in `tests/dentalOffer.test.js` with the
  reasoning, so a later "make it more visible" change has to argue with it rather
  than silently reverse it.
- **No new "Dental" Solutions category.** The Solutions menu already has four
  entries; dental does not belong in it, and inventing a parallel category for one
  offer would be worse.
- **No `llms-full.txt` entry.** That file is Q&A-style quotable product facts. A
  dental section there would be new marketing surface for an offer with no
  customers, and `llms.txt` — the index AI systems actually fetch first — already
  lists `/dental`.
- **No copy changes to `/dental`.** Its `<title>` is 80 chars (over the 60-char
  guidance) but that is a copy decision, not mine to make here.

## Verification

- `npm test` → 183/183 pass (was 182; +1 new IA test).
- `next build` clean; confirmed in build output that `/dental` emits
  `https://openadapt.ai/dental#service` and that
  `/templates/dental-insurance-eligibility` emits `href="/dental"`.
- Live `/dental` HTTP 200; live pricing is `$500` in all four places, no `$499`
  anywhere (the internal brief's $499 never shipped).
- The `dental-founding-cohort` Netlify form **is** registered and accepting posts —
  verified live against production with the honeypot field filled, so the probe was
  discarded as spam rather than landing in the inbox (`200` for the real form name,
  `404` for an unregistered control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM