### PR TITLE
fix: link OpenAdapt Execute from the footer

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -286,6 +286,11 @@ export default function Footer({
                                     </FooterLink>
                                 </li>
                                 <li>
+                                    <FooterLink href="/execute">
+                                        OpenAdapt Execute
+                                    </FooterLink>
+                                </li>
+                                <li>
                                     <FooterLink href="/templates">
                                         Templates
                                     </FooterLink>


### PR DESCRIPTION
## What changed

- Added `OpenAdapt Execute` to the shared Product footer links.

## Why

The Execute buyer page is live and linked from the Product navigation, pricing,
partners, sitemap, and landing-page commercial section. The shared footer was
the remaining public discovery gap.

## Impact

Visitors can find Execute from every public page without adding another section
or CTA to the already dense homepage.

## Validation

- `npm test` (183 tests)
- `npx next build`
- `git diff --check`
