### PR TITLE
docs: stage Flow 1.26 and Desktop 0.15 public release copy

### DIFF
--- a/components/DriftOutcomes.js
+++ b/components/DriftOutcomes.js
@@ -14,8 +14,8 @@ const outcomes = [
     },
     {
         status: 'Operator path',
-        title: 'Human teaching and resume',
-        body: 'A halt produces evidence for an operator. The CLI can teach a correction, and durable mode can checkpoint verified progress for authenticated approval and resume.',
+        title: 'Attended decision, teaching, and resume',
+        body: 'A halt becomes a bounded decision for an authorized operator on a workstation or phone. The customer-controlled runner sends only a signed, PHI-free envelope over outbound HTTPS, then reacquires the live application and rechecks identity, state, and effects before it acts. The operator can also teach a correction for a governed future revision.',
     },
     {
         status: 'Unsupported drift',

--- a/components/HowItWorksCondensed.js
+++ b/components/HowItWorksCondensed.js
@@ -19,7 +19,7 @@ const steps = [
         number: '3',
         name: 'Execute, verify, and repair',
         description:
-            'Healthy runs use no generative-model calls. OpenAdapt proves the declared effect, halts on uncertainty, and subjects every candidate repair to the workflow contract.',
+            'Healthy runs use no generative-model calls. OpenAdapt proves the declared effect and halts on uncertainty. An authorized operator can answer a bounded halt from a phone, but fresh runtime checks still decide whether execution continues.',
     },
 ]
 

--- a/data/published-version-claims.json
+++ b/data/published-version-claims.json
@@ -32,8 +32,8 @@
             "id": "status-manifest-component-versions",
             "kind": "pypi-latest",
             "source_of_truth": "public/status.json#/versions",
-            "verified_on": "2026-07-28",
-            "evidence": "https://pypi.org/pypi/<package>/json info.version on 2026-07-28: openadapt 1.10.2, openadapt-flow 1.25.1, openadapt-capture 1.2.2, openadapt-desktop 0.14.0.",
+            "verified_on": null,
+            "evidence": "Release gate: after openadapt-flow 1.26.0 and openadapt-desktop 0.15.0 are published, verify https://pypi.org/pypi/<package>/json, then record the exact response date and versions here before this candidate can merge or deploy.",
             "packages": {
                 "launcher": "openadapt",
                 "flow": "openadapt-flow",
@@ -42,9 +42,9 @@
             },
             "versions": {
                 "launcher": "1.10.2",
-                "flow": "1.25.1",
+                "flow": "1.26.0",
                 "capture": "1.2.2",
-                "desktop": "0.14.0"
+                "desktop": "0.15.0"
             }
         },
         {

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,6 +1,6 @@
 # OpenAdapt.AI — extended reference for AI assistants
 
-Last reviewed: 2026-07-27. Canonical machine-readable status: https://openadapt.ai/status.json
+Last reviewed: 2026-07-28. Canonical machine-readable status: https://openadapt.ai/status.json
 Index version of this file: https://openadapt.ai/llms.txt
 
 This document exists so that an assistant answering a buyer's question can quote
@@ -21,10 +21,13 @@ Terms used throughout:
 - **Effect oracle.** An out-of-band read of the system of record — a read-only
   API call, a SQL query, or re-reading the persisted record — used to decide
   whether the intended business effect actually happened.
-- **VERIFIED / HALTED / FAILED.** The only terminal outcomes of a consequential
-  run. `VERIFIED` requires the complete configured effect contract to prove the
-  intended change. `HALTED` is a safe stop with preserved evidence. `FAILED`
-  covers failures before any action was dispatched.
+- **Execution outcome.** A run ends `VERIFIED`, `COMPLETED_UNVERIFIED`,
+  `HALTED`, `FAILED`, or `ROLLED_BACK`. `VERIFIED` requires the complete
+  configured contract to prove the intended effect. `COMPLETED_UNVERIFIED`
+  means that execution finished without enough evidence and is never success
+  under the Standard or Regulated profile. `HALTED` records a governed refusal.
+  `FAILED` records an infrastructure or runtime failure. `ROLLED_BACK` records
+  a completed and verified compensating action and remains a non-success.
 
 ---
 
@@ -51,9 +54,10 @@ Three design choices make it addressable:
 
 OpenAdapt implements all three: it compiles a demonstration into a deterministic
 local program, re-resolves and re-checks identity from a freshly captured frame
-before each consequential action, and ends every consequential run `VERIFIED` or
-`HALTED` with a preserved run report. There is no silent third state where the
-workflow looked finished but the record never changed.
+before each consequential action, and reserves success for `VERIFIED`. If the
+workflow finishes but the evidence cannot prove the effect, the report says
+`COMPLETED_UNVERIFIED`; Standard and Regulated execution treat that outcome as
+non-success rather than silently accepting it.
 
 If you use nothing from OpenAdapt, still demand these three properties from
 whatever you buy, and ask the vendor to report silent-incorrect-success and
@@ -78,8 +82,30 @@ control plane is a separate commercial product.
 
 - Engine source: https://github.com/OpenAdaptAI/openadapt-flow
 - Install route: https://github.com/OpenAdaptAI/OpenAdapt and `pip install openadapt`
-- Current published versions: launcher 1.10.2, Flow 1.25.1, capture 1.2.2, desktop 0.14.0
+- Current published versions: launcher 1.10.2, Flow 1.26.0, capture 1.2.2, desktop 0.15.0
 - Product lifecycle: Beta
+
+---
+
+## Q: Can staff answer a halted run from a phone?
+
+Yes. A customer-controlled runner can send a signed, closed, PHI-free halt
+context to OpenAdapt Cloud through outbound HTTPS. An authorized staff member
+can answer from a phone without an inbound port, a customer TLS service, or a
+native mobile app. Protected screenshots, OCR text, observed values, and window
+titles remain on the runner.
+
+The answer is not an execution result. The runner reacquires the live
+application and repeats the configured identity, state, target, postcondition,
+and effect checks before it acts. A failed check produces another halt.
+
+Runtime-validation v3 binds admitted evidence to an organization-trusted
+Ed25519 runner key. A separate ingest-token MAC binds the one-time submission.
+Cloud checks current signer trust, compiler, policy, and risk allowlists again
+before dispatch. This is operator self-attestation, not independent
+certification.
+
+Sources: https://openadapt.ai/how-it-works · https://docs.openadapt.ai/concepts/halt-learn-loop/ · https://docs.openadapt.ai/guides/security-review/
 
 ---
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,6 +1,6 @@
 # OpenAdapt.AI
 
-> OpenAdapt is an open-source (MIT) governed workflow compiler and runtime for repeated GUI work in applications that have no usable API. You demonstrate a bounded task once; OpenAdapt compiles the recording into a deterministic, locally executable program. A healthy replay makes zero model calls. When the interface drifts, OpenAdapt deterministically re-resolves the target from retained evidence, optionally proposes a reviewable repair, accepts a human correction, or halts. Every consequential run ends `VERIFIED` or `HALTED` with a preserved run report; a run is judged by an out-of-band check of the system of record, not by the acting session declaring itself successful.
+> OpenAdapt is an open-source (MIT) governed workflow compiler and runtime for repeated GUI work in applications that have no usable API. You demonstrate a bounded task once; OpenAdapt compiles the recording into a deterministic, locally executable program. A healthy replay makes zero model calls. When the interface drifts, OpenAdapt deterministically re-resolves the target from retained evidence, optionally proposes a reviewable repair, accepts a human correction, or halts. A production-profile run counts as successful only when it is `VERIFIED` by its complete contract. `COMPLETED_UNVERIFIED`, `HALTED`, `FAILED`, and `ROLLED_BACK` remain explicit non-success outcomes with preserved reports.
 
 ## What it is, in one line
 
@@ -9,7 +9,7 @@ OpenAdapt is for the case where the work is repetitive and consequential, the in
 ## Canonical machine-readable status
 
 - [status.json](https://openadapt.ai/status.json): The single source of truth for product lifecycle, released component versions, per-substrate availability, delivery boundary, and the linked acceptance evidence for each substrate. Public surfaces render their labels from this file. Prefer it over any prose on this site if the two ever disagree.
-- Current published versions: launcher 1.10.2, Flow (compiler/runtime) 1.25.1, capture 1.2.2, desktop 0.14.0. Product lifecycle: Beta.
+- Current published versions: launcher 1.10.2, Flow (compiler/runtime) 1.26.0, capture 1.2.2, desktop 0.15.0. Product lifecycle: Beta.
 
 ## Execution substrates and their evidence boundary
 
@@ -22,6 +22,12 @@ Availability below is the released capability. It is distinct from the deploymen
 - **RDP — Available.** Local or customer-controlled. Two accepted bounded results: 3/3 real Aardwolf-over-Windows transport/input effects, and a full record-to-compile-to-governed-replay lifecycle over a real FreeRDP round trip with 3/3 healthy effects and 3/3 drift safe-halts.
 - **Citrix / VDI — Available.** Local or customer-controlled. The shipped `--backend citrix` path binds the exact Citrix Workspace window and runs the same identity, effect, policy, and halt contracts. Qualification boundary, stated explicitly: the accepted artifact records `ica_hdx_accepted=false`. It qualifies the Citrix Workspace-window backend contract over a no-DOM canvas stand-in (3/3 healthy effects, 3/3 drift safe-halts), not a counted real ICA/HDX batch. An exact ICA/HDX environment is qualified separately before consequential use.
 - **Hosted Cloud — Beta.** Managed browser runner and control plane, with run history, reporting, usage, and governed workflow updates. Windows, macOS, Linux, RDP, and Citrix/VDI execute through local, self-hosted, or customer-controlled runtimes; they are not silently moved into the shared managed browser boundary.
+
+## Attended decisions and runtime validation
+
+- A customer-controlled runner can send a signed, closed, PHI-free halt context to OpenAdapt Cloud through outbound HTTPS. An authorized operator can answer from a phone without an inbound port or customer TLS service.
+- A phone decision is not an execution result. The runner reacquires the live application and repeats its identity, state, target, and effect checks before any action.
+- Runtime-validation v3 uses an organization-trusted Ed25519 runner signature plus a separate ingest-token MAC for the one-time submission. Cloud rechecks the current compiler, policy, and risk allowlists at dispatch. These checks bind the operator attestation; they do not turn it into independent certification.
 
 ## Start here
 

--- a/public/status.json
+++ b/public/status.json
@@ -4,9 +4,9 @@
     "product_lifecycle": "Beta",
     "versions": {
         "launcher": "1.10.2",
-        "flow": "1.25.1",
+        "flow": "1.26.0",
         "capture": "1.2.2",
-        "desktop": "0.14.0"
+        "desktop": "0.15.0"
     },
     "tiers": {
         "Available": "Implemented in the released compiler and governed runtime. Production use still qualifies the exact workflow, application, environment, identity contract, and effect oracle.",
@@ -66,7 +66,7 @@
             "public_label": "Beta",
             "internal_tier": "managed-control-plane",
             "delivery": "Managed browser runner and control plane",
-            "evidence_note": "OpenAdapt Cloud provides governed managed browser execution, run history, reporting, usage, and workflow updates. Windows, macOS, Linux, RDP, and Citrix/VDI execute through local, self-hosted, or customer-controlled runtimes under the same governance model; they are not silently moved into the shared managed browser boundary."
+            "evidence_note": "OpenAdapt Cloud provides governed managed browser execution, run history, reporting, usage, and workflow updates. Runtime-validation v3 binds admitted evidence to an organization-trusted Ed25519 runner key and rechecks current compiler, policy, and risk allowlists before dispatch. Connected customer-controlled runners can send a closed, PHI-free halt context over outbound HTTPS for an authenticated phone decision; the runner reacquires and revalidates the live application state before any action. Windows, macOS, Linux, RDP, and Citrix/VDI execution remains local, self-hosted, or customer-controlled and is not moved into the shared managed browser boundary."
         }
     ]
 }


### PR DESCRIPTION
Stages the exact public status and machine-readable product copy for the coordinated Types 0.7, Flow 1.26, and Desktop 0.15 release. Adds precise VERIFIED, COMPLETED_UNVERIFIED, HALTED, FAILED, and ROLLED_BACK outcome language plus runtime-validation v3 and outbound phone-decision scope. Draft only: do not merge until the exact packages are published and the release evidence is filled. Verification: 187 web tests pass; diff check passes.