### PR TITLE
fix: correct the component versions openadapt.ai advertises

### DIFF
--- a/data/published-version-claims.json
+++ b/data/published-version-claims.json
@@ -32,8 +32,8 @@
             "id": "status-manifest-component-versions",
             "kind": "pypi-latest",
             "source_of_truth": "public/status.json#/versions",
-            "verified_on": "2026-07-27",
-            "evidence": "https://pypi.org/pypi/<package>/json info.version on 2026-07-27, reconciled with openadapt-web PR #318 which published these same values.",
+            "verified_on": "2026-07-28",
+            "evidence": "https://pypi.org/pypi/<package>/json info.version on 2026-07-28: openadapt 1.10.1, openadapt-flow 1.25.1, openadapt-capture 1.2.1, openadapt-desktop 0.14.0.",
             "packages": {
                 "launcher": "openadapt",
                 "flow": "openadapt-flow",
@@ -41,8 +41,8 @@
                 "desktop": "openadapt-desktop"
             },
             "versions": {
-                "launcher": "1.10.0",
-                "flow": "1.24.0",
+                "launcher": "1.10.1",
+                "flow": "1.25.1",
                 "capture": "1.2.1",
                 "desktop": "0.14.0"
             }
@@ -57,12 +57,12 @@
             "evidence": "openadapt-flow cbec44c2c2f355d5cc04a72ea9267e2d6ea68ac6 declares version = \"0.1.0\" in pyproject.toml and describes as v0.1.0-24-gcbec44c; v0.2.0 (2026-07-11) is the first release tag containing it.",
             "verified_on": "2026-07-27",
             "acknowledged_release_lag": {
-                "as_of_release": "1.24.0",
-                "releases_behind": 68,
-                "minor_releases_behind_first_containing_tag": 22,
-                "acknowledged_on": "2026-07-27",
+                "as_of_release": "1.25.1",
+                "releases_behind": 70,
+                "minor_releases_behind_first_containing_tag": 23,
+                "acknowledged_on": "2026-07-28",
                 "review_by": "2026-10-31",
-                "note": "68 live openadapt-flow releases postdate 0.1.0, and v0.2.0 -- the first release tag containing the pinned commit -- is 22 minor releases behind 1.24.0. That is recorded, labelled on every surface that renders them, and deliberately NOT edited -- these are historical measurements. The lag may not grow past the acknowledged value without a decision, and the acknowledgement expires on review_by so it cannot be renewed by silence. Refreshing means re-running the benchmarks: MockMed is deterministic and CI-reproducible; OpenEMR runs against a shared public demo that resets daily, so its refresh is a field run whose numbers will legitimately differ."
+                "note": "70 live openadapt-flow releases postdate 0.1.0, and v0.2.0 -- the first release tag containing the pinned commit -- is 23 minor releases behind 1.25.1. That is recorded, labelled on every surface that renders them, and deliberately NOT edited -- these are historical measurements. The lag may not grow past the acknowledged value without a decision, and the acknowledgement expires on review_by so it cannot be renewed by silence. Refreshing means re-running the benchmarks: MockMed is deterministic and CI-reproducible; OpenEMR runs against a shared public demo that resets daily, so its refresh is a field run whose numbers will legitimately differ. Re-acknowledged on 2026-07-28 for v1.25.0 and v1.25.1 (68 -> 70). review_by is deliberately UNCHANGED at 2026-10-31: restating the count is not a decision to keep waiting, and this acknowledgement must still expire on its original date."
             },
             "attribution_required": [
                 {

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -78,7 +78,7 @@ control plane is a separate commercial product.
 
 - Engine source: https://github.com/OpenAdaptAI/openadapt-flow
 - Install route: https://github.com/OpenAdaptAI/OpenAdapt and `pip install openadapt`
-- Current published versions: launcher 1.10.0, Flow 1.24.0, capture 1.2.1, desktop 0.14.0
+- Current published versions: launcher 1.10.1, Flow 1.25.1, capture 1.2.1, desktop 0.14.0
 - Product lifecycle: Beta
 
 ---

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -9,7 +9,7 @@ OpenAdapt is for the case where the work is repetitive and consequential, the in
 ## Canonical machine-readable status
 
 - [status.json](https://openadapt.ai/status.json): The single source of truth for product lifecycle, released component versions, per-substrate availability, delivery boundary, and the linked acceptance evidence for each substrate. Public surfaces render their labels from this file. Prefer it over any prose on this site if the two ever disagree.
-- Current published versions: launcher 1.10.0, Flow (compiler/runtime) 1.24.0, capture 1.2.1, desktop 0.14.0. Product lifecycle: Beta.
+- Current published versions: launcher 1.10.1, Flow (compiler/runtime) 1.25.1, capture 1.2.1, desktop 0.14.0. Product lifecycle: Beta.
 
 ## Execution substrates and their evidence boundary
 

--- a/public/status.json
+++ b/public/status.json
@@ -1,10 +1,10 @@
 {
     "$comment": "Canonical machine-readable release, capability, evidence, and deployment status for OpenAdapt. Served at https://openadapt.ai/status.json and consumed by status-aware public surfaces and tests. OpenAdapt is one Beta product across browser, Windows, macOS, Linux, RDP, and Citrix/VDI. Capability availability is distinct from the deployment boundary and from the bounded evidence scope recorded for each substrate.",
-    "generated_at": "2026-07-27",
+    "generated_at": "2026-07-28",
     "product_lifecycle": "Beta",
     "versions": {
-        "launcher": "1.10.0",
-        "flow": "1.24.0",
+        "launcher": "1.10.1",
+        "flow": "1.25.1",
         "capture": "1.2.1",
         "desktop": "0.14.0"
     },


### PR DESCRIPTION
https://openadapt.ai/status.json stated `flow 1.24.0` and `launcher 1.10.0`.
PyPI has openadapt-flow 1.25.1 (2026-07-27) and openadapt 1.10.1 (2026-07-28).
capture 1.2.1 and desktop 0.14.0 were already correct. status.json is a public
machine-readable surface and other public surfaces render their labels from it,
so the stale values propagated: public/llms.txt and public/llms-full.txt both
restate the same list, and the StructuredData schema takes
`softwareVersion`/`sourceCode.version` straight from it.

Also re-acknowledges the headline-benchmark release lag. v1.25.0 and v1.25.1
moved the retained 2026-07-08 measurements from 68 to 70 published releases
behind the shipping engine, past the value acknowledged on 2026-07-27 against
1.24.0. The measurements are historical and are deliberately NOT edited; only
the recorded gap moves. `review_by` stays 2026-10-31 on purpose -- restating the
count is not a decision to keep waiting, and this acknowledgement must still
expire on its original date rather than be renewed indefinitely by arithmetic.

`node scripts/check_published_version_claims.mjs` now exits 0 against live PyPI
(it reported three drifts before this change). 187 tests pass.

Note on why this drifted, since the same thing will happen again: status.json
is HAND-MAINTAINED here. Nothing generates it. A component release happens in
openadapt-flow or OpenAdapt and nothing writes back to this repo, so the values
go stale the moment anything ships. The guard added on 2026-07-27 detects it --
the daily lane of this same script compares against PyPI -- but detection is
after the fact and up to 24 hours late, and it still needs a person to notice a
red scheduled run and open this PR by hand. Its first scheduled run had not
happened yet when this drift occurred. Closing the loop properly means the
daily lane opening the corrective PR itself, since it already computes the right
answer; that is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM