### PR TITLE
chore: refresh status manifest for flow 1.29.0 and launcher 1.11.0

### DIFF
--- a/data/published-version-claims.json
+++ b/data/published-version-claims.json
@@ -33,7 +33,7 @@
             "kind": "pypi-latest",
             "source_of_truth": "public/status.json#/versions",
             "verified_on": "2026-08-02",
-            "evidence": "Published package and GitHub release records on 2026-08-02: openadapt 1.10.4, openadapt-flow 1.28.0, openadapt-capture 1.2.2, openadapt-desktop 0.15.0.",
+            "evidence": "Published package and GitHub release records on 2026-08-02: openadapt 1.11.0, openadapt-flow 1.29.0, openadapt-capture 1.2.2, openadapt-desktop 0.15.0.",
             "packages": {
                 "launcher": "openadapt",
                 "flow": "openadapt-flow",
@@ -41,8 +41,8 @@
                 "desktop": "openadapt-desktop"
             },
             "versions": {
-                "launcher": "1.10.4",
-                "flow": "1.28.0",
+                "launcher": "1.11.0",
+                "flow": "1.29.0",
                 "capture": "1.2.2",
                 "desktop": "0.15.0"
             }
@@ -57,12 +57,12 @@
             "evidence": "openadapt-flow cbec44c2c2f355d5cc04a72ea9267e2d6ea68ac6 declares version = \"0.1.0\" in pyproject.toml and describes as v0.1.0-24-gcbec44c; v0.2.0 (2026-07-11) is the first release tag containing it.",
             "verified_on": "2026-07-27",
             "acknowledged_release_lag": {
-                "as_of_release": "1.28.0",
-                "releases_behind": 74,
-                "minor_releases_behind_first_containing_tag": 26,
+                "as_of_release": "1.29.0",
+                "releases_behind": 75,
+                "minor_releases_behind_first_containing_tag": 27,
                 "acknowledged_on": "2026-08-02",
                 "review_by": "2026-10-31",
-                "note": "74 live openadapt-flow releases postdate 0.1.0, and v0.2.0 -- the first release tag containing the pinned commit -- is 26 minor releases behind 1.28.0. That is recorded, labelled on every surface that renders them, and deliberately NOT edited -- these are historical measurements. The lag may not grow past the acknowledged value without a decision, and the acknowledgement expires on review_by so it cannot be renewed by silence. Refreshing means re-running the benchmarks: MockMed is deterministic and CI-reproducible; OpenEMR runs against a shared public demo that resets daily, so its refresh is a field run whose numbers will legitimately differ. Re-acknowledged on 2026-08-02 for v1.28.0 (73 -> 74). review_by is deliberately UNCHANGED at 2026-10-31: restating the count is not a decision to keep waiting, and this acknowledgement must still expire on its original date."
+                "note": "75 live openadapt-flow releases postdate 0.1.0, and v0.2.0 -- the first release tag containing the pinned commit -- is 27 minor releases behind 1.29.0. That is recorded, labelled on every surface that renders them, and deliberately NOT edited -- these are historical measurements. The lag may not grow past the acknowledged value without a decision, and the acknowledgement expires on review_by so it cannot be renewed by silence. Refreshing means re-running the benchmarks: MockMed is deterministic and CI-reproducible; OpenEMR runs against a shared public demo that resets daily, so its refresh is a field run whose numbers will legitimately differ. Re-acknowledged on 2026-08-02 for v1.29.0 (74 -> 75). review_by is deliberately UNCHANGED at 2026-10-31: restating the count is not a decision to keep waiting, and this acknowledgement must still expire on its original date."
             },
             "attribution_required": [
                 {

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -78,7 +78,7 @@ control plane is a separate commercial product.
 
 - Engine source: https://github.com/OpenAdaptAI/openadapt-flow
 - Install route: https://github.com/OpenAdaptAI/OpenAdapt and `pip install openadapt`
-- Current published versions: launcher 1.10.4, Flow 1.28.0, capture 1.2.2, desktop 0.15.0
+- Current published versions: launcher 1.11.0, Flow 1.29.0, capture 1.2.2, desktop 0.15.0
 - Product lifecycle: Beta
 
 ---

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -9,7 +9,7 @@ OpenAdapt is for the case where the work is repetitive and consequential, the in
 ## Canonical machine-readable status
 
 - [status.json](https://openadapt.ai/status.json): The single source of truth for product lifecycle, released component versions, per-substrate availability, delivery boundary, and the linked acceptance evidence for each substrate. Public surfaces render their labels from this file. Prefer it over any prose on this site if the two ever disagree.
-- Current published versions: launcher 1.10.4, Flow (compiler/runtime) 1.28.0, capture 1.2.2, desktop 0.15.0. Product lifecycle: Beta.
+- Current published versions: launcher 1.11.0, Flow (compiler/runtime) 1.29.0, capture 1.2.2, desktop 0.15.0. Product lifecycle: Beta.
 
 ## Execution substrates and their evidence boundary
 

--- a/public/status.json
+++ b/public/status.json
@@ -3,8 +3,8 @@
     "generated_at": "2026-08-02",
     "product_lifecycle": "Beta",
     "versions": {
-        "launcher": "1.10.4",
-        "flow": "1.28.0",
+        "launcher": "1.11.0",
+        "flow": "1.29.0",
         "capture": "1.2.2",
         "desktop": "0.15.0"
     },


### PR DESCRIPTION
Routine manifest refresh after today's releases (flow 1.29.0 with `tutorial --break-it`, launcher 1.11.0 with `quickstart --break-it`). Updates status.json, llms.txt/llms-full.txt current-version lines, and the version-claims registry (headline-benchmark lag re-acknowledged 74 -> 75 following the recorded precedent; review_by unchanged at 2026-10-31). Keeps the scheduled Published-version-claims check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)