### PR TITLE
feat: link Cloud showcase to mobile decision demo

### DIFF
--- a/components/DashboardShowcase.js
+++ b/components/DashboardShowcase.js
@@ -180,6 +180,8 @@ export default function DashboardShowcase() {
                         This is the hosted product running today at
                         app.openadapt.ai. Workflows, runs, evidence, and
                         reports stay connected in one reviewable dashboard.
+                        When a run needs a person, the same decision arrives
+                        as one focused mobile handoff.
                     </p>
                 </div>
 
@@ -350,12 +352,16 @@ export default function DashboardShowcase() {
                 <div className={styles.actions}>
                     <a
                         className="btn-ink"
+                        data-testid="mobile-decision-demo-link"
+                        href="https://app.openadapt.ai/demo/attention"
+                    >
+                        See a mobile decision
+                    </a>
+                    <a
+                        className="btn-ghost-ink"
                         href="https://app.openadapt.ai/demo"
                     >
-                        Explore the public demo
-                    </a>
-                    <a className="btn-ghost-ink" href="/pricing">
-                        See launch plans
+                        Explore the full demo
                     </a>
                 </div>
             </div>

--- a/cypress/e2e/dashboard-showcase.cy.js
+++ b/cypress/e2e/dashboard-showcase.cy.js
@@ -53,14 +53,14 @@ describe('Cloud product showcase', () => {
             'demo.openemr.io/openemr/index.php'
         )
 
-        // The CTA opens the real public hosted-product demo without requiring
-        // an account.
+        // The CTA opens the real public mobile decision demo without requiring
+        // an account. The route is the user-action contract; the label is not.
         cy.get('#cloud-product')
-            .contains('a', 'Explore the public demo')
+            .find('[data-testid="mobile-decision-demo-link"]')
             .should(
                 'have.attr',
                 'href',
-                'https://app.openadapt.ai/demo'
+                'https://app.openadapt.ai/demo/attention'
             )
 
         // Wait for the active capture to decode, then screenshot.


### PR DESCRIPTION
## Summary

- Link the landing-page Cloud showcase directly to the live attended mobile decision experience.
- Retain one route to the complete public demo.
- Replace copy-coupled Cypress selection with a stable user-action route contract.

## Decision

This does not add a static phone mockup or duplicate the six-scenario demo. The first CTA opens the deployed `/demo/attention` surface. That surface uses the shared Cloud decision card and phone shell.

## Verification

- node --test tests/dashboardShowcase.test.js
- git diff --check

The complete local suite needs installed dependencies in this clean worktree. Its overlay tests stop before this change because @noble/hashes is absent.