### PR TITLE
fix: publish Launcher 1.10.2 status

### DIFF
--- a/data/published-version-claims.json
+++ b/data/published-version-claims.json
@@ -33,7 +33,7 @@
             "kind": "pypi-latest",
             "source_of_truth": "public/status.json#/versions",
             "verified_on": "2026-07-28",
-            "evidence": "https://pypi.org/pypi/<package>/json info.version on 2026-07-28: openadapt 1.10.1, openadapt-flow 1.25.1, openadapt-capture 1.2.2, openadapt-desktop 0.14.0.",
+            "evidence": "https://pypi.org/pypi/<package>/json info.version on 2026-07-28: openadapt 1.10.2, openadapt-flow 1.25.1, openadapt-capture 1.2.2, openadapt-desktop 0.14.0.",
             "packages": {
                 "launcher": "openadapt",
                 "flow": "openadapt-flow",
@@ -41,7 +41,7 @@
                 "desktop": "openadapt-desktop"
             },
             "versions": {
-                "launcher": "1.10.1",
+                "launcher": "1.10.2",
                 "flow": "1.25.1",
                 "capture": "1.2.2",
                 "desktop": "0.14.0"

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -78,7 +78,7 @@ control plane is a separate commercial product.
 
 - Engine source: https://github.com/OpenAdaptAI/openadapt-flow
 - Install route: https://github.com/OpenAdaptAI/OpenAdapt and `pip install openadapt`
-- Current published versions: launcher 1.10.1, Flow 1.25.1, capture 1.2.2, desktop 0.14.0
+- Current published versions: launcher 1.10.2, Flow 1.25.1, capture 1.2.2, desktop 0.14.0
 - Product lifecycle: Beta
 
 ---

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -9,7 +9,7 @@ OpenAdapt is for the case where the work is repetitive and consequential, the in
 ## Canonical machine-readable status
 
 - [status.json](https://openadapt.ai/status.json): The single source of truth for product lifecycle, released component versions, per-substrate availability, delivery boundary, and the linked acceptance evidence for each substrate. Public surfaces render their labels from this file. Prefer it over any prose on this site if the two ever disagree.
-- Current published versions: launcher 1.10.1, Flow (compiler/runtime) 1.25.1, capture 1.2.2, desktop 0.14.0. Product lifecycle: Beta.
+- Current published versions: launcher 1.10.2, Flow (compiler/runtime) 1.25.1, capture 1.2.2, desktop 0.14.0. Product lifecycle: Beta.
 
 ## Execution substrates and their evidence boundary
 

--- a/public/status.json
+++ b/public/status.json
@@ -3,7 +3,7 @@
     "generated_at": "2026-07-28",
     "product_lifecycle": "Beta",
     "versions": {
-        "launcher": "1.10.1",
+        "launcher": "1.10.2",
         "flow": "1.25.1",
         "capture": "1.2.2",
         "desktop": "0.14.0"


### PR DESCRIPTION
## What changed

- updates the public status manifest from OpenAdapt Launcher 1.10.1 to 1.10.2
- updates the matching published-version claim and its primary-source evidence

## Why

OpenAdapt Launcher 1.10.2 is published on both PyPI and GitHub Releases. The live public status manifest still reports 1.10.1.

## Validation

- `node --test tests/statusManifest.test.js`
- `node scripts/check_published_version_claims.mjs --offline`
- `npm run check:versions`
- `git diff --check`
