### PR TITLE
docs: correct the hosting provider from Vercel to Netlify

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,14 @@
 ## Repository Overview
 This is the marketing website for OpenAdapt at https://openadapt.ai/
 
-Built with Next.js and deployed via Vercel.
+Built with Next.js and deployed via **Netlify** (`netlify.toml`; responses carry
+a `server: Netlify` header).
+
+This matters more than a hosting trivia detail: **lead capture runs on Netlify
+Forms**, which has no Vercel equivalent. Anyone who believes this site is on
+Vercel will reason incorrectly about the entire lead path — form registration,
+spam filtering, and the `submission_created` email notification that delivers
+inbound leads to a human. This file said "Vercel" until 2026-07-27.
 
 ## Important Rules
 
@@ -25,7 +32,7 @@ gh pr create --title "Title" --body "Description"
 
 This allows:
 - Changes to be reviewed before deployment
-- Vercel preview deployments for testing
+- Netlify deploy previews for testing
 - Proper CI checks to run
 
 ### Development


### PR DESCRIPTION
`CLAUDE.md` said the site is "deployed via Vercel." It is on Netlify — `netlify.toml` is present and production responses carry a `server: Netlify` header.

This is worth a PR rather than a silent fix because **lead capture runs on Netlify Forms**, which has no Vercel equivalent. Anyone who trusted that line while touching the lead path would reason about the wrong platform: form registration, spam filtering, and the site-wide `submission_created` email notification that actually delivers inbound leads to a human all live in Netlify.

Surfaced while auditing the `/dental` conversion path, where a separate defect had left that page's submissions invisible to PostHog, GA4, and Meta (fixed in #324).

Docs only — no code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM