### PR TITLE
fix: publish Capture 1.2.2 status

### DIFF
--- a/data/published-version-claims.json
+++ b/data/published-version-claims.json
@@ -33,7 +33,7 @@
             "kind": "pypi-latest",
             "source_of_truth": "public/status.json#/versions",
             "verified_on": "2026-07-28",
-            "evidence": "https://pypi.org/pypi/<package>/json info.version on 2026-07-28: openadapt 1.10.1, openadapt-flow 1.25.1, openadapt-capture 1.2.1, openadapt-desktop 0.14.0.",
+            "evidence": "https://pypi.org/pypi/<package>/json info.version on 2026-07-28: openadapt 1.10.1, openadapt-flow 1.25.1, openadapt-capture 1.2.2, openadapt-desktop 0.14.0.",
             "packages": {
                 "launcher": "openadapt",
                 "flow": "openadapt-flow",
@@ -43,7 +43,7 @@
             "versions": {
                 "launcher": "1.10.1",
                 "flow": "1.25.1",
-                "capture": "1.2.1",
+                "capture": "1.2.2",
                 "desktop": "0.14.0"
             }
         },

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -78,7 +78,7 @@ control plane is a separate commercial product.
 
 - Engine source: https://github.com/OpenAdaptAI/openadapt-flow
 - Install route: https://github.com/OpenAdaptAI/OpenAdapt and `pip install openadapt`
-- Current published versions: launcher 1.10.1, Flow 1.25.1, capture 1.2.1, desktop 0.14.0
+- Current published versions: launcher 1.10.1, Flow 1.25.1, capture 1.2.2, desktop 0.14.0
 - Product lifecycle: Beta
 
 ---

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -9,7 +9,7 @@ OpenAdapt is for the case where the work is repetitive and consequential, the in
 ## Canonical machine-readable status
 
 - [status.json](https://openadapt.ai/status.json): The single source of truth for product lifecycle, released component versions, per-substrate availability, delivery boundary, and the linked acceptance evidence for each substrate. Public surfaces render their labels from this file. Prefer it over any prose on this site if the two ever disagree.
-- Current published versions: launcher 1.10.1, Flow (compiler/runtime) 1.25.1, capture 1.2.1, desktop 0.14.0. Product lifecycle: Beta.
+- Current published versions: launcher 1.10.1, Flow (compiler/runtime) 1.25.1, capture 1.2.2, desktop 0.14.0. Product lifecycle: Beta.
 
 ## Execution substrates and their evidence boundary
 

--- a/public/status.json
+++ b/public/status.json
@@ -5,7 +5,7 @@
     "versions": {
         "launcher": "1.10.1",
         "flow": "1.25.1",
-        "capture": "1.2.1",
+        "capture": "1.2.2",
         "desktop": "0.14.0"
     },
     "tiers": {


### PR DESCRIPTION
## What changed

- update the canonical public status manifest from `openadapt-capture` 1.2.1 to 1.2.2
- update the published-version registry and both guarded `llms` copies

## Why

PyPI and the GitHub release page both publish `openadapt-capture` 1.2.2. The public status sources still stated 1.2.1.

## Validation

- `node --test tests/statusManifest.test.js tests/aiDiscoverability.test.js`
- `npm run check:versions -- --offline`
- `npm run check:versions`
- PyPI reports 1.2.2
- GitHub release `v1.2.2` is public and final
