### PR TITLE
Add the Playbooks entry route

### DIFF
--- a/pages/playbooks/brickeye.js
+++ b/pages/playbooks/brickeye.js
@@ -1,0 +1,15 @@
+// OpenAdapt owns the stable public product path. The customer-specific service
+// stays on its separate deployment boundary and private source repository.
+export default function BrickeyePlaybookPage() {
+    return null
+}
+
+export function getServerSideProps({ res }) {
+    res.setHeader('X-Robots-Tag', 'noindex, nofollow')
+    return {
+        redirect: {
+            destination: 'https://playbooks.openadapt.ai/brickeye',
+            permanent: false,
+        },
+    }
+}

--- a/tests/playbooksRoute.test.js
+++ b/tests/playbooksRoute.test.js
@@ -1,0 +1,16 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+const source = fs.readFileSync(
+    path.join(__dirname, '..', 'pages', 'playbooks', 'brickeye.js'),
+    'utf8'
+)
+
+test('the stable OpenAdapt Brickeye path redirects to the isolated service', () => {
+    assert.match(source, /https:\/\/playbooks\.openadapt\.ai\/brickeye/)
+    assert.match(source, /X-Robots-Tag/)
+    assert.match(source, /noindex, nofollow/)
+    assert.match(source, /permanent: false/)
+})


### PR DESCRIPTION
## What changed

- Add a temporary Playbooks entry route.
- Redirect the route to an isolated private service.
- Keep the route out of search indexes.
- Add a route and security-header contract test.

## Why

This route connected a private service to the canonical OpenAdapt domain without copying private configuration into the public website.

## Checks

- npm test: 185 tests passed.