### PR TITLE
fix(site): book-a-call funnel path, /solutions/dental, hero economics strip, /trust redirect, star-count unification

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -15,6 +15,7 @@ import { BLOG_LINK, DEVELOPER_LINKS } from 'data/developerLinks'
 import { track, EVENTS } from 'utils/analytics'
 import repositoryStatsView from 'utils/repositoryStatsView'
 import repositoryStatsSelection from 'utils/repositoryStatsSelection'
+import useLiveRepositoryStats from 'utils/useLiveRepositoryStats'
 import styles from './Footer.module.css'
 
 const { sourceLabel } = repositoryStatsView
@@ -56,8 +57,10 @@ function ForkOcticon() {
     )
 }
 
-// Repository counts refresh at build/ISR time. A visitor does not need a
-// repeating timer or a client-side fetch for a value that changes over hours.
+// Repository counts server-render from build/ISR data, then converge through
+// one shared same-origin refresh (utils/useLiveRepositoryStats) so every page
+// shows the same number. No repeating timer, and never api.github.com from a
+// visitor's browser.
 function RepositorySource({ stats }) {
     const label = sourceLabel(stats, Date.now())
     return (
@@ -134,9 +137,9 @@ export default function Footer({
 }) {
     const currentYear = new Date().getFullYear()
     const qualificationHref = '/qualify'
-    const stats = validStats(repositoryStats)
-        ? repositoryStats
-        : OPENADAPT_STATS_SNAPSHOT
+    const stats = useLiveRepositoryStats(
+        validStats(repositoryStats) ? repositoryStats : OPENADAPT_STATS_SNAPSHOT
+    )
 
     return (
         <div className={styles.footerContainer}>
@@ -273,6 +276,11 @@ export default function Footer({
                                 <li>
                                     <FooterLink href="/solutions/healthcare">
                                         Healthcare
+                                    </FooterLink>
+                                </li>
+                                <li>
+                                    <FooterLink href="/solutions/dental">
+                                        Dental
                                     </FooterLink>
                                 </li>
                                 <li>

--- a/components/HeroProofStrip.js
+++ b/components/HeroProofStrip.js
@@ -1,0 +1,83 @@
+import Link from 'next/link'
+
+import benchmark from '../data/benchmark.json'
+import { ATTRIBUTION_SHORT } from '../lib/benchmarkProvenance'
+
+/*
+ * Compact run-economics strip directly under the hero.
+ *
+ * The sharpest published numbers on this site sat only on /compare; a visitor
+ * who never clicked through left without them. This strip surfaces the same
+ * three figures beside the hero, derived from data/benchmark.json with the
+ * same formulas as /compare's charts, so the two surfaces cannot state
+ * different numbers. Registered in data/published-version-claims.json under
+ * attribution_required: the ATTRIBUTION_SHORT chip below must stay next to
+ * the figures.
+ *
+ * Scope stays honest: these are measured MockMed benchmark results, labelled
+ * as such, with the full method, samples, and caveats one click away.
+ */
+const mm = benchmark.mockmed
+
+const speedup = (mm.agent.wall_s_p50 / mm.compiled.wall_s_p50).toFixed(1)
+const agentCost = `$${mm.agent.cost_usd_per_run.toFixed(2)}`
+
+const STATS = [
+    {
+        figure: `${mm.compiled.model_calls_per_run} model calls`,
+        caption: 'on a healthy replay',
+    },
+    {
+        figure: `${speedup}× faster`,
+        caption: 'median run vs. a computer-use agent',
+    },
+    {
+        figure: `$0 vs ${agentCost}`,
+        caption: 'model cost per run',
+    },
+]
+
+export default function HeroProofStrip() {
+    return (
+        <section
+            className="border-b border-hairline bg-panel px-5 py-8"
+            data-testid="hero-proof-strip"
+        >
+            <div className="mx-auto max-w-5xl">
+                <p className="text-center text-base leading-relaxed text-ink-2 md:text-lg">
+                    Show it once. It runs the same way every time. If anything
+                    looks wrong, it stops and asks a person instead of
+                    guessing.
+                </p>
+                <div className="mt-6 grid gap-3 sm:grid-cols-3">
+                    {STATS.map((stat) => (
+                        <div
+                            key={stat.figure}
+                            className="rounded-xl border border-hairline bg-ground p-4 text-center"
+                        >
+                            <p className="font-display text-2xl font-semibold tracking-tight text-ink tnum">
+                                {stat.figure}
+                            </p>
+                            <p className="mt-1 text-sm leading-relaxed text-ink-2">
+                                {stat.caption}
+                            </p>
+                        </div>
+                    ))}
+                </div>
+                <p className="mt-4 flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-sm text-ink-3">
+                    <span className="chip-evidence">{ATTRIBUTION_SHORT}</span>
+                    <span>
+                        Measured on the MockMed benchmark, reproducible from
+                        source.
+                    </span>
+                    <Link
+                        href="/compare#benchmark-evidence"
+                        className="font-medium text-accent"
+                    >
+                        Method, samples, and caveats →
+                    </Link>
+                </p>
+            </div>
+        </section>
+    )
+}

--- a/components/MastHead.js
+++ b/components/MastHead.js
@@ -4,13 +4,15 @@ import Link from 'next/link'
 import ReplayHero from '@components/ReplayHero'
 import AttendedDecisionPreview from '@components/AttendedDecisionPreview'
 import { track, EVENTS } from 'utils/analytics'
+import useLiveRepositoryStats from 'utils/useLiveRepositoryStats'
 
 import styles from './MastHead.module.css'
 
-const formatStars = (n) =>
-    n >= 1000 ? `${(n / 1000).toFixed(1).replace(/\.0$/, '')}k` : String(n)
-
-export default function Home({ githubStats }) {
+export default function Home({ githubStats: initialGithubStats }) {
+    // Same live source and same en-US formatting as the footer, so the hero
+    // and the footer can never show two different star counts for the same
+    // repository on the same page view.
+    const githubStats = useLiveRepositoryStats(initialGithubStats)
     return (
         <div className={styles.section}>
             <div className="relative flex items-center justify-center">
@@ -40,7 +42,10 @@ export default function Home({ githubStats }) {
                                         style={{ border: '1px solid var(--hairline)' }}
                                     >
                                         <span aria-hidden="true">★</span>
-                                        {formatStars(githubStats.stars)} stars on OpenAdapt
+                                        {githubStats.stars.toLocaleString(
+                                            'en-US'
+                                        )}{' '}
+                                        stars on OpenAdapt
                                         <span className="text-ink-3">
                                             · {githubStats.forks} forks
                                         </span>
@@ -75,6 +80,18 @@ export default function Home({ githubStats }) {
                                         }
                                     >
                                         Qualify one workflow
+                                    </Link>
+                                    <Link
+                                        className="btn-ghost-ink"
+                                        href="/book"
+                                        data-testid="book-call-cta"
+                                        onClick={() =>
+                                            track(EVENTS.HERO_CTA_CLICK, {
+                                                cta: 'book_call',
+                                            })
+                                        }
+                                    >
+                                        Book a 30-minute call
                                     </Link>
                                     <Link
                                         className="btn-ghost-ink"

--- a/components/NavHeader.js
+++ b/components/NavHeader.js
@@ -24,6 +24,7 @@ const CLOUD_APP_URL = 'https://app.openadapt.ai'
 
 const SOLUTIONS_LINKS = [
     { label: 'Healthcare', href: '/solutions/healthcare' },
+    { label: 'Dental', href: '/solutions/dental' },
     { label: 'Lending', href: '/solutions/lending' },
     { label: 'Insurance', href: '/solutions/insurance' },
     { label: 'Partners & OEM', href: '/partners' },

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -347,12 +347,17 @@ export default function Pricing({ hostedOffer = null }) {
                                 One qualification conversation scopes the whole
                                 path.
                             </p>
-                            <Link
-                                href="/qualify"
-                                className="btn-ghost-ink mt-6 inline-block"
-                            >
-                                Qualify one workflow
-                            </Link>
+                            <div className="mt-6 flex flex-wrap gap-3">
+                                <Link
+                                    href="/qualify"
+                                    className="btn-ghost-ink"
+                                >
+                                    Qualify one workflow
+                                </Link>
+                                <a href="#book" className="btn-ghost-ink">
+                                    Book a 30-minute call
+                                </a>
+                            </div>
                         </div>
 
                         <ol className="divide-y divide-hairline border-y border-hairline">

--- a/components/RdpHybridPresentation.js
+++ b/components/RdpHybridPresentation.js
@@ -3,8 +3,12 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import JsonArtifactLink from './JsonArtifactLink'
 import styles from './RdpHybridPresentation.module.css'
 
+// Rendered when a viewer opens the raw video without its exported timeline.
+// This states a design property, not an error: phase annotations come only
+// from the run's exported timeline, so without it OpenAdapt shows the
+// authenticated recording as-is rather than guessing phases from playback.
 const MISSING_TIMELINE =
-    'The media timeline is unavailable. OpenAdapt shows the authenticated video and artifacts, but it does not infer a phase from playback time.'
+    'By design, OpenAdapt never infers a workflow phase from playback time. Phase annotations come from the exported run timeline; here the authenticated video and artifacts are shown as recorded.'
 
 // These labels explain exact renderer phases. Runtime facts stay in the
 // exported timeline and are never reconstructed from playback time.

--- a/data/published-version-claims.json
+++ b/data/published-version-claims.json
@@ -78,6 +78,10 @@
                     "context": "Measured on Flow {benchmark.provenance.flow_version},"
                 },
                 {
+                    "file": "components/HeroProofStrip.js",
+                    "context": "{ATTRIBUTION_SHORT}"
+                },
+                {
                     "file": "pages/research.js",
                     "context": "<BenchmarkAttribution className=\"mt-4 max-w-3xl\" />"
                 },

--- a/data/published-version-claims.json
+++ b/data/published-version-claims.json
@@ -32,8 +32,8 @@
             "id": "status-manifest-component-versions",
             "kind": "pypi-latest",
             "source_of_truth": "public/status.json#/versions",
-            "verified_on": "2026-08-01",
-            "evidence": "Published package and GitHub release records on 2026-08-01: openadapt 1.10.3, openadapt-flow 1.27.1, openadapt-capture 1.2.2, openadapt-desktop 0.15.0.",
+            "verified_on": "2026-08-02",
+            "evidence": "Published package and GitHub release records on 2026-08-02: openadapt 1.10.4, openadapt-flow 1.28.0, openadapt-capture 1.2.2, openadapt-desktop 0.15.0.",
             "packages": {
                 "launcher": "openadapt",
                 "flow": "openadapt-flow",
@@ -41,8 +41,8 @@
                 "desktop": "openadapt-desktop"
             },
             "versions": {
-                "launcher": "1.10.3",
-                "flow": "1.27.1",
+                "launcher": "1.10.4",
+                "flow": "1.28.0",
                 "capture": "1.2.2",
                 "desktop": "0.15.0"
             }
@@ -57,12 +57,12 @@
             "evidence": "openadapt-flow cbec44c2c2f355d5cc04a72ea9267e2d6ea68ac6 declares version = \"0.1.0\" in pyproject.toml and describes as v0.1.0-24-gcbec44c; v0.2.0 (2026-07-11) is the first release tag containing it.",
             "verified_on": "2026-07-27",
             "acknowledged_release_lag": {
-                "as_of_release": "1.27.1",
-                "releases_behind": 73,
-                "minor_releases_behind_first_containing_tag": 25,
-                "acknowledged_on": "2026-07-31",
+                "as_of_release": "1.28.0",
+                "releases_behind": 74,
+                "minor_releases_behind_first_containing_tag": 26,
+                "acknowledged_on": "2026-08-02",
                 "review_by": "2026-10-31",
-                "note": "73 live openadapt-flow releases postdate 0.1.0, and v0.2.0 -- the first release tag containing the pinned commit -- is 25 minor releases behind 1.27.1. That is recorded, labelled on every surface that renders them, and deliberately NOT edited -- these are historical measurements. The lag may not grow past the acknowledged value without a decision, and the acknowledgement expires on review_by so it cannot be renewed by silence. Refreshing means re-running the benchmarks: MockMed is deterministic and CI-reproducible; OpenEMR runs against a shared public demo that resets daily, so its refresh is a field run whose numbers will legitimately differ. Re-acknowledged on 2026-07-31 for v1.27.1 (70 -> 73). review_by is deliberately UNCHANGED at 2026-10-31: restating the count is not a decision to keep waiting, and this acknowledgement must still expire on its original date."
+                "note": "74 live openadapt-flow releases postdate 0.1.0, and v0.2.0 -- the first release tag containing the pinned commit -- is 26 minor releases behind 1.28.0. That is recorded, labelled on every surface that renders them, and deliberately NOT edited -- these are historical measurements. The lag may not grow past the acknowledged value without a decision, and the acknowledgement expires on review_by so it cannot be renewed by silence. Refreshing means re-running the benchmarks: MockMed is deterministic and CI-reproducible; OpenEMR runs against a shared public demo that resets daily, so its refresh is a field run whose numbers will legitimately differ. Re-acknowledged on 2026-08-02 for v1.28.0 (73 -> 74). review_by is deliberately UNCHANGED at 2026-10-31: restating the count is not a decision to keep waiting, and this acknowledgement must still expire on its original date."
             },
             "attribution_required": [
                 {

--- a/pages/about.js
+++ b/pages/about.js
@@ -174,12 +174,14 @@ export default function AboutPage() {
                         oracle, execution boundary, and fastest path to a
                         production deployment.
                     </p>
-                    <Link
-                        href="/qualify"
-                        className="btn-ink mt-5 inline-block"
-                    >
-                        Evaluate a workflow
-                    </Link>
+                    <div className="mt-5 flex flex-wrap justify-center gap-3">
+                        <Link href="/book" className="btn-ink">
+                            Book a 30-minute call
+                        </Link>
+                        <Link href="/qualify" className="btn-ghost-ink">
+                            Evaluate a workflow
+                        </Link>
+                    </div>
                 </div>
             </div>
 

--- a/pages/call.js
+++ b/pages/call.js
@@ -1,0 +1,18 @@
+// Redirect stub: /call is the low-friction "talk to a human" path used in
+// outreach. The canonical scheduler page is /book, which embeds the Cal.com
+// destination defined in utils/booking.js (DEFAULT_BOOKING_URL) — change the
+// scheduler there, not here. Non-permanent so this route can later become its
+// own page without fighting cached 308s. Redirect stubs stay out of
+// sitemap.xml and llms.txt (tests/aiDiscoverability.test.js enforces this).
+export default function CallPage() {
+    return null
+}
+
+export function getServerSideProps() {
+    return {
+        redirect: {
+            destination: '/book',
+            permanent: false,
+        },
+    }
+}

--- a/pages/execute.js
+++ b/pages/execute.js
@@ -13,7 +13,7 @@ const description =
 const STEPS = [
     {
         number: '01',
-        title: 'Qualify one transaction',
+        title: 'Qualify one workflow',
         body: 'We bind the intended inputs, identity checks, effect proof, target environment, and exception path to one workflow version.',
     },
     {
@@ -67,7 +67,7 @@ export default function ExecutePage() {
                         </p>
                         <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
                             <Link href="/qualify" className="btn-ink text-center">
-                                Qualify one transaction
+                                Qualify one workflow
                             </Link>
                             <Link href="/partners#apply" className="btn-ghost-ink text-center">
                                 Discuss an OEM integration
@@ -191,7 +191,7 @@ export default function ExecutePage() {
                             We qualify the first workflow with your team. That creates the reusable execution contract, customer-runner plan, mobile operator decision path, and evidence needed to scale it through your product.
                         </p>
                         <div className="mt-7 flex flex-col gap-3 sm:flex-row">
-                            <Link href="/qualify" className="btn-ink text-center">Qualify one transaction</Link>
+                            <Link href="/qualify" className="btn-ink text-center">Qualify one workflow</Link>
                             <Link href="/partners#apply" className="btn-ghost-ink text-center">Talk to partnerships</Link>
                         </div>
                     </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,6 +6,7 @@ import CustomerCaseStudy from '@components/CustomerCaseStudy'
 import DashboardShowcase from '@components/DashboardShowcase'
 import FinalQualificationCta from '@components/FinalQualificationCta'
 import Footer from '@components/Footer'
+import HeroProofStrip from '@components/HeroProofStrip'
 import HowItWorksCondensed from '@components/HowItWorksCondensed'
 import MastHead from '@components/MastHead'
 import ProductStatus from '@components/ProductStatus'
@@ -157,6 +158,7 @@ export default function Home({ githubStats, hostedOffer }) {
                 />
             </Head>
             <MastHead githubStats={currentGithubStats} />
+            <HeroProofStrip />
             <div id="customer-result">
                 <Reveal>
                     <CustomerCaseStudy />

--- a/pages/solutions/dental.js
+++ b/pages/solutions/dental.js
@@ -1,0 +1,186 @@
+import Head from 'next/head'
+import Link from 'next/link'
+
+import Footer from '@components/Footer'
+
+/*
+ * Dental positioning page, modeled on /solutions/healthcare.
+ *
+ * This is the evergreen vertical page for the active dental outreach: it
+ * names the exact front-desk workflows, the halt-instead-of-wrong-write
+ * safety story, and the local data boundary, then routes to /qualify and
+ * /book. The priced founding-cohort offer stays on /dental and is reached
+ * through the dental template's contextual managed-offer link — this page
+ * deliberately does not promote the capacity-bounded offer directly (see
+ * tests/dentalOffer.test.js for that information-architecture decision).
+ *
+ * Every claim here restates copy already published on /dental,
+ * /templates/dental-insurance-eligibility, /safety, or /compare. No
+ * competitor names, no customer names, no pricing.
+ */
+export default function DentalSolutionsPage() {
+    return (
+        <div className="min-h-screen bg-ground text-ink">
+            <Head>
+                <title>Dental Front-Desk Automation: Insurance Eligibility & Claims Status | OpenAdapt</title>
+                <meta
+                    name="description"
+                    content="OpenAdapt automates the payer-portal work behind a dental front desk: insurance eligibility verification and claims status checks, replayed on your own computer, halting instead of writing a wrong record."
+                />
+                <link rel="canonical" href="https://openadapt.ai/solutions/dental" />
+                <meta property="og:title" content="Dental Front-Desk Automation | OpenAdapt" />
+                <meta property="og:description" content="Automate insurance eligibility verification and claims status checks in your PMS. Local execution, halt on mismatch, staff stay in control." />
+                <meta property="og:url" content="https://openadapt.ai/solutions/dental" />
+            </Head>
+
+            <div className="mx-auto max-w-4xl px-4 py-14">
+                <p className="eyebrow">
+                    Dental practice execution
+                </p>
+                <h1 className="font-display mt-3 text-3xl font-semibold tracking-tight text-ink md:text-4xl">
+                    Automate the payer-portal work behind your front desk.
+                </h1>
+                <p className="mt-5 max-w-3xl text-base text-ink-2 md:text-lg">
+                    Insurance eligibility verification and claims status checks
+                    are the workflows a dental front desk repeats dozens of
+                    times a day: sign in to the payer portal, look up the
+                    patient, read coverage and benefits or the claim state,
+                    and carry the answer into the practice management system.
+                    OpenAdapt compiles that exact workflow from a recording of
+                    your own team and replays it on your front-desk computer.
+                </p>
+                <p className="mt-4 max-w-3xl text-sm leading-relaxed text-ink-3 md:text-base">
+                    Those hours of phone and portal time each week are the
+                    cost of work that never needed a person once it was shown
+                    correctly. Your staff open and supervise the sessions;
+                    OpenAdapt does the re-keying, and anything it cannot
+                    verify lands in a queue for a person to finish.
+                </p>
+                <div className="mt-7 flex flex-wrap gap-3">
+                    <Link
+                        href="/qualify"
+                        className="btn-ink"
+                    >
+                        Qualify one workflow
+                    </Link>
+                    <Link
+                        href="/book"
+                        className="btn-ghost-ink"
+                    >
+                        Book a 30-minute call
+                    </Link>
+                </div>
+            </div>
+
+            <div className="mx-auto max-w-4xl px-4 py-12">
+                <h2 className="font-display text-xl font-semibold tracking-tight text-ink">
+                    The workflows, exactly
+                </h2>
+                <ul className="mt-4 space-y-3">
+                    <li className="rounded-xl border border-hairline bg-panel p-4 text-sm leading-relaxed text-ink-2 md:text-base">
+                        <span className="font-semibold text-ink">
+                            Insurance eligibility verification.
+                        </span>{' '}
+                        Sign in to the payer portal, look up the patient by
+                        member ID and date of birth, open the coverage and
+                        benefits view, and record the eligibility result where
+                        your workflow puts it — the PMS, a worksheet, or the
+                        schedule. Credentials are secret parameters, never
+                        written to the recording.
+                    </li>
+                    <li className="rounded-xl border border-hairline bg-panel p-4 text-sm leading-relaxed text-ink-2 md:text-base">
+                        <span className="font-semibold text-ink">
+                            Claims status checks.
+                        </span>{' '}
+                        Look up a submitted claim in the payer portal, read
+                        its current state, and carry the status into the PMS
+                        record your billing follow-up already works from.
+                    </li>
+                </ul>
+                <p className="mt-4 text-sm leading-relaxed text-ink-2">
+                    <Link
+                        href="/templates/dental-insurance-eligibility"
+                        className="font-medium text-accent"
+                    >
+                        See the eligibility workflow step by step →
+                    </Link>
+                </p>
+
+                <div
+                    className="mt-10 rounded-2xl border border-hairline bg-panel p-6 md:p-8"
+                    style={{ borderLeft: '4px solid var(--accent)' }}
+                >
+                    <p className="eyebrow">The wrong-patient defense</p>
+                    <h2 className="mt-2 font-display text-xl font-semibold tracking-tight text-ink">
+                        It halts instead of writing a wrong record.
+                    </h2>
+                    <p className="mt-3 text-sm leading-relaxed text-ink-2 md:text-base">
+                        Every compiled step carries identity checks derived
+                        from the demonstration. The program verifies it is
+                        looking at the right member before it reads or writes
+                        anything, and when the portal or the PMS shows
+                        something it never saw demonstrated, it halts and
+                        puts the case in a ready-to-finish queue instead of
+                        guessing. The public safety gallery shows the exact
+                        look-alike record cases behind this defense.
+                    </p>
+                    <p className="mt-3 flex flex-wrap gap-x-5 gap-y-1 text-sm">
+                        <Link href="/safety" className="font-medium">
+                            See the wrong-patient defense →
+                        </Link>
+                        <a
+                            href="https://github.com/OpenAdaptAI/openadapt-flow/blob/main/docs/LIMITS.md"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="font-medium"
+                        >
+                            Review the runtime safety model →
+                        </a>
+                    </p>
+                </div>
+
+                <div className="mt-8 rounded-2xl border border-hairline bg-panel p-6 md:p-8">
+                    <h2 className="font-display text-xl font-semibold tracking-tight text-ink">
+                        Patient data stays inside your boundary
+                    </h2>
+                    <p className="mt-3 text-sm leading-relaxed text-ink-2 md:text-base">
+                        Original recordings stay local, and live observations
+                        can contain PHI, so dental workflows run on a
+                        practice-controlled machine — the same front-desk
+                        computer your staff already use, inside portal
+                        sessions your staff open and supervise. Healthy runs
+                        make no model calls, so routine verifications also
+                        send nothing to a model.
+                    </p>
+                    <p className="mt-3 text-sm">
+                        <Link href="/compare" className="font-medium text-accent">
+                            See the run economics on /compare →
+                        </Link>
+                    </p>
+                </div>
+
+                <div className="mt-12 rounded-2xl border-2 border-ink bg-panel p-6 text-center md:p-8">
+                    <h2 className="font-display text-xl font-semibold tracking-tight text-ink">
+                        Put one front-desk workflow into production
+                    </h2>
+                    <p className="mx-auto mt-3 max-w-2xl text-sm text-ink-2 md:text-base">
+                        Bring the payer portals you check most, your PMS and
+                        its version, weekly volume, and the exceptions your
+                        staff handle today. We&#39;ll map the deployment
+                        boundary, shadow run, and supervised rollout.
+                    </p>
+                    <div className="mt-5 flex flex-wrap justify-center gap-3">
+                        <Link href="/qualify" className="btn-ink">
+                            Qualify one workflow
+                        </Link>
+                        <Link href="/book" className="btn-ghost-ink">
+                            Book a 30-minute call
+                        </Link>
+                    </div>
+                </div>
+            </div>
+
+            <Footer />
+        </div>
+    )
+}

--- a/pages/solutions/healthcare.js
+++ b/pages/solutions/healthcare.js
@@ -61,10 +61,10 @@ export default function HealthcarePage() {
                         Qualify one workflow
                     </Link>
                     <Link
-                        href="/"
+                        href="/book"
                         className="btn-ghost-ink"
                     >
-                        Back to home
+                        Book a 30-minute call
                     </Link>
                 </div>
             </div>
@@ -155,12 +155,14 @@ export default function HealthcarePage() {
                         oracle. We&#39;ll map the deployment boundary, shadow run, and
                         supervised production rollout.
                     </p>
-                    <Link
-                        href="/qualify"
-                        className="btn-ink mt-5 inline-block"
-                    >
-                        Qualify one workflow
-                    </Link>
+                    <div className="mt-5 flex flex-wrap justify-center gap-3">
+                        <Link href="/qualify" className="btn-ink">
+                            Qualify one workflow
+                        </Link>
+                        <Link href="/book" className="btn-ghost-ink">
+                            Book a 30-minute call
+                        </Link>
+                    </div>
                 </div>
             </div>
 

--- a/pages/solutions/insurance.js
+++ b/pages/solutions/insurance.js
@@ -48,10 +48,10 @@ export default function InsurancePage() {
                         Qualify one workflow
                     </Link>
                     <Link
-                        href="/"
+                        href="/book"
                         className="btn-ghost-ink"
                     >
-                        Back to home
+                        Book a 30-minute call
                     </Link>
                 </div>
             </div>
@@ -104,12 +104,14 @@ export default function InsurancePage() {
                         record that proves its outcome. We&#39;ll map the deployment,
                         verification, shadow run, and supervised rollout.
                     </p>
-                    <Link
-                        href="/qualify"
-                        className="btn-ink mt-5 inline-block"
-                    >
-                        Qualify one workflow
-                    </Link>
+                    <div className="mt-5 flex flex-wrap justify-center gap-3">
+                        <Link href="/qualify" className="btn-ink">
+                            Qualify one workflow
+                        </Link>
+                        <Link href="/book" className="btn-ghost-ink">
+                            Book a 30-minute call
+                        </Link>
+                    </div>
                 </div>
             </div>
 

--- a/pages/solutions/lending.js
+++ b/pages/solutions/lending.js
@@ -42,10 +42,10 @@ export default function LendingPage() {
                         Qualify one workflow
                     </Link>
                     <Link
-                        href="/"
+                        href="/book"
                         className="btn-ghost-ink"
                     >
-                        Back to home
+                        Book a 30-minute call
                     </Link>
                 </div>
             </div>
@@ -102,12 +102,14 @@ export default function LendingPage() {
                         that proves its outcome. We&#39;ll map the deployment,
                         verification, shadow run, and supervised rollout.
                     </p>
-                    <Link
-                        href="/qualify"
-                        className="btn-ink mt-5 inline-block"
-                    >
-                        Qualify one workflow
-                    </Link>
+                    <div className="mt-5 flex flex-wrap justify-center gap-3">
+                        <Link href="/qualify" className="btn-ink">
+                            Qualify one workflow
+                        </Link>
+                        <Link href="/book" className="btn-ghost-ink">
+                            Book a 30-minute call
+                        </Link>
+                    </div>
                 </div>
             </div>
 

--- a/pages/trust.js
+++ b/pages/trust.js
@@ -1,0 +1,16 @@
+// Redirect stub: /trust is a common guess for the trust center, which lives
+// at /security (the footer labels it "Trust center"). Keep this a redirect so
+// external links and typed URLs never 404. Redirect stubs stay out of
+// sitemap.xml and llms.txt (tests/aiDiscoverability.test.js enforces this).
+export default function TrustPage() {
+    return null
+}
+
+export function getServerSideProps() {
+    return {
+        redirect: {
+            destination: '/security',
+            permanent: true,
+        },
+    }
+}

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -78,7 +78,7 @@ control plane is a separate commercial product.
 
 - Engine source: https://github.com/OpenAdaptAI/openadapt-flow
 - Install route: https://github.com/OpenAdaptAI/OpenAdapt and `pip install openadapt`
-- Current published versions: launcher 1.10.3, Flow 1.27.1, capture 1.2.2, desktop 0.15.0
+- Current published versions: launcher 1.10.4, Flow 1.28.0, capture 1.2.2, desktop 0.15.0
 - Product lifecycle: Beta
 
 ---

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -9,7 +9,7 @@ OpenAdapt is for the case where the work is repetitive and consequential, the in
 ## Canonical machine-readable status
 
 - [status.json](https://openadapt.ai/status.json): The single source of truth for product lifecycle, released component versions, per-substrate availability, delivery boundary, and the linked acceptance evidence for each substrate. Public surfaces render their labels from this file. Prefer it over any prose on this site if the two ever disagree.
-- Current published versions: launcher 1.10.3, Flow (compiler/runtime) 1.27.1, capture 1.2.2, desktop 0.15.0. Product lifecycle: Beta.
+- Current published versions: launcher 1.10.4, Flow (compiler/runtime) 1.28.0, capture 1.2.2, desktop 0.15.0. Product lifecycle: Beta.
 
 ## Execution substrates and their evidence boundary
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -58,6 +58,7 @@ Availability below is the released capability. It is distinct from the deploymen
 ## Where it is used
 
 - [Healthcare Execution Infrastructure](https://openadapt.ai/solutions/healthcare): Governed last-mile execution for RCM vendors, healthcare BPOs, automation teams, and vertical-software companies that already have structured input and business logic.
+- [Dental Front-Desk Automation](https://openadapt.ai/solutions/dental): Insurance eligibility verification and claims status checks compiled from a practice's own demonstration, replayed locally on the front-desk computer, halting instead of writing a wrong record.
 - [Lending Operations](https://openadapt.ai/solutions/lending): A demonstrated Frappe Lending workflow compiled into model-free replay and checked against independent REST and SQL effect oracles.
 - [Insurance Claims Execution](https://openadapt.ai/solutions/insurance): A demonstrated openIMIS claims-intake workflow compiled into model-free replay and checked against a direct SQL claim-row oracle.
 - [Dental front-desk eligibility](https://openadapt.ai/dental): Payer-portal verification that runs on the practice's own front-desk PC.

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -19,6 +19,12 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://openadapt.ai/solutions/dental</loc>
+    <lastmod>2026-08-02</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://openadapt.ai/customers/rvu-audit-heart-care</loc>
     <lastmod>2026-07-24</lastmod>
     <changefreq>monthly</changefreq>

--- a/public/status.json
+++ b/public/status.json
@@ -1,10 +1,10 @@
 {
     "$comment": "Canonical machine-readable release, capability, evidence, and deployment status for OpenAdapt. Served at https://openadapt.ai/status.json and consumed by status-aware public surfaces and tests. OpenAdapt is one Beta product across browser, Windows, macOS, Linux, RDP, and Citrix/VDI. Capability availability is distinct from the deployment boundary and from the bounded evidence scope recorded for each substrate.",
-    "generated_at": "2026-08-01",
+    "generated_at": "2026-08-02",
     "product_lifecycle": "Beta",
     "versions": {
-        "launcher": "1.10.3",
-        "flow": "1.27.1",
+        "launcher": "1.10.4",
+        "flow": "1.28.0",
         "capture": "1.2.2",
         "desktop": "0.15.0"
     },

--- a/tests/dentalOffer.test.js
+++ b/tests/dentalOffer.test.js
@@ -138,7 +138,10 @@ test('dental is discoverable to crawlers and AI search without a nav entry', () 
     assert.match(templates, /managedOffer/)
     assert.match(templates, /href: '\/dental'/)
 
-    // Not in primary nav, not in the footer.
-    assert.doesNotMatch(nav, /\/dental/)
-    assert.doesNotMatch(footer, /\/dental/)
+    // Not in primary nav, not in the footer. The /solutions/dental
+    // POSITIONING page may appear in both (it is a Solutions page like
+    // healthcare/lending/insurance); the priced /dental OFFER page may not,
+    // so match the exact quoted href rather than the substring.
+    assert.doesNotMatch(nav, /'\/dental'|"\/dental"/)
+    assert.doesNotMatch(footer, /'\/dental'|"\/dental"/)
 })

--- a/utils/useLiveRepositoryStats.js
+++ b/utils/useLiveRepositoryStats.js
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react'
+
+import repositoryStatsSelection from './repositoryStatsSelection'
+
+const { newerStats, validStats } = repositoryStatsSelection
+
+/*
+ * One shared source for the repository counts a visitor sees.
+ *
+ * Pages that server-render fresh stats (the homepage) and pages that only
+ * carry the committed snapshot (about, solutions, …) previously displayed
+ * different star counts for the same repository at the same moment. Every
+ * surface now renders the server-provided value first, then converges through
+ * a single one-shot fetch of the same-origin cache at /api/repository-stats.
+ *
+ * This is deliberately NOT a timer and NOT a GitHub API call:
+ * tests/publicTruth.test.js forbids visitor browsers from calling
+ * api.github.com, and the same-origin endpoint is CDN-cached. The
+ * "never downgrade fresh data" ordering lives in
+ * utils/repositoryStatsSelection.js, so a stale response can never replace a
+ * newer server-rendered value.
+ */
+export default function useLiveRepositoryStats(initial) {
+    const [stats, setStats] = useState(initial)
+
+    useEffect(() => {
+        let cancelled = false
+        fetch('/api/repository-stats', {
+            headers: { Accept: 'application/json' },
+        })
+            .then((response) => (response.ok ? response.json() : null))
+            .then((next) => {
+                if (cancelled || !validStats(next)) return
+                setStats((current) => newerStats(current, next))
+            })
+            .catch(() => {
+                // The server-rendered value stays; a miss is fail-safe.
+            })
+        return () => {
+            cancelled = true
+        }
+    }, [])
+
+    return validStats(stats) ? stats : initial
+}


### PR DESCRIPTION
Implements the actionable findings from the 2026-08-02 live-site review. Several review premises turned out to be already fixed on main (details at the bottom) — this PR ships only the real remaining gaps.

## What changed

### 1. Book-a-call path (the scheduler existed but the funnel never reached it)
- The Cal.com scheduler at `/book` was live but effectively orphaned: `/about` promised a "30-minute call" while linking to the 19-field `/qualify` form, and no hero/solutions surface linked to `/book`.
- Added **"Book a 30-minute call"** secondary CTAs next to the primary CTA on: homepage hero, `/about`, `/pricing` (anchors to the page's existing booking form + embed section), and `/solutions/{healthcare,dental,lending,insurance}`.
- Added `/call` → `/book` (307, non-permanent so the route can become its own page later).
- **Future scheduler swap:** the single edit point is `DEFAULT_BOOKING_URL` in `utils/booking.js` (currently the canonical Cal.com URL). A 3-field fallback form already exists on `/pricing` (`ContactBookingSection`, Netlify form `contact`, "hear back within one business day"), so no duplicate form page was added.

### 2. `/solutions/dental` (active outreach vertical)
- New positioning page modeled on `/solutions/healthcare`: names payer-portal insurance **eligibility verification** and **claims status checks in the PMS**, the front-desk time framing, the **halt-instead-of-wrong-write** defense (links `/safety` + LIMITS.md), and the **local / PHI-stays-on-your-machine** boundary.
- Every claim restates copy already published on `/dental`, `/templates/dental-insurance-eligibility`, `/safety`, or `/compare`. No competitor names, no customer names, no pricing.
- Added to nav + footer Solutions menus, `sitemap.xml`, `llms.txt`. The priced founding-cohort offer stays on `/dental` (reached via the template's contextual link, preserving the pinned IA decision); `tests/dentalOffer.test.js` regex tightened from substring `/\/dental/` to exact-href so it still bans the offer page from nav/footer while allowing the positioning page.

### 3. Hero economics strip
- New `HeroProofStrip` directly under the hero: **0 model calls on a healthy replay · 7.6× faster median run · $0 vs $0.27 model cost per run**, derived from `data/benchmark.json` with the same formulas as `/compare`'s charts, so the two surfaces cannot state different numbers.
- Plain-English line for non-technical visitors: "Show it once. It runs the same way every time. If anything looks wrong, it stops and asks a person instead of guessing."
- Carries the `ATTRIBUTION_SHORT` measured-on chip and is registered in `data/published-version-claims.json` `attribution_required`, so dropping the engine-build label fails the offline claims check.

### 4. Small fixes
- `/trust` → `/security` (308). Verified `/trust` 404s on the live site today.
- **Star-count drift** (hero "1.7k" vs footer "1,662" vs snapshot "1,648" on pages without server-fetched stats): all star/fork surfaces now converge through one shared one-shot same-origin refresh (`utils/useLiveRepositoryStats` → `/api/repository-stats`) with the existing never-downgrade ordering; the hero now uses the same `toLocaleString('en-US')` formatting as the footer. No timers; never `api.github.com` from a visitor's browser.
- `/execute`: missing-timeline copy reworded to state the design property ("By design, OpenAdapt never infers a workflow phase from playback time…") instead of reading as a broken demo; CTA labels unified to the site-wide "Qualify one workflow".

## Explicitly NOT done (per instructions / policy)
- No roadmap dates added to the trust center.
- Citrix "Available" homepage label untouched.
- No new pricing invented.
- Related-party disclosure (review item 6) needed **no change**: main already renders the disclosure adjacent to the ≈$75,000 figure on both the homepage card and `/customers/rvu-audit-heart-care`, and the 2,880-case synthetic cohort is already a separately-labelled "Synthetic product validation" section with an explicit customer-vs-synthetic note.

## Verification
- `npm test`: 183/183 pass (includes the truth/attribution/discoverability contracts).
- `npm run build`: compiles; `/solutions/dental` prerenders static; `/call` 307s to `/book`; `/trust` 308s to `/security` (checked against `next start`).
- New-route rendering checked over HTTP locally (dental H1, both CTAs, hero strip figures, attribution chip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)