### PR TITLE
fix(deps): bump next to ^15.5.21 and override sharp to ^0.35.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "classnames": "^2.5.1",
                 "daisyui": "^4.7.2",
                 "framer-motion": "^11.0.8",
-                "next": "^15.5.16",
+                "next": "^15.5.21",
                 "p5": "^1.9.1",
                 "posthog-js": "^1.399.2",
                 "react": "^18.2.0",
@@ -104,9 +104,9 @@
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.11.2",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-            "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+            "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -422,9 +422,9 @@
             }
         },
         "node_modules/@img/sharp-darwin-arm64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-            "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+            "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
             "cpu": [
                 "arm64"
             ],
@@ -434,19 +434,19 @@
                 "darwin"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-darwin-arm64": "1.2.4"
+                "@img/sharp-libvips-darwin-arm64": "1.3.2"
             }
         },
         "node_modules/@img/sharp-darwin-x64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-            "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+            "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
             "cpu": [
                 "x64"
             ],
@@ -456,19 +456,38 @@
                 "darwin"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-darwin-x64": "1.2.4"
+                "@img/sharp-libvips-darwin-x64": "1.3.2"
+            }
+        },
+        "node_modules/@img/sharp-freebsd-wasm32": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+            "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "dependencies": {
+                "@img/sharp-wasm32": "0.35.3"
+            },
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-libvips-darwin-arm64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-            "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+            "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
             "cpu": [
                 "arm64"
             ],
@@ -482,9 +501,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-darwin-x64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-            "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+            "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
             "cpu": [
                 "x64"
             ],
@@ -498,9 +517,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-arm": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-            "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+            "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
             "cpu": [
                 "arm"
             ],
@@ -514,9 +533,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-arm64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-            "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+            "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
             "cpu": [
                 "arm64"
             ],
@@ -530,9 +549,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-ppc64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-            "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+            "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
             "cpu": [
                 "ppc64"
             ],
@@ -546,9 +565,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-riscv64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-            "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+            "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
             "cpu": [
                 "riscv64"
             ],
@@ -562,9 +581,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-s390x": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-            "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+            "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
             "cpu": [
                 "s390x"
             ],
@@ -578,9 +597,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-x64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-            "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+            "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
             "cpu": [
                 "x64"
             ],
@@ -594,9 +613,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-            "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+            "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
             "cpu": [
                 "arm64"
             ],
@@ -610,9 +629,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-            "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+            "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
             "cpu": [
                 "x64"
             ],
@@ -626,9 +645,9 @@
             }
         },
         "node_modules/@img/sharp-linux-arm": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-            "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+            "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
             "cpu": [
                 "arm"
             ],
@@ -638,19 +657,19 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-arm": "1.2.4"
+                "@img/sharp-libvips-linux-arm": "1.3.2"
             }
         },
         "node_modules/@img/sharp-linux-arm64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-            "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+            "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
             "cpu": [
                 "arm64"
             ],
@@ -660,19 +679,19 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-arm64": "1.2.4"
+                "@img/sharp-libvips-linux-arm64": "1.3.2"
             }
         },
         "node_modules/@img/sharp-linux-ppc64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-            "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+            "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
             "cpu": [
                 "ppc64"
             ],
@@ -682,19 +701,19 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-ppc64": "1.2.4"
+                "@img/sharp-libvips-linux-ppc64": "1.3.2"
             }
         },
         "node_modules/@img/sharp-linux-riscv64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-            "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+            "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -704,19 +723,19 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-riscv64": "1.2.4"
+                "@img/sharp-libvips-linux-riscv64": "1.3.2"
             }
         },
         "node_modules/@img/sharp-linux-s390x": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-            "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+            "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
             "cpu": [
                 "s390x"
             ],
@@ -726,19 +745,19 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-s390x": "1.2.4"
+                "@img/sharp-libvips-linux-s390x": "1.3.2"
             }
         },
         "node_modules/@img/sharp-linux-x64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-            "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+            "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
             "cpu": [
                 "x64"
             ],
@@ -748,19 +767,19 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-x64": "1.2.4"
+                "@img/sharp-libvips-linux-x64": "1.3.2"
             }
         },
         "node_modules/@img/sharp-linuxmusl-arm64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-            "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+            "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
             "cpu": [
                 "arm64"
             ],
@@ -770,19 +789,19 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+                "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
             }
         },
         "node_modules/@img/sharp-linuxmusl-x64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-            "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+            "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
             "cpu": [
                 "x64"
             ],
@@ -792,38 +811,54 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+                "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
             }
         },
         "node_modules/@img/sharp-wasm32": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-            "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-            "cpu": [
-                "wasm32"
-            ],
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+            "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
             "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/runtime": "^1.7.0"
+                "@emnapi/runtime": "^1.11.1"
             },
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-webcontainers-wasm32": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+            "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@img/sharp-wasm32": "0.35.3"
+            },
+            "engines": {
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-win32-arm64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-            "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+            "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
             "cpu": [
                 "arm64"
             ],
@@ -833,16 +868,16 @@
                 "win32"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-win32-ia32": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-            "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+            "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
             "cpu": [
                 "ia32"
             ],
@@ -852,16 +887,16 @@
                 "win32"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": "^20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-win32-x64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-            "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+            "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
             "cpu": [
                 "x64"
             ],
@@ -871,7 +906,7 @@
                 "win32"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
@@ -941,9 +976,9 @@
             }
         },
         "node_modules/@next/env": {
-            "version": "15.5.20",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.20.tgz",
-            "integrity": "sha512-dXh51Wvddf8daEyBXryZZEe1FdVxEWx9lgaTseLZUtC1XP/W8Wri+Z+VPOElHlByk23CyqHdc2oVByX7wsTWsw==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.22.tgz",
+            "integrity": "sha512-O5BlKb3KtsHkvO0gjjV66PuJnAgCtIEIzwkt50HRAHsQkU1t77eksIXSZV84/WMtZJjWrnDUPKHVRi0D62nSAA==",
             "license": "MIT"
         },
         "node_modules/@next/eslint-plugin-next": {
@@ -987,9 +1022,9 @@
             }
         },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "15.5.20",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.20.tgz",
-            "integrity": "sha512-in0yXG7/pRBVjWeEl7f7ZZETpletSMFKXVS4GJgHENTPVrJFNJKPrYewa9rpZcvdjwFece5fZP0CK34G4PxowA==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.22.tgz",
+            "integrity": "sha512-/VISwtffSg8+fVvBbXdglsvruCsdbBC4dG25iU6xascKVqfQKsj/OtjGnOEkIS7pX5GB9e9/r5QprpicsGL3gw==",
             "cpu": [
                 "arm64"
             ],
@@ -1003,9 +1038,9 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "15.5.20",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.20.tgz",
-            "integrity": "sha512-0hsFshdPnTzGJdDTHeHJ+XPUShOpnyp9pUFDwDhqctsA0Cd8NcIVGRPtptYhgYY9DjkKgCDRkXxmgRc+CgT5Wg==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.22.tgz",
+            "integrity": "sha512-NiA9ve8hbiuhG/Q17a2mZDRVxMTtg3rTOgjLnDaLlE+AEPAQlkkuKrfePEbeOrgYmX0U2KGX4EVEn09hXU5GlQ==",
             "cpu": [
                 "x64"
             ],
@@ -1019,9 +1054,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "15.5.20",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.20.tgz",
-            "integrity": "sha512-DMvkoBtAABOzE6pMZRW/xNm7sKqql3wzzzZJ1R/d/rp4BCxv6LykouD3tHjGY8WdQqGpZs11t+R9AtjPxvvljw==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.22.tgz",
+            "integrity": "sha512-vAPa9vltW+UW/KWtjXeSUFgV3wb1x9d/BeyC6WFI6eBpL0D2f70oGwtOp6193mNW3qusrpgBzMQferPf+Zh8Dw==",
             "cpu": [
                 "arm64"
             ],
@@ -1035,9 +1070,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "15.5.20",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.20.tgz",
-            "integrity": "sha512-RQmDfeYBtXV2FSId7dfA1hE6M/T6+g7wdbYnFQ47tw/gUBwV+CccLVejNmCGa9yLDitk83foeg8hl/3DjfYQ5g==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.22.tgz",
+            "integrity": "sha512-iknK80pWlNDnkdSr13bd8mMuG3Z2oTxODwsZHvuMY7caMk77+rBLdHVWsy8v2EVa3ZojJ/+wJX5fnq8va6Gv8A==",
             "cpu": [
                 "arm64"
             ],
@@ -1051,9 +1086,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "15.5.20",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.20.tgz",
-            "integrity": "sha512-DkWLEdKajJwdGt27M3i1VEO2kelTvZrK6Pcb7JvW2BY+nofWm7FBsBNDj7g7Pr1NuQ5PLJvqEqYa20GTsBDnKQ==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.22.tgz",
+            "integrity": "sha512-penuEdkwU2OOAiS+n4LE8T/VIoCfAI01QcLZTJ2xc3+l4Q22L/DzURocmI2LU1b+8BMQoLAP1Sze3uYAZT05Bg==",
             "cpu": [
                 "x64"
             ],
@@ -1067,9 +1102,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-musl": {
-            "version": "15.5.20",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.20.tgz",
-            "integrity": "sha512-rAO5b7pKHvX+ExdmJskusDXTNbiNZfptifIPZItbUx+AOXxxTydVBsPt7Oz84DRd5mY8e0DcE8kvLj3AIfjE6w==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.22.tgz",
+            "integrity": "sha512-ZM0BKJm3FZ+guG6WT6PcyOLtp6paZ5tngcJC/uUKvLW4Y0TQnnVi1+UGdo8Q6Yxp5gaS82pmC1rD/oFlhkWB3g==",
             "cpu": [
                 "x64"
             ],
@@ -1083,9 +1118,9 @@
             }
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "15.5.20",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.20.tgz",
-            "integrity": "sha512-Hp3zFsN8N8Kj9+vY6L4vnZ9EtA9eXyATu0q4EfGbZTiocgPUNSfz8NWhym6xvaOmHpJ8EuoypuU1WejCPsTFtg==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.22.tgz",
+            "integrity": "sha512-rY/YaumrZaS0//94BnHLF5VSRp0GFUO4GvXNuoCBb0cGSci96yO+p1JaNL2aq9YZAYv9cuZRziV02x5IQH/wjg==",
             "cpu": [
                 "arm64"
             ],
@@ -1099,9 +1134,9 @@
             }
         },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "15.5.20",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.20.tgz",
-            "integrity": "sha512-T/L7CXpR1M0wij/xbF3rT1+7KvSkfOLr7C+ToHHWZTG2eKmb52C5WvsyGCBNtkVvDEUESWkRUbbqSH4rSbOCYQ==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.22.tgz",
+            "integrity": "sha512-s5IA4cyrbR2XK/5NWcu5dp8CfPBiKME+UhvNperia7uQybEgg5+LIhGMiY37WQE4rcI4owsDcU4IVUjLoTuDkA==",
             "cpu": [
                 "x64"
             ],
@@ -5865,12 +5900,12 @@
             "dev": true
         },
         "node_modules/next": {
-            "version": "15.5.20",
-            "resolved": "https://registry.npmjs.org/next/-/next-15.5.20.tgz",
-            "integrity": "sha512-cvyS3/geydan1xLtE3FA8VCgdoQ/Gg/dlOldFkFCbB5VcVYJV7090hQLBnvTW2PwT76Z/dHdzDZCsVhZpoOlUA==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/next/-/next-15.5.22.tgz",
+            "integrity": "sha512-mrtal1sRxO4YrlDS98sDuIvGZivKbFix8w7oAL9ZynfOgc3cADQOQgvwtMooc18Qr8bKzvQAcHwHZ0mbJ7zcfQ==",
             "license": "MIT",
             "dependencies": {
-                "@next/env": "15.5.20",
+                "@next/env": "15.5.22",
                 "@swc/helpers": "0.5.15",
                 "caniuse-lite": "^1.0.30001579",
                 "postcss": "8.4.31",
@@ -5883,14 +5918,14 @@
                 "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "15.5.20",
-                "@next/swc-darwin-x64": "15.5.20",
-                "@next/swc-linux-arm64-gnu": "15.5.20",
-                "@next/swc-linux-arm64-musl": "15.5.20",
-                "@next/swc-linux-x64-gnu": "15.5.20",
-                "@next/swc-linux-x64-musl": "15.5.20",
-                "@next/swc-win32-arm64-msvc": "15.5.20",
-                "@next/swc-win32-x64-msvc": "15.5.20",
+                "@next/swc-darwin-arm64": "15.5.22",
+                "@next/swc-darwin-x64": "15.5.22",
+                "@next/swc-linux-arm64-gnu": "15.5.22",
+                "@next/swc-linux-arm64-musl": "15.5.22",
+                "@next/swc-linux-x64-gnu": "15.5.22",
+                "@next/swc-linux-x64-musl": "15.5.22",
+                "@next/swc-win32-arm64-msvc": "15.5.22",
+                "@next/swc-win32-x64-msvc": "15.5.22",
                 "sharp": "^0.34.3"
             },
             "peerDependencies": {
@@ -7021,48 +7056,53 @@
             }
         },
         "node_modules/sharp": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-            "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-            "hasInstallScript": true,
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+            "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@img/colour": "^1.0.0",
+                "@img/colour": "^1.1.0",
                 "detect-libc": "^2.1.2",
-                "semver": "^7.7.3"
+                "semver": "^7.8.5"
             },
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-darwin-arm64": "0.34.5",
-                "@img/sharp-darwin-x64": "0.34.5",
-                "@img/sharp-libvips-darwin-arm64": "1.2.4",
-                "@img/sharp-libvips-darwin-x64": "1.2.4",
-                "@img/sharp-libvips-linux-arm": "1.2.4",
-                "@img/sharp-libvips-linux-arm64": "1.2.4",
-                "@img/sharp-libvips-linux-ppc64": "1.2.4",
-                "@img/sharp-libvips-linux-riscv64": "1.2.4",
-                "@img/sharp-libvips-linux-s390x": "1.2.4",
-                "@img/sharp-libvips-linux-x64": "1.2.4",
-                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-                "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-                "@img/sharp-linux-arm": "0.34.5",
-                "@img/sharp-linux-arm64": "0.34.5",
-                "@img/sharp-linux-ppc64": "0.34.5",
-                "@img/sharp-linux-riscv64": "0.34.5",
-                "@img/sharp-linux-s390x": "0.34.5",
-                "@img/sharp-linux-x64": "0.34.5",
-                "@img/sharp-linuxmusl-arm64": "0.34.5",
-                "@img/sharp-linuxmusl-x64": "0.34.5",
-                "@img/sharp-wasm32": "0.34.5",
-                "@img/sharp-win32-arm64": "0.34.5",
-                "@img/sharp-win32-ia32": "0.34.5",
-                "@img/sharp-win32-x64": "0.34.5"
+                "@img/sharp-darwin-arm64": "0.35.3",
+                "@img/sharp-darwin-x64": "0.35.3",
+                "@img/sharp-freebsd-wasm32": "0.35.3",
+                "@img/sharp-libvips-darwin-arm64": "1.3.2",
+                "@img/sharp-libvips-darwin-x64": "1.3.2",
+                "@img/sharp-libvips-linux-arm": "1.3.2",
+                "@img/sharp-libvips-linux-arm64": "1.3.2",
+                "@img/sharp-libvips-linux-ppc64": "1.3.2",
+                "@img/sharp-libvips-linux-riscv64": "1.3.2",
+                "@img/sharp-libvips-linux-s390x": "1.3.2",
+                "@img/sharp-libvips-linux-x64": "1.3.2",
+                "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+                "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+                "@img/sharp-linux-arm": "0.35.3",
+                "@img/sharp-linux-arm64": "0.35.3",
+                "@img/sharp-linux-ppc64": "0.35.3",
+                "@img/sharp-linux-riscv64": "0.35.3",
+                "@img/sharp-linux-s390x": "0.35.3",
+                "@img/sharp-linux-x64": "0.35.3",
+                "@img/sharp-linuxmusl-arm64": "0.35.3",
+                "@img/sharp-linuxmusl-x64": "0.35.3",
+                "@img/sharp-webcontainers-wasm32": "0.35.3",
+                "@img/sharp-win32-arm64": "0.35.3",
+                "@img/sharp-win32-ia32": "0.35.3",
+                "@img/sharp-win32-x64": "0.35.3"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
             }
         },
         "node_modules/shebang-command": {
@@ -8395,9 +8435,9 @@
             }
         },
         "@emnapi/runtime": {
-            "version": "1.11.2",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-            "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+            "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
             "optional": true,
             "requires": {
                 "tslib": "^2.4.0"
@@ -8605,180 +8645,198 @@
             "optional": true
         },
         "@img/sharp-darwin-arm64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-            "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+            "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
             "optional": true,
             "requires": {
-                "@img/sharp-libvips-darwin-arm64": "1.2.4"
+                "@img/sharp-libvips-darwin-arm64": "1.3.2"
             }
         },
         "@img/sharp-darwin-x64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-            "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+            "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
             "optional": true,
             "requires": {
-                "@img/sharp-libvips-darwin-x64": "1.2.4"
+                "@img/sharp-libvips-darwin-x64": "1.3.2"
+            }
+        },
+        "@img/sharp-freebsd-wasm32": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+            "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+            "optional": true,
+            "requires": {
+                "@img/sharp-wasm32": "0.35.3"
             }
         },
         "@img/sharp-libvips-darwin-arm64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-            "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+            "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
             "optional": true
         },
         "@img/sharp-libvips-darwin-x64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-            "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+            "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
             "optional": true
         },
         "@img/sharp-libvips-linux-arm": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-            "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+            "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
             "optional": true
         },
         "@img/sharp-libvips-linux-arm64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-            "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+            "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
             "optional": true
         },
         "@img/sharp-libvips-linux-ppc64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-            "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+            "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
             "optional": true
         },
         "@img/sharp-libvips-linux-riscv64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-            "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+            "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
             "optional": true
         },
         "@img/sharp-libvips-linux-s390x": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-            "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+            "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
             "optional": true
         },
         "@img/sharp-libvips-linux-x64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-            "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+            "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
             "optional": true
         },
         "@img/sharp-libvips-linuxmusl-arm64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-            "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+            "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
             "optional": true
         },
         "@img/sharp-libvips-linuxmusl-x64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-            "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+            "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
             "optional": true
         },
         "@img/sharp-linux-arm": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-            "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+            "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
             "optional": true,
             "requires": {
-                "@img/sharp-libvips-linux-arm": "1.2.4"
+                "@img/sharp-libvips-linux-arm": "1.3.2"
             }
         },
         "@img/sharp-linux-arm64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-            "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+            "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
             "optional": true,
             "requires": {
-                "@img/sharp-libvips-linux-arm64": "1.2.4"
+                "@img/sharp-libvips-linux-arm64": "1.3.2"
             }
         },
         "@img/sharp-linux-ppc64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-            "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+            "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
             "optional": true,
             "requires": {
-                "@img/sharp-libvips-linux-ppc64": "1.2.4"
+                "@img/sharp-libvips-linux-ppc64": "1.3.2"
             }
         },
         "@img/sharp-linux-riscv64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-            "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+            "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
             "optional": true,
             "requires": {
-                "@img/sharp-libvips-linux-riscv64": "1.2.4"
+                "@img/sharp-libvips-linux-riscv64": "1.3.2"
             }
         },
         "@img/sharp-linux-s390x": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-            "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+            "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
             "optional": true,
             "requires": {
-                "@img/sharp-libvips-linux-s390x": "1.2.4"
+                "@img/sharp-libvips-linux-s390x": "1.3.2"
             }
         },
         "@img/sharp-linux-x64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-            "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+            "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
             "optional": true,
             "requires": {
-                "@img/sharp-libvips-linux-x64": "1.2.4"
+                "@img/sharp-libvips-linux-x64": "1.3.2"
             }
         },
         "@img/sharp-linuxmusl-arm64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-            "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+            "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
             "optional": true,
             "requires": {
-                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+                "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
             }
         },
         "@img/sharp-linuxmusl-x64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-            "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+            "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
             "optional": true,
             "requires": {
-                "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+                "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
             }
         },
         "@img/sharp-wasm32": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-            "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+            "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
             "optional": true,
             "requires": {
-                "@emnapi/runtime": "^1.7.0"
+                "@emnapi/runtime": "^1.11.1"
+            }
+        },
+        "@img/sharp-webcontainers-wasm32": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+            "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+            "optional": true,
+            "requires": {
+                "@img/sharp-wasm32": "0.35.3"
             }
         },
         "@img/sharp-win32-arm64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-            "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+            "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
             "optional": true
         },
         "@img/sharp-win32-ia32": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-            "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+            "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
             "optional": true
         },
         "@img/sharp-win32-x64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-            "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+            "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
             "optional": true
         },
         "@jridgewell/gen-mapping": {
@@ -8834,9 +8892,9 @@
             "dev": true
         },
         "@next/env": {
-            "version": "15.5.20",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.20.tgz",
-            "integrity": "sha512-dXh51Wvddf8daEyBXryZZEe1FdVxEWx9lgaTseLZUtC1XP/W8Wri+Z+VPOElHlByk23CyqHdc2oVByX7wsTWsw=="
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.22.tgz",
+            "integrity": "sha512-O5BlKb3KtsHkvO0gjjV66PuJnAgCtIEIzwkt50HRAHsQkU1t77eksIXSZV84/WMtZJjWrnDUPKHVRi0D62nSAA=="
         },
         "@next/eslint-plugin-next": {
             "version": "15.5.20",
@@ -8872,51 +8930,51 @@
             }
         },
         "@next/swc-darwin-arm64": {
-            "version": "15.5.20",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.20.tgz",
-            "integrity": "sha512-in0yXG7/pRBVjWeEl7f7ZZETpletSMFKXVS4GJgHENTPVrJFNJKPrYewa9rpZcvdjwFece5fZP0CK34G4PxowA==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.22.tgz",
+            "integrity": "sha512-/VISwtffSg8+fVvBbXdglsvruCsdbBC4dG25iU6xascKVqfQKsj/OtjGnOEkIS7pX5GB9e9/r5QprpicsGL3gw==",
             "optional": true
         },
         "@next/swc-darwin-x64": {
-            "version": "15.5.20",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.20.tgz",
-            "integrity": "sha512-0hsFshdPnTzGJdDTHeHJ+XPUShOpnyp9pUFDwDhqctsA0Cd8NcIVGRPtptYhgYY9DjkKgCDRkXxmgRc+CgT5Wg==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.22.tgz",
+            "integrity": "sha512-NiA9ve8hbiuhG/Q17a2mZDRVxMTtg3rTOgjLnDaLlE+AEPAQlkkuKrfePEbeOrgYmX0U2KGX4EVEn09hXU5GlQ==",
             "optional": true
         },
         "@next/swc-linux-arm64-gnu": {
-            "version": "15.5.20",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.20.tgz",
-            "integrity": "sha512-DMvkoBtAABOzE6pMZRW/xNm7sKqql3wzzzZJ1R/d/rp4BCxv6LykouD3tHjGY8WdQqGpZs11t+R9AtjPxvvljw==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.22.tgz",
+            "integrity": "sha512-vAPa9vltW+UW/KWtjXeSUFgV3wb1x9d/BeyC6WFI6eBpL0D2f70oGwtOp6193mNW3qusrpgBzMQferPf+Zh8Dw==",
             "optional": true
         },
         "@next/swc-linux-arm64-musl": {
-            "version": "15.5.20",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.20.tgz",
-            "integrity": "sha512-RQmDfeYBtXV2FSId7dfA1hE6M/T6+g7wdbYnFQ47tw/gUBwV+CccLVejNmCGa9yLDitk83foeg8hl/3DjfYQ5g==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.22.tgz",
+            "integrity": "sha512-iknK80pWlNDnkdSr13bd8mMuG3Z2oTxODwsZHvuMY7caMk77+rBLdHVWsy8v2EVa3ZojJ/+wJX5fnq8va6Gv8A==",
             "optional": true
         },
         "@next/swc-linux-x64-gnu": {
-            "version": "15.5.20",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.20.tgz",
-            "integrity": "sha512-DkWLEdKajJwdGt27M3i1VEO2kelTvZrK6Pcb7JvW2BY+nofWm7FBsBNDj7g7Pr1NuQ5PLJvqEqYa20GTsBDnKQ==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.22.tgz",
+            "integrity": "sha512-penuEdkwU2OOAiS+n4LE8T/VIoCfAI01QcLZTJ2xc3+l4Q22L/DzURocmI2LU1b+8BMQoLAP1Sze3uYAZT05Bg==",
             "optional": true
         },
         "@next/swc-linux-x64-musl": {
-            "version": "15.5.20",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.20.tgz",
-            "integrity": "sha512-rAO5b7pKHvX+ExdmJskusDXTNbiNZfptifIPZItbUx+AOXxxTydVBsPt7Oz84DRd5mY8e0DcE8kvLj3AIfjE6w==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.22.tgz",
+            "integrity": "sha512-ZM0BKJm3FZ+guG6WT6PcyOLtp6paZ5tngcJC/uUKvLW4Y0TQnnVi1+UGdo8Q6Yxp5gaS82pmC1rD/oFlhkWB3g==",
             "optional": true
         },
         "@next/swc-win32-arm64-msvc": {
-            "version": "15.5.20",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.20.tgz",
-            "integrity": "sha512-Hp3zFsN8N8Kj9+vY6L4vnZ9EtA9eXyATu0q4EfGbZTiocgPUNSfz8NWhym6xvaOmHpJ8EuoypuU1WejCPsTFtg==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.22.tgz",
+            "integrity": "sha512-rY/YaumrZaS0//94BnHLF5VSRp0GFUO4GvXNuoCBb0cGSci96yO+p1JaNL2aq9YZAYv9cuZRziV02x5IQH/wjg==",
             "optional": true
         },
         "@next/swc-win32-x64-msvc": {
-            "version": "15.5.20",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.20.tgz",
-            "integrity": "sha512-T/L7CXpR1M0wij/xbF3rT1+7KvSkfOLr7C+ToHHWZTG2eKmb52C5WvsyGCBNtkVvDEUESWkRUbbqSH4rSbOCYQ==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.22.tgz",
+            "integrity": "sha512-s5IA4cyrbR2XK/5NWcu5dp8CfPBiKME+UhvNperia7uQybEgg5+LIhGMiY37WQE4rcI4owsDcU4IVUjLoTuDkA==",
             "optional": true
         },
         "@noble/hashes": {
@@ -12061,23 +12119,23 @@
             "dev": true
         },
         "next": {
-            "version": "15.5.20",
-            "resolved": "https://registry.npmjs.org/next/-/next-15.5.20.tgz",
-            "integrity": "sha512-cvyS3/geydan1xLtE3FA8VCgdoQ/Gg/dlOldFkFCbB5VcVYJV7090hQLBnvTW2PwT76Z/dHdzDZCsVhZpoOlUA==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/next/-/next-15.5.22.tgz",
+            "integrity": "sha512-mrtal1sRxO4YrlDS98sDuIvGZivKbFix8w7oAL9ZynfOgc3cADQOQgvwtMooc18Qr8bKzvQAcHwHZ0mbJ7zcfQ==",
             "requires": {
-                "@next/env": "15.5.20",
-                "@next/swc-darwin-arm64": "15.5.20",
-                "@next/swc-darwin-x64": "15.5.20",
-                "@next/swc-linux-arm64-gnu": "15.5.20",
-                "@next/swc-linux-arm64-musl": "15.5.20",
-                "@next/swc-linux-x64-gnu": "15.5.20",
-                "@next/swc-linux-x64-musl": "15.5.20",
-                "@next/swc-win32-arm64-msvc": "15.5.20",
-                "@next/swc-win32-x64-msvc": "15.5.20",
+                "@next/env": "15.5.22",
+                "@next/swc-darwin-arm64": "15.5.22",
+                "@next/swc-darwin-x64": "15.5.22",
+                "@next/swc-linux-arm64-gnu": "15.5.22",
+                "@next/swc-linux-arm64-musl": "15.5.22",
+                "@next/swc-linux-x64-gnu": "15.5.22",
+                "@next/swc-linux-x64-musl": "15.5.22",
+                "@next/swc-win32-arm64-msvc": "15.5.22",
+                "@next/swc-win32-x64-msvc": "15.5.22",
                 "@swc/helpers": "0.5.15",
                 "caniuse-lite": "^1.0.30001579",
                 "postcss": "^8.5.10",
-                "sharp": "^0.34.3",
+                "sharp": "^0.35.0",
                 "styled-jsx": "5.1.6"
             }
         },
@@ -12807,38 +12865,39 @@
             }
         },
         "sharp": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-            "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+            "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
             "optional": true,
             "requires": {
-                "@img/colour": "^1.0.0",
-                "@img/sharp-darwin-arm64": "0.34.5",
-                "@img/sharp-darwin-x64": "0.34.5",
-                "@img/sharp-libvips-darwin-arm64": "1.2.4",
-                "@img/sharp-libvips-darwin-x64": "1.2.4",
-                "@img/sharp-libvips-linux-arm": "1.2.4",
-                "@img/sharp-libvips-linux-arm64": "1.2.4",
-                "@img/sharp-libvips-linux-ppc64": "1.2.4",
-                "@img/sharp-libvips-linux-riscv64": "1.2.4",
-                "@img/sharp-libvips-linux-s390x": "1.2.4",
-                "@img/sharp-libvips-linux-x64": "1.2.4",
-                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-                "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-                "@img/sharp-linux-arm": "0.34.5",
-                "@img/sharp-linux-arm64": "0.34.5",
-                "@img/sharp-linux-ppc64": "0.34.5",
-                "@img/sharp-linux-riscv64": "0.34.5",
-                "@img/sharp-linux-s390x": "0.34.5",
-                "@img/sharp-linux-x64": "0.34.5",
-                "@img/sharp-linuxmusl-arm64": "0.34.5",
-                "@img/sharp-linuxmusl-x64": "0.34.5",
-                "@img/sharp-wasm32": "0.34.5",
-                "@img/sharp-win32-arm64": "0.34.5",
-                "@img/sharp-win32-ia32": "0.34.5",
-                "@img/sharp-win32-x64": "0.34.5",
+                "@img/colour": "^1.1.0",
+                "@img/sharp-darwin-arm64": "0.35.3",
+                "@img/sharp-darwin-x64": "0.35.3",
+                "@img/sharp-freebsd-wasm32": "0.35.3",
+                "@img/sharp-libvips-darwin-arm64": "1.3.2",
+                "@img/sharp-libvips-darwin-x64": "1.3.2",
+                "@img/sharp-libvips-linux-arm": "1.3.2",
+                "@img/sharp-libvips-linux-arm64": "1.3.2",
+                "@img/sharp-libvips-linux-ppc64": "1.3.2",
+                "@img/sharp-libvips-linux-riscv64": "1.3.2",
+                "@img/sharp-libvips-linux-s390x": "1.3.2",
+                "@img/sharp-libvips-linux-x64": "1.3.2",
+                "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+                "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+                "@img/sharp-linux-arm": "0.35.3",
+                "@img/sharp-linux-arm64": "0.35.3",
+                "@img/sharp-linux-ppc64": "0.35.3",
+                "@img/sharp-linux-riscv64": "0.35.3",
+                "@img/sharp-linux-s390x": "0.35.3",
+                "@img/sharp-linux-x64": "0.35.3",
+                "@img/sharp-linuxmusl-arm64": "0.35.3",
+                "@img/sharp-linuxmusl-x64": "0.35.3",
+                "@img/sharp-webcontainers-wasm32": "0.35.3",
+                "@img/sharp-win32-arm64": "0.35.3",
+                "@img/sharp-win32-ia32": "0.35.3",
+                "@img/sharp-win32-x64": "0.35.3",
                 "detect-libc": "^2.1.2",
-                "semver": "^7.7.3"
+                "semver": "^7.8.5"
             }
         },
         "shebang-command": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "classnames": "^2.5.1",
         "daisyui": "^4.7.2",
         "framer-motion": "^11.0.8",
-        "next": "^15.5.16",
+        "next": "^15.5.21",
         "p5": "^1.9.1",
         "posthog-js": "^1.399.2",
         "react": "^18.2.0",
@@ -56,6 +56,7 @@
         "tailwindcss": "^3.4.1"
     },
     "overrides": {
-        "postcss": "$postcss"
+        "postcss": "$postcss",
+        "sharp": "^0.35.0"
     }
 }


### PR DESCRIPTION
## Summary

Resolves all **9 open Dependabot alerts** on the default branch (4 high, 5 moderate). All 9 map to two packages:

| Package | Before | After | Alerts | First patched |
|---|---|---|---|---|
| next | 15.5.20 | 15.5.22 | #3–#10 (SSRF in Server Actions & rewrites, response-cache confusion ×2, Server Action DoS, unbounded Edge payload, SVG image-optimization DoS, server-function endpoint disclosure) | 15.5.21 |
| sharp (transitive, optional dep of next) | 0.34.5 | 0.35.3 | #2 (libvips CVE-2026-33327/33328/35590/35591) | 0.35.0 |

## Reachability

- The site defines **no Server Actions** (`"use server"` appears nowhere) and **no rewrites** (only a `/signin` redirect), so the two SSRF alerts and the Server-Action DoS/payload alerts are not directly exploitable today — patched anyway since `next` is a runtime dependency and usage can change.
- The site **does use `next/image`**, so the SVG image-optimization DoS (#5) and the sharp/libvips alerts (#2) are plausibly reachable on the Netlify runtime.
- Cache-confusion (#8, #9) and endpoint-disclosure (#4) are framework-level and reachable on any deployed Next server.

## Why the sharp override

`next` 15.5.21+ still pins `sharp@^0.34.3` as its optional dependency, so bumping `next` alone cannot pull in the patched sharp. An npm `overrides` entry forces `^0.35.0` until upstream bumps its range. The existing `postcss` override pattern is preserved.

## Verification

- `npm ci` — clean install
- `npm test` — 183/183 pass
- `npm run build` — succeeds (includes prebuild: paper fetch, tests, presentation verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)