### PR TITLE
fix(deps): bump dompurify to 3.4.13 to resolve XSS advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2929,9 +2929,9 @@
             "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
         },
         "node_modules/dompurify": {
-            "version": "3.4.12",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-            "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+            "version": "3.4.13",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+            "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
@@ -10147,9 +10147,9 @@
             "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
         },
         "dompurify": {
-            "version": "3.4.12",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-            "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+            "version": "3.4.13",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+            "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
             "requires": {
                 "@types/trusted-types": "^2.0.7"
             }


### PR DESCRIPTION
## Summary
- Resolves Dependabot alert #14: `dompurify` <= 3.4.12 has a medium-severity XSS advisory (GHSA), fixed in 3.4.13.
- `dompurify` is a **transitive** dependency, pulled in via `posthog-js@1.399.2`. It is not listed in `package.json`.
- Fixed with `npm update dompurify`, which resolved the transitive resolution from 3.4.12 to 3.4.13 (the first patched version) without any `package.json` change or override needed.
- Only `package-lock.json` changed (12 lines: two `dompurify` entries, version/resolved/integrity).

## Test plan
- [x] `npm ci` — clean install succeeds
- [x] `npm ls dompurify` — confirms `dompurify@3.4.13` resolved via `posthog-js@1.399.2` after `npm ci`
- [x] `npm test` — 193/193 tests pass
- [x] `npm run build` — production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)