### PR TITLE
chore: publish current platform versions

### DIFF
--- a/data/published-version-claims.json
+++ b/data/published-version-claims.json
@@ -32,8 +32,8 @@
             "id": "status-manifest-component-versions",
             "kind": "pypi-latest",
             "source_of_truth": "public/status.json#/versions",
-            "verified_on": "2026-07-28",
-            "evidence": "https://pypi.org/pypi/<package>/json info.version on 2026-07-28: openadapt 1.10.2, openadapt-flow 1.25.1, openadapt-capture 1.2.2, openadapt-desktop 0.14.0.",
+            "verified_on": "2026-07-31",
+            "evidence": "https://pypi.org/pypi/<package>/json info.version on 2026-07-31: openadapt 1.10.3, openadapt-flow 1.27.1, openadapt-capture 1.2.2, openadapt-desktop 0.14.0.",
             "packages": {
                 "launcher": "openadapt",
                 "flow": "openadapt-flow",
@@ -41,8 +41,8 @@
                 "desktop": "openadapt-desktop"
             },
             "versions": {
-                "launcher": "1.10.2",
-                "flow": "1.25.1",
+                "launcher": "1.10.3",
+                "flow": "1.27.1",
                 "capture": "1.2.2",
                 "desktop": "0.14.0"
             }
@@ -57,12 +57,12 @@
             "evidence": "openadapt-flow cbec44c2c2f355d5cc04a72ea9267e2d6ea68ac6 declares version = \"0.1.0\" in pyproject.toml and describes as v0.1.0-24-gcbec44c; v0.2.0 (2026-07-11) is the first release tag containing it.",
             "verified_on": "2026-07-27",
             "acknowledged_release_lag": {
-                "as_of_release": "1.25.1",
-                "releases_behind": 70,
-                "minor_releases_behind_first_containing_tag": 23,
-                "acknowledged_on": "2026-07-28",
+                "as_of_release": "1.27.1",
+                "releases_behind": 73,
+                "minor_releases_behind_first_containing_tag": 25,
+                "acknowledged_on": "2026-07-31",
                 "review_by": "2026-10-31",
-                "note": "70 live openadapt-flow releases postdate 0.1.0, and v0.2.0 -- the first release tag containing the pinned commit -- is 23 minor releases behind 1.25.1. That is recorded, labelled on every surface that renders them, and deliberately NOT edited -- these are historical measurements. The lag may not grow past the acknowledged value without a decision, and the acknowledgement expires on review_by so it cannot be renewed by silence. Refreshing means re-running the benchmarks: MockMed is deterministic and CI-reproducible; OpenEMR runs against a shared public demo that resets daily, so its refresh is a field run whose numbers will legitimately differ. Re-acknowledged on 2026-07-28 for v1.25.0 and v1.25.1 (68 -> 70). review_by is deliberately UNCHANGED at 2026-10-31: restating the count is not a decision to keep waiting, and this acknowledgement must still expire on its original date."
+                "note": "73 live openadapt-flow releases postdate 0.1.0, and v0.2.0 -- the first release tag containing the pinned commit -- is 25 minor releases behind 1.27.1. That is recorded, labelled on every surface that renders them, and deliberately NOT edited -- these are historical measurements. The lag may not grow past the acknowledged value without a decision, and the acknowledgement expires on review_by so it cannot be renewed by silence. Refreshing means re-running the benchmarks: MockMed is deterministic and CI-reproducible; OpenEMR runs against a shared public demo that resets daily, so its refresh is a field run whose numbers will legitimately differ. Re-acknowledged on 2026-07-31 for v1.27.1 (70 -> 73). review_by is deliberately UNCHANGED at 2026-10-31: restating the count is not a decision to keep waiting, and this acknowledgement must still expire on its original date."
             },
             "attribution_required": [
                 {

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -78,7 +78,7 @@ control plane is a separate commercial product.
 
 - Engine source: https://github.com/OpenAdaptAI/openadapt-flow
 - Install route: https://github.com/OpenAdaptAI/OpenAdapt and `pip install openadapt`
-- Current published versions: launcher 1.10.2, Flow 1.25.1, capture 1.2.2, desktop 0.14.0
+- Current published versions: launcher 1.10.3, Flow 1.27.1, capture 1.2.2, desktop 0.14.0
 - Product lifecycle: Beta
 
 ---

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -9,7 +9,7 @@ OpenAdapt is for the case where the work is repetitive and consequential, the in
 ## Canonical machine-readable status
 
 - [status.json](https://openadapt.ai/status.json): The single source of truth for product lifecycle, released component versions, per-substrate availability, delivery boundary, and the linked acceptance evidence for each substrate. Public surfaces render their labels from this file. Prefer it over any prose on this site if the two ever disagree.
-- Current published versions: launcher 1.10.2, Flow (compiler/runtime) 1.25.1, capture 1.2.2, desktop 0.14.0. Product lifecycle: Beta.
+- Current published versions: launcher 1.10.3, Flow (compiler/runtime) 1.27.1, capture 1.2.2, desktop 0.14.0. Product lifecycle: Beta.
 
 ## Execution substrates and their evidence boundary
 

--- a/public/status.json
+++ b/public/status.json
@@ -1,10 +1,10 @@
 {
     "$comment": "Canonical machine-readable release, capability, evidence, and deployment status for OpenAdapt. Served at https://openadapt.ai/status.json and consumed by status-aware public surfaces and tests. OpenAdapt is one Beta product across browser, Windows, macOS, Linux, RDP, and Citrix/VDI. Capability availability is distinct from the deployment boundary and from the bounded evidence scope recorded for each substrate.",
-    "generated_at": "2026-07-28",
+    "generated_at": "2026-07-31",
     "product_lifecycle": "Beta",
     "versions": {
-        "launcher": "1.10.2",
-        "flow": "1.25.1",
+        "launcher": "1.10.3",
+        "flow": "1.27.1",
         "capture": "1.2.2",
         "desktop": "0.14.0"
     },


### PR DESCRIPTION
## What changed

- update the public status manifest to Launcher 1.10.3 and Flow 1.27.1
- update the current-version registry and both machine-readable discovery files
- retain the historical benchmark version while updating its measured release lag

## Why

The public status source still named Launcher 1.10.2 and Flow 1.25.1 after newer verified releases reached PyPI. The launcher platform-manifest check detected the drift.

## Verification

- `node scripts/check_published_version_claims.mjs --offline`
- `node scripts/check_published_version_claims.mjs`
- `node --test tests/aiDiscoverability.test.js tests/publishedVersionClaims.test.js tests/statusManifest.test.js` (31 passed)
- `git diff --check`
