### PR TITLE
chore: publish exact current release provenance

### DIFF
--- a/data/published-version-claims.json
+++ b/data/published-version-claims.json
@@ -32,8 +32,9 @@
             "id": "status-manifest-component-versions",
             "kind": "pypi-latest",
             "source_of_truth": "public/status.json#/versions",
-            "verified_on": "2026-08-02",
-            "evidence": "Published package and GitHub release records on 2026-08-02: openadapt 1.11.0, openadapt-flow 1.29.0, openadapt-capture 1.2.2, openadapt-desktop 0.15.0.",
+            "release_source_of_truth": "public/status.json#/releases",
+            "verified_on": "2026-08-06",
+            "evidence": "Published package and GitHub release records on 2026-08-06: openadapt 1.12.0, openadapt-flow 1.30.0, openadapt-capture 1.2.2, openadapt-desktop 0.15.0.",
             "packages": {
                 "launcher": "openadapt",
                 "flow": "openadapt-flow",
@@ -41,8 +42,8 @@
                 "desktop": "openadapt-desktop"
             },
             "versions": {
-                "launcher": "1.11.0",
-                "flow": "1.29.0",
+                "launcher": "1.12.0",
+                "flow": "1.30.0",
                 "capture": "1.2.2",
                 "desktop": "0.15.0"
             }
@@ -57,12 +58,12 @@
             "evidence": "openadapt-flow cbec44c2c2f355d5cc04a72ea9267e2d6ea68ac6 declares version = \"0.1.0\" in pyproject.toml and describes as v0.1.0-24-gcbec44c; v0.2.0 (2026-07-11) is the first release tag containing it.",
             "verified_on": "2026-07-27",
             "acknowledged_release_lag": {
-                "as_of_release": "1.29.0",
-                "releases_behind": 75,
-                "minor_releases_behind_first_containing_tag": 27,
-                "acknowledged_on": "2026-08-02",
+                "as_of_release": "1.30.0",
+                "releases_behind": 76,
+                "minor_releases_behind_first_containing_tag": 28,
+                "acknowledged_on": "2026-08-06",
                 "review_by": "2026-10-31",
-                "note": "75 live openadapt-flow releases postdate 0.1.0, and v0.2.0 -- the first release tag containing the pinned commit -- is 27 minor releases behind 1.29.0. That is recorded, labelled on every surface that renders them, and deliberately NOT edited -- these are historical measurements. The lag may not grow past the acknowledged value without a decision, and the acknowledgement expires on review_by so it cannot be renewed by silence. Refreshing means re-running the benchmarks: MockMed is deterministic and CI-reproducible; OpenEMR runs against a shared public demo that resets daily, so its refresh is a field run whose numbers will legitimately differ. Re-acknowledged on 2026-08-02 for v1.29.0 (74 -> 75). review_by is deliberately UNCHANGED at 2026-10-31: restating the count is not a decision to keep waiting, and this acknowledgement must still expire on its original date."
+                "note": "76 live openadapt-flow releases postdate 0.1.0; v0.2.0 is the first release tag containing the pinned commit. The machine-readable minor_releases_behind_first_containing_tag field records the release distance without duplicating it in this note. These are historical measurements and are deliberately NOT edited. The lag may not grow past the acknowledged value without a decision, and the acknowledgement expires on review_by so it cannot be renewed by silence. Refreshing means re-running the benchmarks: MockMed is deterministic and CI-reproducible; OpenEMR runs against a shared public demo that resets daily, so its refresh is a field run whose numbers will legitimately differ. Re-acknowledged on 2026-08-06 for v1.30.0 (75 -> 76). review_by is deliberately UNCHANGED at 2026-10-31: restating the count is not a decision to keep waiting, and this acknowledgement must still expire on its original date."
             },
             "attribution_required": [
                 {

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -78,7 +78,7 @@ control plane is a separate commercial product.
 
 - Engine source: https://github.com/OpenAdaptAI/openadapt-flow
 - Install route: https://github.com/OpenAdaptAI/OpenAdapt and `pip install openadapt`
-- Current published versions: launcher 1.11.0, Flow 1.29.0, capture 1.2.2, desktop 0.15.0
+- Current published versions: launcher 1.12.0, Flow 1.30.0, capture 1.2.2, desktop 0.15.0
 - Product lifecycle: Beta
 
 ---

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -9,7 +9,7 @@ OpenAdapt is for the case where the work is repetitive and consequential, the in
 ## Canonical machine-readable status
 
 - [status.json](https://openadapt.ai/status.json): The single source of truth for product lifecycle, released component versions, per-substrate availability, delivery boundary, and the linked acceptance evidence for each substrate. Public surfaces render their labels from this file. Prefer it over any prose on this site if the two ever disagree.
-- Current published versions: launcher 1.11.0, Flow (compiler/runtime) 1.29.0, capture 1.2.2, desktop 0.15.0. Product lifecycle: Beta.
+- Current published versions: launcher 1.12.0, Flow (compiler/runtime) 1.30.0, capture 1.2.2, desktop 0.15.0. Product lifecycle: Beta.
 
 ## Execution substrates and their evidence boundary
 

--- a/public/status.json
+++ b/public/status.json
@@ -1,12 +1,60 @@
 {
     "$comment": "Canonical machine-readable release, capability, evidence, and deployment status for OpenAdapt. Served at https://openadapt.ai/status.json and consumed by status-aware public surfaces and tests. OpenAdapt is one Beta product across browser, Windows, macOS, Linux, RDP, and Citrix/VDI. Capability availability is distinct from the deployment boundary and from the bounded evidence scope recorded for each substrate.",
-    "generated_at": "2026-08-02",
+    "generated_at": "2026-08-06",
     "product_lifecycle": "Beta",
     "versions": {
-        "launcher": "1.11.0",
-        "flow": "1.29.0",
+        "launcher": "1.12.0",
+        "flow": "1.30.0",
         "capture": "1.2.2",
         "desktop": "0.15.0"
+    },
+    "releases": {
+        "launcher": {
+            "package": "openadapt",
+            "version": "1.12.0",
+            "source": "pypi",
+            "github_repository": "OpenAdaptAI/OpenAdapt",
+            "tag": "v1.12.0",
+            "release_commit": "f9a7ec4e9981a0a2926ce7a5b5ee498ac5e22576",
+            "qualified_source_commit": "870f2d6820e50ac4ac6a4e6bba2c0bc2f533d216",
+            "artifacts": [
+                {
+                    "type": "bdist_wheel",
+                    "filename": "openadapt-1.12.0-py3-none-any.whl",
+                    "url": "https://files.pythonhosted.org/packages/8c/0b/47b511f00e9e8a579bdb4fda71272b3663e16d99bb5dd966a5703e37a67b/openadapt-1.12.0-py3-none-any.whl",
+                    "sha256": "06c249def17f95b30292ebb7a9994242128acb91b1c4e81a16b88ca19cd65d6c"
+                },
+                {
+                    "type": "sdist",
+                    "filename": "openadapt-1.12.0.tar.gz",
+                    "url": "https://files.pythonhosted.org/packages/09/d3/34a7cba44f056cc196ab9b67e368fe955826472d9dee7c51a0b4234380e1/openadapt-1.12.0.tar.gz",
+                    "sha256": "e7938ca5c4aa531fdac1197d0a190a75df9bbfd57aad9dba79ff44fdbd2043b4"
+                }
+            ]
+        },
+        "flow": {
+            "package": "openadapt-flow",
+            "version": "1.30.0",
+            "source": "pypi",
+            "github_repository": "OpenAdaptAI/openadapt-flow",
+            "tag": "v1.30.0",
+            "release_commit": "0461fb86d255e681306e6403c134f08a823e70e4",
+            "qualified_source_commit": "c150ad597214eaca27350f8d21f611caa71aade5",
+            "artifacts": [
+                {
+                    "type": "bdist_wheel",
+                    "filename": "openadapt_flow-1.30.0-py3-none-any.whl",
+                    "url": "https://files.pythonhosted.org/packages/5c/0e/680aebe9683c358d1f4b9d0aac62c21f6698f63c46dbff4e027f9d3836ae/openadapt_flow-1.30.0-py3-none-any.whl",
+                    "sha256": "7bf1a7b00388172a79bda666def182688c296ffb5bc9be2fd3281169fc36ae63"
+                },
+                {
+                    "type": "sdist",
+                    "filename": "openadapt_flow-1.30.0.tar.gz",
+                    "url": "https://files.pythonhosted.org/packages/c8/5d/883e608ac2a8e414551b55368fdc3b0b52a83f58ccaff8ba47956e22f5be/openadapt_flow-1.30.0.tar.gz",
+                    "sha256": "3a402610e35f47fd54daaf066b8c3a6006c13483cb4c778740014abea1854ea4"
+                }
+            ]
+        }
     },
     "tiers": {
         "Available": "Implemented in the released compiler and governed runtime. Production use still qualifies the exact workflow, application, environment, identity contract, and effect oracle.",

--- a/scripts/check_published_version_claims.mjs
+++ b/scripts/check_published_version_claims.mjs
@@ -65,6 +65,8 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const REGISTRY_PATH = path.join(ROOT, 'data', 'published-version-claims.json')
 const PYPI_BASE = process.env.OPENADAPT_PYPI_BASE ?? 'https://pypi.org/pypi'
 const PYPI_URL = (pkg) => `${PYPI_BASE}/${pkg}/json`
+const GITHUB_API_BASE =
+    process.env.OPENADAPT_GITHUB_API_BASE ?? 'https://api.github.com'
 const HTTP_TIMEOUT_MS = 20000
 
 const errors = []
@@ -73,6 +75,21 @@ const notes = []
 
 const readJson = (relative) =>
     JSON.parse(fs.readFileSync(path.join(ROOT, relative), 'utf8'))
+
+function readSourceOfTruth(source) {
+    const [file, pointer] = String(source).split('#')
+    const document = readJson(file)
+    const value = pointer
+        .split('/')
+        .filter(Boolean)
+        .reduce((node, key) => (node == null ? node : node[key]), document)
+    return { file, pointer, value }
+}
+
+function releaseRecordsForClaim(claim) {
+    if (!claim.release_source_of_truth) return {}
+    return readSourceOfTruth(claim.release_source_of_truth).value ?? {}
+}
 
 function parseArgs(argv) {
     const args = { offline: false, versions: {}, releases: {}, today: null }
@@ -129,12 +146,7 @@ function releasesBehind(version, publishedVersions) {
 // ---------------------------------------------------------------------------
 
 function checkPypiLatestSourceOfTruth(claim) {
-    const [file, pointer] = String(claim.source_of_truth).split('#')
-    const document = readJson(file)
-    const container = pointer
-        .split('/')
-        .filter(Boolean)
-        .reduce((node, key) => (node == null ? node : node[key]), document)
+    const { file, value: container } = readSourceOfTruth(claim.source_of_truth)
     if (container == null) {
         errors.push(
             `${claim.id}: source of truth ${claim.source_of_truth} does not exist`
@@ -149,6 +161,78 @@ function checkPypiLatestSourceOfTruth(claim) {
                     `registry and the served file must not drift apart.`
             )
         }
+    }
+
+    const releaseRecords = releaseRecordsForClaim(claim)
+    if (!Object.keys(releaseRecords).length) {
+        errors.push(
+            `${claim.id}: ${claim.release_source_of_truth} declares no releases`
+        )
+    }
+    for (const [field, record] of Object.entries(releaseRecords)) {
+        checkReleaseRecordStructure(claim, field, record)
+    }
+}
+
+function checkReleaseRecordStructure(claim, field, record) {
+    if (record.package !== claim.packages[field]) {
+        errors.push(
+            `${claim.id}: ${field} release package ${record.package} does not ` +
+                `match ${claim.packages[field]}`
+        )
+    }
+    if (record.version !== claim.versions[field]) {
+        errors.push(
+            `${claim.id}: ${field} release version ${record.version} does not ` +
+                `match ${claim.versions[field]}`
+        )
+    }
+    if (record.source !== 'pypi') {
+        errors.push(`${claim.id}: ${field} release source must be pypi`)
+    }
+    if (record.tag !== `v${record.version}`) {
+        errors.push(
+            `${claim.id}: ${field} release tag ${record.tag} must be ` +
+                `v${record.version}`
+        )
+    }
+    if (!/^[0-9a-f]{40}$/.test(record.release_commit ?? '')) {
+        errors.push(`${claim.id}: ${field} release_commit must be an exact SHA`)
+    }
+    if (!/^[0-9a-f]{40}$/.test(record.qualified_source_commit ?? '')) {
+        errors.push(
+            `${claim.id}: ${field} qualified_source_commit must be an exact SHA`
+        )
+    }
+    if (!/^[^/]+\/[^/]+$/.test(record.github_repository ?? '')) {
+        errors.push(
+            `${claim.id}: ${field} github_repository must be owner/repository`
+        )
+    }
+    if (!Array.isArray(record.artifacts) || record.artifacts.length === 0) {
+        errors.push(`${claim.id}: ${field} release must list artifacts`)
+        return
+    }
+    const filenames = new Set()
+    for (const artifact of record.artifacts) {
+        if (!artifact.type || !artifact.filename || !artifact.url) {
+            errors.push(
+                `${claim.id}: ${field} release artifact is missing its ` +
+                    `type, filename, or URL`
+            )
+        }
+        if (!/^[0-9a-f]{64}$/.test(artifact.sha256 ?? '')) {
+            errors.push(
+                `${claim.id}: ${field} artifact ${artifact.filename} must ` +
+                    `carry an exact sha256 digest`
+            )
+        }
+        if (filenames.has(artifact.filename)) {
+            errors.push(
+                `${claim.id}: ${field} repeats artifact ${artifact.filename}`
+            )
+        }
+        filenames.add(artifact.filename)
     }
 }
 
@@ -238,7 +322,11 @@ async function fetchReleases(pkg) {
                 ([, files]) => files.length && !files.every((f) => f.yanked)
             )
             .map(([version]) => version)
-        return { version: document.info.version, published: live }
+        return {
+            version: document.info.version,
+            published: live,
+            releases: document.releases ?? {},
+        }
     } finally {
         clearTimeout(timer)
     }
@@ -256,6 +344,111 @@ function checkPypiLatestAgainstRelease(claim, latest) {
                     `${current}. Update the manifest and this registry.`
             )
         }
+    }
+
+    for (const [field, record] of Object.entries(releaseRecordsForClaim(claim))) {
+        const entry = latest[record.package]
+        if (!entry?.releases) continue
+        const files = entry.releases[record.version] ?? []
+        const published = new Map(
+            files.map((file) => [
+                file.filename,
+                {
+                    type: file.packagetype,
+                    url: file.url,
+                    sha256: file.digests?.sha256,
+                },
+            ])
+        )
+        for (const artifact of record.artifacts) {
+            const actual = published.get(artifact.filename)
+            if (!actual) {
+                errors.push(
+                    `${claim.id}: ${field} artifact ${artifact.filename} is ` +
+                        `not published on PyPI for ${record.version}`
+                )
+                continue
+            }
+            for (const key of ['type', 'url', 'sha256']) {
+                if (artifact[key] !== actual[key]) {
+                    errors.push(
+                        `${claim.id}: ${field} artifact ${artifact.filename} ` +
+                            `${key} does not match PyPI`
+                    )
+                }
+            }
+        }
+    }
+}
+
+async function fetchGithubJson(pathname) {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), HTTP_TIMEOUT_MS)
+    try {
+        const response = await fetch(`${GITHUB_API_BASE}${pathname}`, {
+            signal: controller.signal,
+            headers: {
+                Accept: 'application/vnd.github+json',
+                'User-Agent': 'openadapt-published-version-claims',
+            },
+        })
+        if (!response.ok) throw new Error(`HTTP ${response.status}`)
+        return response.json()
+    } finally {
+        clearTimeout(timer)
+    }
+}
+
+async function checkGithubReleaseRecord(claim, field, record) {
+    const repository = record.github_repository
+    try {
+        const ref = await fetchGithubJson(
+            `/repos/${repository}/git/ref/tags/${encodeURIComponent(record.tag)}`
+        )
+        let releaseCommit
+        if (ref.object?.type === 'tag') {
+            const tag = await fetchGithubJson(
+                `/repos/${repository}/git/tags/${ref.object.sha}`
+            )
+            if (tag.object?.type !== 'commit') {
+                errors.push(
+                    `${claim.id}: ${field} tag ${record.tag} does not resolve ` +
+                        `to a commit`
+                )
+                return
+            }
+            releaseCommit = tag.object.sha
+        } else if (ref.object?.type === 'commit') {
+            releaseCommit = ref.object.sha
+        } else {
+            errors.push(
+                `${claim.id}: ${field} tag ${record.tag} has unsupported target`
+            )
+            return
+        }
+        if (releaseCommit !== record.release_commit) {
+            errors.push(
+                `${claim.id}: ${field} release_commit ${record.release_commit} ` +
+                    `does not match ${record.tag} target ${releaseCommit}`
+            )
+            return
+        }
+        const commit = await fetchGithubJson(
+            `/repos/${repository}/git/commits/${releaseCommit}`
+        )
+        const qualifiedSource = commit.parents?.[0]?.sha
+        if (qualifiedSource !== record.qualified_source_commit) {
+            errors.push(
+                `${claim.id}: ${field} qualified_source_commit ` +
+                    `${record.qualified_source_commit} does not match the ` +
+                    `release commit parent ${qualifiedSource}`
+            )
+        }
+    } catch (error) {
+        warnings.push(
+            `could not verify ${repository} ${record.tag} (${error.message}); ` +
+                `skipping its release-commit comparison`
+        )
     }
 }
 
@@ -359,6 +552,16 @@ async function main() {
             if (claim.kind === 'pypi-latest')
                 checkPypiLatestAgainstRelease(claim, latest)
             if (claim.kind === 'historical') checkHistoricalLag(claim, latest)
+        }
+    }
+
+    if (!args.offline) {
+        for (const claim of claims) {
+            for (const [field, record] of Object.entries(
+                releaseRecordsForClaim(claim)
+            )) {
+                await checkGithubReleaseRecord(claim, field, record)
+            }
         }
     }
 

--- a/tests/publishedVersionClaims.test.js
+++ b/tests/publishedVersionClaims.test.js
@@ -73,6 +73,21 @@ test('the guard fails when the acknowledged benchmark lag expires', () => {
     assert.match(result.stderr, /acknowledged release lag expired/)
 })
 
+test('the guard fails when served release provenance is not an exact SHA', () => {
+    const target = path.join(root, 'public', 'status.json')
+    const original = fs.readFileSync(target, 'utf8')
+    try {
+        const status = JSON.parse(original)
+        status.releases.flow.release_commit = 'not-a-sha'
+        fs.writeFileSync(target, `${JSON.stringify(status, null, 4)}\n`)
+        const result = run(['--offline'])
+        assert.equal(result.status, 1)
+        assert.match(result.stderr, /flow release_commit must be an exact SHA/)
+    } finally {
+        fs.writeFileSync(target, original)
+    }
+})
+
 test('every historical claim states the build and date it was measured on', () => {
     for (const claim of registry.claims) {
         if (claim.kind !== 'historical') continue

--- a/tests/statusManifest.test.js
+++ b/tests/statusManifest.test.js
@@ -159,3 +159,31 @@ test('status manifest encodes exact component versions', () => {
         Object.keys(REGISTERED_VERSIONS.packages).sort()
     )
 })
+
+test('status manifest binds current releases to source and artifacts', () => {
+    assert.equal(
+        REGISTERED_VERSIONS.release_source_of_truth,
+        'public/status.json#/releases'
+    )
+
+    for (const [role, release] of Object.entries(manifest.releases)) {
+        assert.equal(release.package, REGISTERED_VERSIONS.packages[role])
+        assert.equal(release.version, manifest.versions[role])
+        assert.equal(release.source, 'pypi')
+        assert.equal(release.tag, `v${release.version}`)
+        assert.match(release.github_repository, /^[^/]+\/[^/]+$/)
+        assert.match(release.release_commit, /^[0-9a-f]{40}$/)
+        assert.match(release.qualified_source_commit, /^[0-9a-f]{40}$/)
+
+        assert.ok(release.artifacts.length > 0)
+        for (const artifact of release.artifacts) {
+            assert.ok(artifact.type)
+            assert.ok(artifact.filename)
+            assert.match(
+                artifact.url,
+                /^https:\/\/files\.pythonhosted\.org\//
+            )
+            assert.match(artifact.sha256, /^[0-9a-f]{64}$/)
+        }
+    }
+})


### PR DESCRIPTION
## Summary

- publish Launcher 1.12.0 and Flow 1.30.0 in the canonical public status record
- bind both releases to their GitHub release commit, qualified source commit, PyPI artifacts, and exact SHA-256 hashes
- extend the existing daily drift check to verify PyPI files and GitHub tag lineage
- keep lifecycle, maturity, substrate, and marketing claims unchanged

## Coordination

OpenAdapt PR #1088 merged as `870f2d6820e50ac4ac6a4e6bba2c0bc2f533d216`. Launcher 1.12.0 then published and the launcher manifest reconciled on `main`. Its Launcher 1.12.0 and Flow 1.30.0 artifact URLs and hashes match this public status update.

## Validation

- `node scripts/check_published_version_claims.mjs` against live PyPI and GitHub
- `npm test` (186 tests)
- `npx next build`
- `node --test tests/publishedVersionClaims.test.js tests/statusManifest.test.js tests/aiDiscoverability.test.js`
