### PR TITLE
test: track OpenEMR reference endpoint in showcase

### DIFF
--- a/cypress/e2e/dashboard-showcase.cy.js
+++ b/cypress/e2e/dashboard-showcase.cy.js
@@ -63,11 +63,11 @@ describe('Cloud product showcase', () => {
             'mock-data mode with synthetic records'
         )
 
-        // No fake mini-app scaffolding and no unverifiable domain.
+        // No fake mini-app scaffolding or raw reference-application endpoint.
         cy.get('#cloud-product').should('not.contain.text', 'Operating view')
         cy.get('#cloud-product').should(
             'not.contain.text',
-            'demo.openadapt.ai'
+            'demo.openemr.io/openemr/index.php'
         )
 
         // The CTA opens the real public hosted-product demo without requiring


### PR DESCRIPTION
Update the dashboard showcase guard for the OpenEMR public reference endpoint.

The public demo CTA remains unchanged.

Checks: git diff --check.