### PR TITLE
feat(trust): mark SSO, installer signing, and SOC 2 as planned

### DIFF
--- a/pages/security.js
+++ b/pages/security.js
@@ -77,13 +77,13 @@ const summary = [
         area: 'Identity, access & tenancy',
         anchor: 'access',
         status: 'core',
-        note: 'Org RBAC, row-level tenant isolation, and TOTP step-up protect platform administration; SSO / SAML / SCIM is not included.',
+        note: 'Org RBAC, row-level tenant isolation, and TOTP step-up protect platform administration; SSO / SAML / SCIM is planned and not yet included.',
     },
     {
         area: 'Release integrity',
         anchor: 'release-integrity',
         status: 'provenance',
-        note: 'Build provenance today; code signing not yet — desktop is unsigned/ad-hoc.',
+        note: 'Build provenance today. Installer code signing is planned; desktop is unsigned/ad-hoc until it lands, with published checksums and attestations in the meantime.',
     },
     {
         area: 'Secure development',
@@ -113,7 +113,7 @@ const summary = [
         area: 'SOC 2',
         anchor: 'assurance',
         status: 'none',
-        note: 'Internal controls and evidence are mapped; no auditor-defined observation period or SOC 2 report is held.',
+        note: 'A SOC 2 audit is planned. Internal controls and evidence are mapped; no auditor-defined observation period or SOC 2 report is held yet.',
     },
 ]
 


### PR DESCRIPTION
Trust-center gaps (SSO/SAML/SCIM, installer code signing, SOC 2) now carry a "planned" status so the list reads as a roadmap rather than a disqualification list. Founder decided 2026-08-11: planned wording, no public target dates. Subprocessor naming and the pricing ladder stay unchanged by the same decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)