### PR TITLE
fix(site): fire the /qualify lead conversion and make the tracking test discover its own subjects

### DIFF
--- a/components/BookingEmbed.js
+++ b/components/BookingEmbed.js
@@ -27,7 +27,19 @@ function isCalBookingSuccess(event) {
     }
 }
 
-export default function BookingEmbed({ name = '', email = '' }) {
+/**
+ * `location` names the surface this scheduler is mounted on. The same embed
+ * renders on /book, inside the /dental paid-campaign landing page, and inside
+ * the /pricing contact section; without it every completed booking reported
+ * the same `booking_embed` label and a confirmed lead could not be attributed
+ * to the page that produced it. That matters most for /dental, whose paid
+ * spend is judged on cost per qualified lead.
+ */
+export default function BookingEmbed({
+    name = '',
+    email = '',
+    location = 'booking_embed',
+}) {
     const { bookingUrl, provider } = useMemo(() => {
         const config = getBookingConfig()
         return {
@@ -45,12 +57,12 @@ export default function BookingEmbed({ name = '', email = '' }) {
         if (!bookingUrl || provider !== 'calcom') return undefined
         const handleMessage = (event) => {
             if (isCalBookingSuccess(event)) {
-                trackBookingConfirmed({ location: 'booking_embed' })
+                trackBookingConfirmed({ location })
             }
         }
         window.addEventListener('message', handleMessage)
         return () => window.removeEventListener('message', handleMessage)
-    }, [bookingUrl, provider])
+    }, [bookingUrl, provider, location])
 
     if (!bookingUrl) {
         return (
@@ -92,7 +104,7 @@ export default function BookingEmbed({ name = '', email = '' }) {
                         className="btn-ink"
                         onClick={() =>
                             trackBookingClick({
-                                location: 'booking_embed_fallback',
+                                location: `${location}_fallback`,
                             })
                         }
                     >
@@ -128,7 +140,7 @@ export default function BookingEmbed({ name = '', email = '' }) {
                     className="text-accent underline hover:text-ink"
                     onClick={() =>
                         trackBookingClick({
-                            location: 'booking_embed_direct_link',
+                            location: `${location}_direct_link`,
                         })
                     }
                 >

--- a/components/ContactBookingSection.js
+++ b/components/ContactBookingSection.js
@@ -236,7 +236,11 @@ export default function ContactBookingSection({
                                 time directly below.
                             </p>
                         </div>
-                        <BookingEmbed name={form.name} email={form.email} />
+                        <BookingEmbed
+                            name={form.name}
+                            email={form.email}
+                            location="contact_form"
+                        />
                     </div>
                 )}
             </div>

--- a/components/DentalLeadForm.js
+++ b/components/DentalLeadForm.js
@@ -43,14 +43,6 @@ export default function DentalLeadForm({ sectionId = 'book' }) {
         setIsSubmitting(true)
 
         try {
-            // The canonical E1 "qualified lead" conversion. It must go through
-            // utils/conversion so PostHog, GA4 `generate_lead`, and the Meta
-            // `Lead` standard event all fire with first-touch attribution
-            // attached. A raw gtag call reaches none of them, which leaves the
-            // cost-per-qualified-lead kill criteria blind and gives Meta
-            // nothing to optimize against.
-            trackEmailCapture({ location: 'dental_landing' })
-
             const formData = new URLSearchParams()
             formData.set('form-name', DENTAL_FORM_NAME)
             formData.set('name', form.name)
@@ -82,6 +74,19 @@ export default function DentalLeadForm({ sectionId = 'book' }) {
                     `Form submission failed with status ${response.status}`
                 )
             }
+
+            // The canonical E1 "qualified lead" conversion. It must go through
+            // utils/conversion so PostHog, GA4 `generate_lead`, and the Meta
+            // `Lead` standard event all fire with first-touch attribution
+            // attached. A raw gtag call reaches none of them, which leaves the
+            // cost-per-qualified-lead kill criteria blind and gives Meta
+            // nothing to optimize against.
+            //
+            // Fired only after Netlify accepted the submission, matching every
+            // other lead surface. Firing it before the POST counted leads that
+            // never arrived, which understates cost-per-lead and teaches Meta
+            // to optimize toward submits that failed.
+            trackEmailCapture({ location: 'dental_landing' })
 
             setIsSubmitted(true)
         } catch (submitError) {
@@ -256,7 +261,11 @@ export default function DentalLeadForm({ sectionId = 'book' }) {
                                 time directly below.
                             </p>
                         </div>
-                        <BookingEmbed name={form.name} email={form.email} />
+                        <BookingEmbed
+                            name={form.name}
+                            email={form.email}
+                            location="dental_landing"
+                        />
                     </div>
                 )}
             </div>

--- a/components/FeedbackForm.js
+++ b/components/FeedbackForm.js
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPaperPlane } from '@fortawesome/free-solid-svg-icons'
 import styles from './FeedbackForm.module.css'
+import { trackEmailCapture } from 'utils/conversion'
 
 export default function FeedbackForm({ feedbackData }) {
     const router = useRouter()
@@ -34,6 +35,14 @@ export default function FeedbackForm({ feedbackData }) {
             .then((response) => {
                 if (response.ok) {
                     setFormHidden(true) // Hide form and show success message on successful submission
+                    // E1 qualified-lead conversion: email captured. Carries
+                    // first-touch utm_* attribution; never the email itself.
+                    //
+                    // This component is not currently rendered by any page,
+                    // but its `feedback` Netlify form is still registered and
+                    // accepting submissions, so re-mounting it must not
+                    // silently produce untracked leads.
+                    trackEmailCapture({ location: 'feedback_form' })
                     console.log('Form successfully submitted')
                 } else {
                     console.error('Form submission failed')

--- a/components/WorkflowQualificationForm.js
+++ b/components/WorkflowQualificationForm.js
@@ -6,6 +6,7 @@ import {
     scoreWorkflowQualification,
 } from '../lib/workflowQualification.mjs'
 import { EVENTS, track } from '../utils/analytics'
+import { trackEmailCapture } from '../utils/conversion'
 
 const INITIAL_FORM = {
     name: '',
@@ -111,6 +112,20 @@ export default function WorkflowQualificationForm({ compact = false }) {
             if (qualification.tier === 'priority') {
                 track(EVENTS.QUALIFIED_WORKFLOW, { tier: 'priority' })
             }
+            // /qualify is the destination of nearly every CTA on the site, so
+            // this submit is the canonical E1 "qualified lead". The PostHog
+            // events above are funnel detail and reach only PostHog; the
+            // fan-out is what emits GA4 `generate_lead` and the Meta `Lead`
+            // standard event with first-touch attribution attached. Without
+            // it, the site's primary conversion is unmeasurable by the
+            // cost-per-qualified-lead kill criteria and unoptimizable by Meta.
+            // `tier` is a computed enum, never a form field.
+            trackEmailCapture({
+                location: compact
+                    ? 'qualification_form_home'
+                    : 'qualification_form',
+                tier: qualification.tier,
+            })
             setResult(qualification)
             setState('submitted')
         } catch (submitError) {

--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -119,9 +119,38 @@ inline `gtag`/`fbq` calls):
 
 | Conversion | Fires when | PostHog | GA4 | Meta |
 | ---------- | ---------- | ------- | --- | ---- |
-| Email capture (**qualified lead**) | email/contact form submits successfully (`components/EmailForm.js`, `components/ContactBookingSection.js`) | `email_capture_submitted` | `generate_lead` | `Lead` |
-| Booking click | visitor reaches the scheduler (`pages/book.js`) or clicks a direct booking link (`components/BookingEmbed.js`) | `book_call_click` | `book_call_click` | `Contact` |
+| Email capture (**qualified lead**) | any lead form submits **and Netlify accepts it** | `email_capture_submitted` | `generate_lead` | `Lead` |
+| Booking click | visitor reaches the scheduler (`pages/book.js`), reveals it in place (`components/DentalLeadForm.js`), or clicks a direct booking link (`components/BookingEmbed.js`) | `book_call_click` | `book_call_click` | `Contact` |
 | Booking confirmed (**qualified lead**) | Cal.com embed reports a completed booking — best-effort postMessage signal (`components/BookingEmbed.js`) | `book_call_confirmed` | `book_call_confirmed` | `Schedule` |
+
+Every lead form fires the same email-capture conversion, distinguished only by
+its `location` property, so "leads" is one number across the whole site:
+
+| Surface | Page | `location` | Netlify form |
+| ------- | ---- | ---------- | ------------ |
+| `components/WorkflowQualificationForm.js` | `/qualify` (destination of most site CTAs) | `qualification_form` | `workflow-qualification` |
+| `components/DentalLeadForm.js` | `/dental` (paid campaign) | `dental_landing` | `dental-founding-cohort` |
+| `components/ContactBookingSection.js` | `/pricing` | `contact_form` | `contact` |
+| `components/PartnerInquiryForm.js` | `/partners` | `partner_inquiry_form` | `partner-inquiry` |
+| `components/ContributorProgramForm.js` | `/contribute` | `contributor_program_form` | `contributor-program` |
+| `components/EmailForm.js` | not currently mounted | `email_form` (caller-set) | `email` |
+| `components/FeedbackForm.js` | not currently mounted | `feedback_form` | `feedback` |
+
+`components/BookingEmbed.js` renders on `/book`, `/dental`, and `/pricing`, so
+it takes a `location` prop from each mount (`book_page`, `dental_landing`,
+`contact_form`); without it every confirmed booking reported the same label and
+could not be attributed to the page that produced it.
+
+**Ordering rule:** a conversion fires *after* the submission is accepted, never
+before. Firing on submit-attempt counts leads that never arrived, which
+understates cost-per-lead and teaches Meta to optimize toward failed submits.
+
+**This table is not the enforcement mechanism.** `tests/e1Tracking.test.js`
+discovers lead surfaces structurally — any component or page with a submit
+handler and an email field — and fails if one does not route through
+`utils/conversion.js`. Adding a new lead form requires no edit to any list.
+`components/Pricing.js` is deliberately not a lead surface: it opens Stripe
+Checkout, which collects the email on its own hosted page.
 
 ### Attribution
 

--- a/pages/book.js
+++ b/pages/book.js
@@ -54,7 +54,11 @@ export default function BookPage() {
                     </Link>
                 </div>
                 <div className="mt-8">
-                    <BookingEmbed name={name} email={email} />
+                    <BookingEmbed
+                        name={name}
+                        email={email}
+                        location="book_page"
+                    />
                 </div>
             </div>
             <Footer />

--- a/tests/e1Tracking.test.js
+++ b/tests/e1Tracking.test.js
@@ -11,6 +11,69 @@ function read(relativePath) {
     return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
 }
 
+// ---------------------------------------------------------------------------
+// Self-discovering surface enumeration.
+//
+// The previous version of this file hardcoded the list of lead surfaces it
+// checked. `components/DentalLeadForm.js` shipped a raw `window.gtag` call and
+// the suite stayed green purely because nobody added the new file to the list
+// (fixed in #324). A test that enumerates its own subjects cannot be silently
+// outgrown, so the subjects are derived from the source tree instead.
+// ---------------------------------------------------------------------------
+
+const SOURCE_ROOTS = ['components', 'pages']
+
+function walk(relativeDir, out = []) {
+    const absolute = path.join(process.cwd(), relativeDir)
+    for (const entry of fs.readdirSync(absolute, { withFileTypes: true })) {
+        const relative = path.join(relativeDir, entry.name)
+        if (entry.isDirectory()) {
+            walk(relative, out)
+        } else if (entry.name.endsWith('.js')) {
+            out.push(relative)
+        }
+    }
+    return out
+}
+
+/**
+ * A lead-capture surface is any component or page that submits a form
+ * containing an email address. That is the shape of every conversion the E1
+ * `Lead` optimization is measured on, and it is deliberately structural: a new
+ * lead form is caught the moment it exists, with no list to remember to edit.
+ *
+ * Deliberately NOT matched: forms with no email field (for example the Stripe
+ * checkout form in components/Pricing.js, where Stripe collects the email on
+ * its own hosted page). Those are not lead captures and must not fire `Lead`.
+ */
+function isLeadCaptureSurface(source) {
+    const submits = /onSubmit=\{/.test(source)
+    const hasEmailField =
+        /type="email"/.test(source) || /name="email"/.test(source)
+    return submits && hasEmailField
+}
+
+/**
+ * Surfaces that match the structural signature but must NOT fire a conversion,
+ * each with the reason. Keep this empty if at all possible: an entry here is a
+ * lead surface deliberately excluded from paid-campaign measurement, and it is
+ * the one place this test can still be outgrown by omission.
+ */
+const LEAD_SURFACE_EXCEPTIONS = {}
+
+function discoverLeadSurfaces() {
+    const found = []
+    for (const root of SOURCE_ROOTS) {
+        for (const relativePath of walk(root)) {
+            if (relativePath in LEAD_SURFACE_EXCEPTIONS) continue
+            if (isLeadCaptureSurface(read(relativePath))) {
+                found.push(relativePath)
+            }
+        }
+    }
+    return found.sort()
+}
+
 test('GA4 loader is gated on NEXT_PUBLIC_GA_MEASUREMENT_ID', () => {
     const source = read('components/analytics/GoogleAnalytics.js')
     assert.match(source, /process\.env\.NEXT_PUBLIC_GA_MEASUREMENT_ID/)
@@ -79,42 +142,121 @@ test('attribution captures the standard utm params, first-touch only', () => {
     )
 })
 
-test('lead forms and booking surfaces use the fan-out, not inline gtag/fbq', () => {
-    const conversionSurfaces = [
-        'components/EmailForm.js',
-        'components/ContactBookingSection.js',
-        'components/BookingEmbed.js',
-        'components/DentalLeadForm.js',
-        'pages/book.js',
-    ]
-    for (const relativePath of conversionSurfaces) {
+test('every discovered lead-capture surface fires the fan-out', () => {
+    const surfaces = discoverLeadSurfaces()
+
+    // Guard against the discovery itself silently matching nothing: a renamed
+    // prop or a refactor to a shared <Form> wrapper must fail loudly here
+    // rather than turn this suite into a no-op. Raise the floor when surfaces
+    // are added; lower it only alongside a deliberate removal.
+    assert.ok(
+        surfaces.length >= 7,
+        `expected the lead-surface scan to find at least 7 surfaces, found ${surfaces.length}: ${surfaces.join(', ')}`
+    )
+
+    for (const relativePath of surfaces) {
         const source = read(relativePath)
         assert.match(
             source,
-            /from 'utils\/conversion'/,
-            `${relativePath} must import the conversion fan-out`
+            /from '(\.\.\/)?utils\/conversion'/,
+            `${relativePath} looks like a lead-capture form but does not import the conversion fan-out. Call trackEmailCapture() from utils/conversion after the submission succeeds, or add it to LEAD_SURFACE_EXCEPTIONS with a reason.`
         )
-        assert.doesNotMatch(
+        assert.match(
             source,
-            /window\.gtag|window\.fbq/,
-            `${relativePath} must not call gtag/fbq directly`
+            /trackEmailCapture\(/,
+            `${relativePath} imports the fan-out but never calls trackEmailCapture()`
         )
     }
-    assert.match(read('components/EmailForm.js'), /trackEmailCapture\(/)
-    assert.match(
-        read('components/ContactBookingSection.js'),
-        /trackEmailCapture\(/
-    )
+})
+
+test('lead conversions fire only after the submission is accepted', () => {
+    // A conversion fired before the POST resolves counts leads that never
+    // arrived: it understates cost-per-lead and teaches Meta to optimize
+    // toward failed submits. In every surface the trackEmailCapture() call
+    // must come after the response.ok / response check in the source.
+    for (const relativePath of discoverLeadSurfaces()) {
+        const source = read(relativePath)
+        const okIndex = source.search(/response\.ok/)
+        const trackIndex = source.search(/trackEmailCapture\(/)
+        assert.ok(okIndex !== -1, `${relativePath} must check response.ok`)
+        assert.ok(
+            trackIndex > okIndex,
+            `${relativePath} fires trackEmailCapture() before the submission is confirmed accepted`
+        )
+    }
+})
+
+test('nothing outside the loaders and the fan-out touches gtag/fbq', () => {
+    // The whole point of utils/conversion.js is that there is exactly one
+    // place that knows about the ad platforms. This rule needs no list of
+    // subjects at all, so a new component cannot escape it.
+    const allowed = new Set([
+        'utils/conversion.js',
+        path.join('components', 'analytics', 'GoogleAnalytics.js'),
+        path.join('components', 'analytics', 'MetaPixel.js'),
+    ])
+    for (const root of [...SOURCE_ROOTS, 'utils']) {
+        for (const relativePath of walk(root)) {
+            if (allowed.has(relativePath)) continue
+            assert.doesNotMatch(
+                read(relativePath),
+                /window\.gtag|window\.fbq|\bfbq\(/,
+                `${relativePath} must route conversions through utils/conversion, not inline gtag/fbq`
+            )
+        }
+    }
+})
+
+test('booking surfaces use the fan-out and name their location', () => {
+    // Anything that knows the booking destination is a booking entry point and
+    // must report the intent through the fan-out. Derived, not listed.
+    for (const root of SOURCE_ROOTS) {
+        for (const relativePath of walk(root)) {
+            const source = read(relativePath)
+            if (!/from 'utils\/booking'/.test(source)) continue
+            assert.match(
+                source,
+                /from 'utils\/conversion'/,
+                `${relativePath} reaches the booking destination without tracking the intent`
+            )
+        }
+    }
+
     assert.match(read('pages/book.js'), /trackBookingClick\(/)
     assert.match(read('components/BookingEmbed.js'), /trackBookingConfirmed\(/)
 
-    // /dental is the paid-campaign landing page: its form submit IS the E1
-    // "qualified lead" the cost-per-lead kill criteria are measured on, and
-    // its in-place booking reveal is the booking-intent signal. It shipped
-    // with a raw gtag call that reached none of the three sinks.
+    // The same embed renders on /book, /dental, and /pricing. Without a
+    // per-mount location a confirmed booking cannot be attributed to the page
+    // that produced it, which is exactly what paid spend is judged on.
+    assert.match(
+        read('components/BookingEmbed.js'),
+        /location = 'booking_embed'/,
+        'BookingEmbed must accept a per-mount location'
+    )
+    assert.match(read('components/BookingEmbed.js'), /trackBookingConfirmed\(\{ location \}\)/)
+    for (const [mount, location] of [
+        ['pages/book.js', 'book_page'],
+        ['components/DentalLeadForm.js', 'dental_landing'],
+        ['components/ContactBookingSection.js', 'contact_form'],
+    ]) {
+        assert.match(
+            read(mount),
+            new RegExp(`location="${location}"`),
+            `${mount} must name the booking location it mounts the scheduler on`
+        )
+    }
+})
+
+test('the paid-campaign surfaces carry their campaign locations', () => {
+    // /dental is the paid-campaign landing page and /qualify is the
+    // destination of nearly every CTA on the site: these two submits ARE the
+    // conversions the cost-per-qualified-lead kill criteria are measured on.
     const dental = read('components/DentalLeadForm.js')
     assert.match(dental, /trackEmailCapture\(\{ location: 'dental_landing' \}\)/)
     assert.match(dental, /trackBookingClick\(\{[\s\S]{0,80}'dental_landing'/)
+
+    const qualification = read('components/WorkflowQualificationForm.js')
+    assert.match(qualification, /trackEmailCapture\(\{[\s\S]{0,160}'qualification_form'/)
 })
 
 test('.env.example documents both tracker ids as off-by-default', () => {


### PR DESCRIPTION
## Why

`/dental` (#324) was not an isolated mistake. The same defect class — a lead
surface that does not route through `utils/conversion` — was live on the
site's **primary** conversion destination, and the test that was supposed to
catch it could not, because it enumerated its own subjects by hand.

Verified against production before changing anything (live JS, not the tree):

```
$ curl https://openadapt.ai/_next/static/chunks/pages/qualify-fa70911a029f242a.js
  generate_lead                0
  email_capture_submitted      0
  "Lead"                       0
  qualification_form_submit    1     <- PostHog only
```

Form registration and baseline submission counts read from the authenticated
Netlify API rather than by sending probe submissions, so **no test data was
written to any form bucket and no analytics were fired into production
properties**.

## Inventory: every conversion and lead-capture surface

| # | Surface | file:line | Fired before | Should fire | Verdict |
|---|---------|-----------|--------------|-------------|---------|
| 1 | Workflow qualification form (`/qualify`, target of ~40 CTAs) | `components/WorkflowQualificationForm.js:108` | PostHog `qualification_form_submit` + `qualified_workflow` only | + `email_capture_submitted` / `generate_lead` / `Lead` | **DEFECT — fixed** |
| 2 | Dental founding-cohort form (`/dental`, paid campaign) | `components/DentalLeadForm.js:52` (pre-fix) | fan-out, but fired **before** the POST resolved | fire after `response.ok` | **DEFECT — fixed** |
| 3 | Cal.com booking embed (`/book`, `/dental`, `/pricing`) | `components/BookingEmbed.js:48` (pre-fix) | `book_call_confirmed` with a constant `location: 'booking_embed'` from all three mounts | per-mount `location` | **DEFECT — fixed** |
| 4 | Product-updates form | `components/FeedbackForm.js:36` (pre-fix) | nothing | `email_capture_submitted` / `generate_lead` / `Lead` | **DEFECT — fixed** |
| 5 | Contact / booking section (`/pricing`) | `components/ContactBookingSection.js:73` | `trackEmailCapture({location:'contact_form'})` after `response.ok` | same | correct |
| 6 | Partner inquiry (`/partners`) | `components/PartnerInquiryForm.js:80` | `trackEmailCapture({location:'partner_inquiry_form'})` after `response.ok` | same | correct |
| 7 | Contributor program (`/contribute`) | `components/ContributorProgramForm.js:72` | `trackEmailCapture({location:'contributor_program_form'})` after `response.ok` | same | correct |
| 8 | Generic email form (not mounted on any page) | `components/EmailForm.js:36` | `trackEmailCapture({location})` after `response.ok` | same | correct |
| 9 | `/book` scheduler page | `pages/book.js:16` | `trackBookingClick({location:'book_page'})` on mount | same | correct — reaching the page *is* the intent; deliberate, not a render-fire bug |
| 10 | Booking direct-link fallbacks | `components/BookingEmbed.js:106,142` | `trackBookingClick` | same | correct |
| 11 | Stripe checkout (`/pricing`) | `components/Pricing.js:107,137` | PostHog `pricing_cta_click` | PostHog only | correct — **not** a lead capture; Stripe collects the email on its own page. Deliberately excluded from the new rule. |
| 12 | `/download` asset clicks | `pages/download.js:190,232,353` | PostHog `download_click` | PostHog only | correct for its intent tier — a download is not a `Lead` |
| 13 | Nav / footer / hero / install / compare / workflows CTAs | `NavHeader.js`, `Footer.js`, `MastHead.js`, `InstallSection.js`, `pages/compare.js`, `pages/start.js`, `pages/workflows.js` | PostHog named events + autocapture | PostHog only | correct — intermediate clicks; the terminal form/booking is the conversion |
| 14 | `mailto:` links (`Footer.js:386`, `pages/about.js:144`, legal pages) | — | nothing | nothing | correct — a mailto click is not a captured lead; firing `Lead` there would inflate the denominator |
| 15 | `pages/contact.js` | `pages/contact.js:5` | 301 → `/qualify`, no page render | nothing | correct |
| 16 | `pages/hosted/welcome.js` | — | nothing | nothing | correct — `noindex` post-checkout support page; checkout returns to the cloud app, not here |
| 17 | GA4 / Meta loaders | `components/analytics/GoogleAnalytics.js`, `MetaPixel.js` | env-gated `PageView` once on load + once per route change | same | correct — no double-fire (`send_page_view: true` covers the initial view, route changes are manual) |

## Defects fixed

**1. `/qualify` fired no `Lead`, no `generate_lead`.** (critical) The single
highest-intent form on the site — it captures budget, timeline, economic
buyer, and a computed qualification tier — reached PostHog only. Every CTA on
`/pricing`, `/solutions/*`, `/compare`, `/templates`, `/security`,
`/how-it-works`, `/safety`, `/about`, `/start`, `/workflows`, and the nav
routes here. Any paid traffic converting through this form was invisible to
Meta's optimizer and absent from the cost-per-qualified-lead kill criteria.
Fixed by calling `trackEmailCapture({ location: 'qualification_form', tier })`
after `response.ok`, alongside (not replacing) the existing PostHog funnel
events. `tier` is a computed enum, never a form field.

**2. `/dental` fired its conversion before the submission was accepted.** The
`trackEmailCapture` call from #324 sat at the top of the `try` block, before
the `fetch`. A network failure or a Netlify rejection still counted a `Lead`.
That over-reports leads, *understates* cost-per-lead, and teaches Meta to
optimize toward submits that failed — the opposite of the kill criteria's
intent. Moved after the `response.ok` check, matching every other surface, and
pinned by a new test that compares source positions.

**3. `BookingEmbed` reported an ambiguous `location`.** The same embed renders
on `/book`, inside `/dental`, and inside `/pricing`, and all three reported
`location: 'booking_embed'` on `book_call_confirmed` (Meta `Schedule`) — one
of the two qualified-lead conversions. A booking produced by paid `/dental`
traffic was indistinguishable from an organic one on `/pricing`. Added a
`location` prop, passed as `book_page` / `dental_landing` / `contact_form`.

**4. `FeedbackForm` fired nothing.** It posts to the `feedback` Netlify form,
which is still registered and has 87 historical submissions. It is not
rendered by any page today, so nothing is leaking right now, but re-mounting
it would have silently produced untracked leads. Routed through the fan-out
with `location: 'feedback_form'`.

## The enumeration fix

`tests/e1Tracking.test.js` no longer contains a list of surfaces. It walks
`components/` and `pages/` and classifies a file as a lead-capture surface
structurally: **a submit handler plus an email field**. Four rules now apply
to whatever it finds:

1. every discovered surface must import `utils/conversion` and call `trackEmailCapture()`;
2. the `trackEmailCapture()` call must appear *after* the `response.ok` check;
3. nothing under `components/`, `pages/`, or `utils/` may reference `window.gtag`/`window.fbq` except the two loaders and `utils/conversion.js` — this rule needs no subject list at all;
4. anything importing `utils/booking` must also import `utils/conversion`.

Verified by planting a throwaway component with the exact `/dental` defect
(Netlify form, email input, inline `window.gtag('event','submit_form')`).
Three tests failed on it with no list edited; removed after.

### Limits, stated plainly

- **The signature can be evaded.** A lead form that renders its email input
  from a shared sub-component, or uses a `<Form>` wrapper instead of a raw
  `onSubmit={}`, would not match. Mitigated by a **floor assertion** (`>= 7`
  surfaces) so a refactor that empties the scan fails loudly rather than
  turning the suite into a no-op — this is the meta-version of the same bug
  and is the one I could actually defend against.
- **`LEAD_SURFACE_EXCEPTIONS` is a hole by design**, currently empty. An entry
  is a lead surface deliberately excluded from paid measurement and needs a
  written reason. It exists so the escape hatch is one reviewable line rather
  than someone deleting the test.
- **Static analysis only.** These are source-text rules; they prove the call
  exists and is ordered correctly, not that it executes at runtime. Runtime
  proof needs the Cypress suite or a real pixel-helper session.
- **The three sinks are still checked at one point** (`utils/conversion.js`
  must contain `generate_lead`, `'Lead'`, `'Schedule'`). If someone deletes a
  sink from the fan-out, that one test catches it — but that is by design, it
  is the single chokepoint.

## Deliberately left alone

- **`components/Pricing.js` Stripe checkout.** Not a lead capture — Stripe
  collects the email. It fires `pricing_cta_click` for the funnel, which is
  right. Adding `Lead` here would double-count against form submissions. The
  discovery rule correctly excludes it (no email field).
- **`/download` and all nav/hero/footer CTA clicks.** PostHog-only is correct
  for intermediate intent. Promoting them to `Lead` would corrupt the
  cost-per-qualified-lead denominator, and PostHog autocapture already covers
  the funnel pages.
- **`mailto:` links.** A mailto click is not a captured lead and the site
  cannot observe whether an email was ever sent.
- **`BookingEmbed`'s degraded branches** (`!bookingUrl`, `provider !== 'calcom'`).
  Their "Go to Contact Form" and "Email Sales" links are untracked, but
  `getBookingConfig()` returns hardcoded constants, so both branches are
  statically unreachable. Reported, not padded into the diff.
- **CTA-click instrumentation on the ~40 links pointing at `/qualify`.**
  The terminal form submit is the conversion and is now correct; adding 40
  click events would add noise, not signal.
- **No new event names and no new abstraction.** Everything routes through the
  existing three fan-out functions.
- **Deleting the dead components.** `EmailForm.js`, `FeedbackForm.js`, and
  `AudiencePaths.js` are not rendered by any page. That is repo hygiene, not
  tracking, and there is an open branch in that lane — see "For a human".

## Verification

- `npm test` — **187/187 pass**.
- `npx next build` — succeeds; the built chunks for `/qualify`, `/dental`,
  `/book`, `/pricing`, `/partners`, and `/contribute` all now contain
  `generate_lead`, `email_capture_submitted`, and the Meta `"Lead"` string.
  Before this change only `/dental` and `/book` did.
- Netlify form registration and baseline submission counts read via the
  authenticated API. All six form names used in code are registered. **No
  probe submissions were sent and no production analytics were fired.**

## For a human

- **Baseline counts at time of audit:** `email` 425, `feedback` 87, `contact`
  4, and `workflow-qualification`, `partner-inquiry`, `contributor-program`,
  `dental-founding-cohort` all **0**. The site's primary conversion form has
  produced zero submissions to date — worth knowing before reading any
  cost-per-lead number.
- `components/EmailForm.js`, `components/FeedbackForm.js`, and
  `components/AudiencePaths.js` are dead code (no page renders them).
  `FeedbackForm`'s `feedback` form is also missing from `public/form.html`
  even though Netlify still has it registered. Suggest deleting all three in
  the repo-hygiene lane rather than here.
- If `/qualify` has ever received paid traffic, historical lead attribution
  for it is unrecoverable — the events were never sent.

Claude-Session: https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM
