### PR TITLE
docs: align public readiness and canonical quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # openadapt-web
 
-**Lifecycle: Beta**
+**Lifecycle: Internal**
+
+This label classifies the website publishing repository. It does not change the
+OpenAdapt product lifecycle in `public/status.json`, which is Beta.
 
 Source for the [openadapt.ai](https://openadapt.ai) marketing site.
 

--- a/components/Faq.js
+++ b/components/Faq.js
@@ -28,6 +28,10 @@ export const faqItems = [
         answer: 'Yes. OpenAdapt Cloud provides managed browser execution plus run history, reports, usage, and governed workflow updates. Desktop, RDP, and Citrix connect through self-hosted or customer-controlled runtimes under the same governance model. Start from the pricing section, then qualify the first workflow and its verification boundary during onboarding.',
     },
     {
+        question: 'How does OpenAdapt qualify production use?',
+        answer: 'OpenAdapt does not use one platform-wide readiness label. The product lifecycle is Beta. Each production deployment qualifies the exact workflow, application, environment, identity contract, effect verifier, data boundary, and operator responsibilities. The public Cloud readiness page checks service dependencies; it is not an SLA or a workflow certificate. A production SLA or regulated deployment is scoped separately.',
+    },
+    {
         question: 'What software does OpenAdapt work with?',
         answer: 'OpenAdapt targets repeated workflows across browser applications, Windows UI Automation, native macOS Accessibility, Linux AT-SPI, RDP, Citrix, and other remote desktop environments. Choose managed browser execution or connect a local, self-hosted, or customer-controlled runtime for desktop, remote, private-system, and regulated workflows.',
     },

--- a/components/Faq.js
+++ b/components/Faq.js
@@ -29,7 +29,7 @@ export const faqItems = [
     },
     {
         question: 'How does OpenAdapt qualify production use?',
-        answer: 'OpenAdapt does not use one platform-wide readiness label. The product lifecycle is Beta. Each production deployment qualifies the exact workflow, application, environment, identity contract, effect verifier, data boundary, and operator responsibilities. The public Cloud readiness page checks service dependencies; it is not an SLA or a workflow certificate. A production SLA or regulated deployment is scoped separately.',
+        answer: 'OpenAdapt qualifies production use per deployment, not with one platform-wide readiness label. Browser is the available end-to-end reference path. Each production deployment qualifies the exact workflow, application, environment, identity contract, effect verifier, data boundary, and operator responsibilities. The public Cloud readiness page checks service dependencies; it is not an SLA or a workflow certificate. A production SLA or regulated deployment is scoped separately.',
     },
     {
         question: 'What software does OpenAdapt work with?',

--- a/components/InstallSection.js
+++ b/components/InstallSection.js
@@ -47,9 +47,9 @@ export default function InstallSection() {
                 One command installs the OpenAdapt launcher and governed
                 workflow compiler. The same CLI records, compiles, and replays
                 across browser, Windows, macOS, Linux, RDP, and Citrix under one
-                governed loop; browser runs in production today, and the desktop
-                and remote surfaces run through customer-controlled
-                qualification. No account or hosted service is required.
+                governed loop. Browser is the reference Beta path. Desktop and
+                remote surfaces run through customer-controlled qualification.
+                No account or hosted service is required.
             </p>
 
             <div className={styles.codeContainer}>

--- a/components/InstallSection.js
+++ b/components/InstallSection.js
@@ -47,8 +47,9 @@ export default function InstallSection() {
                 One command installs the OpenAdapt launcher and governed
                 workflow compiler. The same CLI records, compiles, and replays
                 across browser, Windows, macOS, Linux, RDP, and Citrix under one
-                governed loop. Browser is the reference Beta path. Desktop and
-                remote surfaces run through customer-controlled qualification.
+                governed loop. Browser is the available end-to-end reference
+                path. Desktop and remote surfaces run through
+                customer-controlled qualification.
                 No account or hosted service is required.
             </p>
 

--- a/components/MastHead.js
+++ b/components/MastHead.js
@@ -58,8 +58,8 @@ export default function Home({ githubStats: initialGithubStats }) {
                             <p className="mt-0 mb-4 mx-auto max-w-2xl font-sans font-normal text-base md:text-lg text-ink-2">
                                 OpenAdapt compiles demonstrations into one
                                 governed loop across browser, desktop, RDP, and
-                                Citrix. Browser runs in production today;
-                                desktop, RDP, and Citrix run through
+                                Citrix. Browser is the reference Beta path.
+                                Desktop, RDP, and Citrix run through
                                 customer-controlled qualification. It verifies
                                 consequential results and halts when it cannot
                                 prove the intended outcome.

--- a/components/MastHead.js
+++ b/components/MastHead.js
@@ -58,7 +58,8 @@ export default function Home({ githubStats: initialGithubStats }) {
                             <p className="mt-0 mb-4 mx-auto max-w-2xl font-sans font-normal text-base md:text-lg text-ink-2">
                                 OpenAdapt compiles demonstrations into one
                                 governed loop across browser, desktop, RDP, and
-                                Citrix. Browser is the reference Beta path.
+                                Citrix. Browser is the available end-to-end
+                                reference path.
                                 Desktop, RDP, and Citrix run through
                                 customer-controlled qualification. It verifies
                                 consequential results and halts when it cannot

--- a/components/ProductStatus.js
+++ b/components/ProductStatus.js
@@ -48,10 +48,10 @@ export default function ProductStatus() {
                     treated as interchangeable.
                 </p>
                 <p className="mx-auto mt-3 max-w-3xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
-                    Browser is the reference Beta path. Desktop, RDP, and
-                    Citrix run through customer-controlled qualification. Each
-                    surface carries its own measured acceptance evidence,
-                    published per surface in the{' '}
+                    Browser is the available end-to-end reference path.
+                    Desktop, RDP, and Citrix run through customer-controlled
+                    qualification. Each surface carries its own measured
+                    acceptance evidence, published per surface in the{' '}
                     <a
                         href="https://docs.openadapt.ai/get-started/what-works-today/"
                         target="_blank"

--- a/components/ProductStatus.js
+++ b/components/ProductStatus.js
@@ -48,10 +48,10 @@ export default function ProductStatus() {
                     treated as interchangeable.
                 </p>
                 <p className="mx-auto mt-3 max-w-3xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
-                    Browser runs in production today; desktop, RDP, and Citrix
-                    run through customer-controlled qualification. Each surface
-                    carries its own measured acceptance evidence, published per
-                    surface in the{' '}
+                    Browser is the reference Beta path. Desktop, RDP, and
+                    Citrix run through customer-controlled qualification. Each
+                    surface carries its own measured acceptance evidence,
+                    published per surface in the{' '}
                     <a
                         href="https://docs.openadapt.ai/get-started/what-works-today/"
                         target="_blank"

--- a/components/StructuredData.js
+++ b/components/StructuredData.js
@@ -122,7 +122,7 @@ export const softwareApplicationNode = {
     softwareVersion: status.versions.launcher,
     url: SITE_URL,
     description:
-        'Open-source governed workflow compiler and runtime. Demonstrate a bounded, repeated GUI task once; OpenAdapt compiles it into a deterministic local program, replays it with zero model calls on healthy runs, and re-resolves, proposes a reviewable repair, or halts when the interface drifts. Runs on browser, Windows, macOS, Linux, RDP, and Citrix/VDI surfaces.',
+        'Open-source Beta governed workflow compiler and runtime. Demonstrate a bounded, repeated GUI task once; OpenAdapt compiles it into a deterministic local program, replays it with zero model calls on healthy runs, and re-resolves, proposes a reviewable repair, or halts when the interface drifts. Runs on browser, Windows, macOS, Linux, RDP, and Citrix/VDI surfaces. Production use qualifies the exact workflow, application, environment, identity contract, and effect verifier.',
     downloadUrl: 'https://pypi.org/project/openadapt/',
     installUrl: `${SITE_URL}/download`,
     softwareHelp: { '@type': 'CreativeWork', url: 'https://docs.openadapt.ai' },

--- a/components/StructuredData.js
+++ b/components/StructuredData.js
@@ -122,7 +122,7 @@ export const softwareApplicationNode = {
     softwareVersion: status.versions.launcher,
     url: SITE_URL,
     description:
-        'Open-source Beta governed workflow compiler and runtime. Demonstrate a bounded, repeated GUI task once; OpenAdapt compiles it into a deterministic local program, replays it with zero model calls on healthy runs, and re-resolves, proposes a reviewable repair, or halts when the interface drifts. Runs on browser, Windows, macOS, Linux, RDP, and Citrix/VDI surfaces. Production use qualifies the exact workflow, application, environment, identity contract, and effect verifier.',
+        'Open-source governed workflow compiler and runtime. Demonstrate a bounded, repeated GUI task once; OpenAdapt compiles it into a deterministic local program, replays it with zero model calls on healthy runs, and re-resolves, proposes a reviewable repair, or halts when the interface drifts. Runs on browser, Windows, macOS, Linux, RDP, and Citrix/VDI surfaces. Production use qualifies the exact workflow, application, environment, identity contract, and effect verifier.',
     downloadUrl: 'https://pypi.org/project/openadapt/',
     installUrl: `${SITE_URL}/download`,
     softwareHelp: { '@type': 'CreativeWork', url: 'https://docs.openadapt.ai' },

--- a/pages/index.js
+++ b/pages/index.js
@@ -59,7 +59,7 @@ const softwareSchema = {
     applicationCategory: 'DeveloperApplication',
     operatingSystem: 'Windows, macOS, Linux',
     description:
-        'Beta governed execution for consequential UI-only work across browser, Windows, macOS, Linux, RDP, and Citrix, with identity gates, effect verification, and fail-closed outcomes. Production use qualifies the exact workflow, application, environment, identity contract, and effect verifier.',
+        'Governed execution for consequential UI-only work across browser, Windows, macOS, Linux, RDP, and Citrix, with identity gates, effect verification, and fail-closed outcomes. Production use qualifies the exact workflow, application, environment, identity contract, and effect verifier.',
     url: 'https://openadapt.ai',
     downloadUrl: 'https://pypi.org/project/openadapt/',
     author: {

--- a/pages/index.js
+++ b/pages/index.js
@@ -59,7 +59,7 @@ const softwareSchema = {
     applicationCategory: 'DeveloperApplication',
     operatingSystem: 'Windows, macOS, Linux',
     description:
-        'Governed execution for consequential UI-only work across browser, Windows, macOS, Linux, RDP, and Citrix, with identity gates, effect verification, and fail-closed outcomes.',
+        'Beta governed execution for consequential UI-only work across browser, Windows, macOS, Linux, RDP, and Citrix, with identity gates, effect verification, and fail-closed outcomes. Production use qualifies the exact workflow, application, environment, identity contract, and effect verifier.',
     url: 'https://openadapt.ai',
     downloadUrl: 'https://pypi.org/project/openadapt/',
     author: {

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -83,6 +83,27 @@ control plane is a separate commercial product.
 
 ---
 
+## Q: How does OpenAdapt qualify production use?
+
+OpenAdapt does not use one platform-wide readiness label. The product lifecycle
+is Beta. Each production deployment qualifies the exact workflow, application,
+environment, identity contract, effect verifier, data boundary, and operator
+responsibilities. The public Cloud readiness page checks service dependencies;
+it is not an SLA or a workflow certificate. The public Cloud subscription
+includes no production SLA or regulated deployment unless those terms are
+scoped separately.
+
+Desktop is a Beta supporting surface. Installer signing is a separate
+distribution property. An unsigned or ad-hoc-signed installer adds installation
+and trust friction; it does not by itself prohibit governed desktop execution.
+Attended or unattended use depends on the qualified workflow and deployment
+contract.
+
+Sources: https://openadapt.ai/status.json · https://openadapt.ai/pricing ·
+https://docs.openadapt.ai/get-started/what-works-today/
+
+---
+
 ## Q: How is this different from an AI computer-use agent?
 
 A computer-use agent is the right tool for **novel** work, because it re-plans
@@ -418,9 +439,11 @@ interface is the only integration point.
 
 ## Q: How do I try it, and how long does it take?
 
-1. `pip install openadapt`, or install the Desktop cockpit. Both lanes are
-   first-class and produce the same portable recording, workflow bundle, and run
-   evidence. https://openadapt.ai/start
+1. Run `python -m pip install --upgrade 'openadapt[browser]'`, then
+   `openadapt quickstart`; or install the Desktop cockpit. Both lanes are
+   first-class and produce the same portable recording, workflow bundle, and
+   run evidence. Later engine commands keep the `openadapt flow` prefix.
+   https://openadapt.ai/start
 2. Run a bundled reference workflow end to end against a real open-source
    application to see record → compile → replay → verify with your own eyes.
    https://openadapt.ai/templates

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -85,13 +85,13 @@ control plane is a separate commercial product.
 
 ## Q: How does OpenAdapt qualify production use?
 
-OpenAdapt does not use one platform-wide readiness label. The product lifecycle
-is Beta. Each production deployment qualifies the exact workflow, application,
-environment, identity contract, effect verifier, data boundary, and operator
-responsibilities. The public Cloud readiness page checks service dependencies;
-it is not an SLA or a workflow certificate. The public Cloud subscription
-includes no production SLA or regulated deployment unless those terms are
-scoped separately.
+OpenAdapt qualifies production use per deployment, not with one platform-wide
+readiness label. Browser is the available end-to-end reference path. Each
+production deployment qualifies the exact workflow, application, environment,
+identity contract, effect verifier, data boundary, and operator responsibilities.
+The public Cloud readiness page checks service dependencies; it is not an SLA or
+a workflow certificate. The public Cloud subscription includes no production
+SLA or regulated deployment unless those terms are scoped separately.
 
 Desktop is a Beta supporting surface. Installer signing is a separate
 distribution property. An unsigned or ad-hoc-signed installer adds installation

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -11,6 +11,12 @@ OpenAdapt is for the case where the work is repetitive and consequential, the in
 - [status.json](https://openadapt.ai/status.json): The single source of truth for product lifecycle, released component versions, per-substrate availability, delivery boundary, and the linked acceptance evidence for each substrate. Public surfaces render their labels from this file. Prefer it over any prose on this site if the two ever disagree.
 - Current published versions: launcher 1.12.1, Flow (compiler/runtime) 1.31.0, capture 1.2.2, desktop 0.15.0. Product lifecycle: Beta.
 
+## How to describe production use
+
+OpenAdapt does not use one platform-wide readiness label. The product lifecycle is Beta. Each production deployment qualifies the exact workflow, application, environment, identity contract, effect verifier, data boundary, and operator responsibilities. The public Cloud readiness page checks service dependencies; it is not an SLA or a workflow certificate. The public Cloud subscription includes no production SLA or regulated deployment unless those terms are scoped separately.
+
+Desktop is a Beta supporting surface. Installer signing is a separate distribution property. An unsigned or ad-hoc-signed installer adds installation and trust friction; it does not by itself prohibit governed desktop execution. Attended or unattended use depends on the qualified workflow and deployment contract.
+
 ## Execution substrates and their evidence boundary
 
 Availability below is the released capability. It is distinct from the deployment boundary and from the bounded acceptance evidence recorded for each substrate. Exact evidence URLs are in `status.json`.
@@ -25,6 +31,7 @@ Availability below is the released capability. It is distinct from the deploymen
 
 ## Start here
 
+- Canonical local tutorial: `python -m pip install --upgrade 'openadapt[browser]'`, then `openadapt quickstart`. Do not remove the `openadapt` command prefix from later engine commands.
 - [Run it locally, free](https://openadapt.ai/start): The CLI and the Desktop cockpit are equal first-class local lanes. Both produce the same portable recording, workflow bundle, and run evidence. Cloud is an optional handoff after local success.
 - [Install](https://openadapt.ai/download): Installers and `pip install openadapt`, then `openadapt flow ...`.
 - [How it works](https://openadapt.ai/how-it-works): Record and compile, replay deterministically, then resolve, repair, or halt under drift — including what a compiled program actually contains and where repair stops.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -13,7 +13,7 @@ OpenAdapt is for the case where the work is repetitive and consequential, the in
 
 ## How to describe production use
 
-OpenAdapt does not use one platform-wide readiness label. The product lifecycle is Beta. Each production deployment qualifies the exact workflow, application, environment, identity contract, effect verifier, data boundary, and operator responsibilities. The public Cloud readiness page checks service dependencies; it is not an SLA or a workflow certificate. The public Cloud subscription includes no production SLA or regulated deployment unless those terms are scoped separately.
+OpenAdapt qualifies production use per deployment, not with one platform-wide readiness label. Browser is the available end-to-end reference path. Each production deployment qualifies the exact workflow, application, environment, identity contract, effect verifier, data boundary, and operator responsibilities. The public Cloud readiness page checks service dependencies; it is not an SLA or a workflow certificate. The public Cloud subscription includes no production SLA or regulated deployment unless those terms are scoped separately.
 
 Desktop is a Beta supporting surface. Installer signing is a separate distribution property. An unsigned or ad-hoc-signed installer adds installation and trust friction; it does not by itself prohibit governed desktop execution. Attended or unattended use depends on the qualified workflow and deployment contract.
 

--- a/tests/aiDiscoverability.test.js
+++ b/tests/aiDiscoverability.test.js
@@ -368,10 +368,11 @@ test('every anchor cited by llms.txt exists in a rendered component', () => {
     }
 })
 
-test('llms.txt and llms-full.txt never promote a substrate above status.json', () => {
+test('llms.txt and llms-full.txt bind a production-ready claim to immutable evidence', () => {
     // status.json is the canonical machine-readable source of truth. The
     // superseded ladder wording ("early access", "exploratory") must never
-    // reappear, and neither may an unqualified "production ready" claim.
+    // reappear. The target browser claim can publish only with an immutable
+    // acceptance record from the engine or hosted control-plane repository.
     for (const [name, text] of [
         ['llms.txt', llms],
         ['llms-full.txt', llmsFull],
@@ -381,11 +382,19 @@ test('llms.txt and llms-full.txt never promote a substrate above status.json', (
             /early access|exploratory|design.partner/i,
             `${name} must not use the superseded maturity ladder`
         )
-        assert.doesNotMatch(
-            text,
-            /production[- ]ready|fully certified|guaranteed/i,
-            `${name} must not overstate maturity`
-        )
+        assert.doesNotMatch(text, /fully certified|guaranteed/i)
+        if (/production[- ]ready/i.test(text)) {
+            assert.match(
+                text,
+                /production-ready for qualified browser workflows/i,
+                `${name} must scope a production-ready claim to qualified browser workflows`
+            )
+            assert.match(
+                text,
+                /Production-readiness evidence:\s+https:\/\/github\.com\/OpenAdaptAI\/(?:openadapt-flow|openadapt-cloud)\/blob\/[0-9a-f]{40}\/\S+/i,
+                `${name} must bind the production-ready claim to an immutable acceptance record`
+            )
+        }
         for (const substrate of status.substrates) {
             assert.ok(
                 text.includes(substrate.name),
@@ -448,8 +457,8 @@ test('llms files make production qualification workflow-specific', () => {
         ['llms-full.txt', llmsFull],
     ]) {
         const normalized = text.replace(/\s+/g, ' ')
-        assert.match(normalized, /does not use one platform-wide readiness label/i)
-        assert.match(normalized, /product lifecycle is Beta/i)
+        assert.match(normalized, /not with one platform-wide readiness label/i)
+        assert.match(normalized, /Browser is the available end-to-end reference path/i)
         assert.match(normalized, /Each production deployment qualifies the exact workflow/i)
         assert.match(normalized, /not an SLA or a workflow certificate/i)
         assert.match(normalized, /Desktop is a Beta supporting surface/i)

--- a/tests/aiDiscoverability.test.js
+++ b/tests/aiDiscoverability.test.js
@@ -439,6 +439,43 @@ test('llms-full.txt states the limitations rather than only the strengths', () =
     )
 })
 
+test('llms files make production qualification workflow-specific', () => {
+    // Assistants often collapse a Beta product and a live service dependency
+    // check into one global verdict. The published answer must keep product,
+    // workflow, deployment, and SLA status separate.
+    for (const [name, text] of [
+        ['llms.txt', llms],
+        ['llms-full.txt', llmsFull],
+    ]) {
+        const normalized = text.replace(/\s+/g, ' ')
+        assert.match(normalized, /does not use one platform-wide readiness label/i)
+        assert.match(normalized, /product lifecycle is Beta/i)
+        assert.match(normalized, /Each production deployment qualifies the exact workflow/i)
+        assert.match(normalized, /not an SLA or a workflow certificate/i)
+        assert.match(normalized, /Desktop is a Beta supporting surface/i)
+        assert.doesNotMatch(
+            normalized,
+            /no unattended desktop runs/i,
+            `${name} must not invent a platform-wide unattended-run prohibition`
+        )
+    }
+})
+
+test('llms files publish the canonical launcher quickstart', () => {
+    for (const [name, text] of [
+        ['llms.txt', llms],
+        ['llms-full.txt', llmsFull],
+    ]) {
+        assert.match(text, /python -m pip install --upgrade 'openadapt\[browser\]'/)
+        assert.match(text, /openadapt quickstart/)
+        assert.doesNotMatch(
+            text,
+            /^demo-record\b/m,
+            `${name} must not drop the launcher or engine command prefix`
+        )
+    }
+})
+
 test('llms.txt points at the canonical machine-readable status', () => {
     assert.ok(llms.includes(`${SITE}/status.json`))
     assert.ok(llms.includes(`${SITE}/llms-full.txt`))

--- a/tests/publicTruth.test.js
+++ b/tests/publicTruth.test.js
@@ -207,7 +207,8 @@ test('machine-readable use cases do not claim mortgage, LOS, or a healthcare ver
 })
 
 test('public repository declares its lifecycle state', () => {
-    assert.match(read('README.md'), /Lifecycle: Beta/)
+    assert.match(read('README.md'), /Lifecycle: Internal/)
+    assert.match(read('README.md'), /product lifecycle.*Beta/is)
 })
 
 test('lending demo media has durable synthetic evidence provenance', () => {


### PR DESCRIPTION
## Summary

- state Browser as the available end-to-end reference path without making Beta the buyer-facing destination
- make production qualification workflow-specific and keep Cloud dependency readiness separate from an SLA or workflow certificate
- publish the canonical launcher quickstart in both AI-discovery files
- classify this publishing repository as Internal
- permit the target phrase `production-ready for qualified browser workflows` only when it includes an immutable acceptance-evidence URL

## Merge gate

**Keep this pull request as a draft. Do not merge it until the hosted browser acceptance run passes.** At that point, add the immutable GitHub evidence URL and publish the exact qualified-browser production claim.

## Validation

- `npm test`: 195 passed
- `npm run verify:presentations`: 4 exact assets verified
- `npm run build`: passed; 42 routes generated
- `git diff --check`: passed

The build used the committed paper PDF fallback because this isolated environment could not fetch the release asset.