### PR TITLE
fix: clarify the workflow-owned entity label

### DIFF
--- a/components/AttendedDecisionPreview.js
+++ b/components/AttendedDecisionPreview.js
@@ -52,7 +52,8 @@ export default function AttendedDecisionPreview() {
                     data-testid="attended-decision-capture"
                 />
                 <figcaption>
-                    Exact public Cloud capture · synthetic OpenEMR data
+                    OpenEMR example · “patient record” is this workflow’s
+                    qualified entity class · synthetic data
                 </figcaption>
             </figure>
             <div className={styles.copy}>


### PR DESCRIPTION
## Summary

- identify the phone capture as the OpenEMR example
- state that `patient record` is the qualified entity class for this workflow
- keep the general landing-page copy domain-neutral

## Verification

- `npm test` (183 passed)
- `npx next build`
- `git diff --check`

No screenshot, fixture, runtime behavior, or data boundary changes.