### PR TITLE
chore(manifest): refresh published versions to flow 1.32.0 and launcher 1.13.1

### DIFF
--- a/data/published-version-claims.json
+++ b/data/published-version-claims.json
@@ -33,8 +33,8 @@
             "kind": "pypi-latest",
             "source_of_truth": "public/status.json#/versions",
             "release_source_of_truth": "public/status.json#/releases",
-            "verified_on": "2026-08-11",
-            "evidence": "Published package and GitHub release records on 2026-08-11: openadapt 1.12.1, openadapt-flow 1.31.0, openadapt-capture 1.2.2, openadapt-desktop 0.15.0.",
+            "verified_on": "2026-08-20",
+            "evidence": "Published package and GitHub release records on 2026-08-20: openadapt 1.13.1, openadapt-flow 1.32.0, openadapt-capture 1.2.2, openadapt-desktop 0.15.0.",
             "packages": {
                 "launcher": "openadapt",
                 "flow": "openadapt-flow",
@@ -42,8 +42,8 @@
                 "desktop": "openadapt-desktop"
             },
             "versions": {
-                "launcher": "1.12.1",
-                "flow": "1.31.0",
+                "launcher": "1.13.1",
+                "flow": "1.32.0",
                 "capture": "1.2.2",
                 "desktop": "0.15.0"
             }
@@ -58,12 +58,12 @@
             "evidence": "openadapt-flow cbec44c2c2f355d5cc04a72ea9267e2d6ea68ac6 declares version = \"0.1.0\" in pyproject.toml and describes as v0.1.0-24-gcbec44c; v0.2.0 (2026-07-11) is the first release tag containing it.",
             "verified_on": "2026-07-27",
             "acknowledged_release_lag": {
-                "as_of_release": "1.31.0",
-                "releases_behind": 77,
-                "minor_releases_behind_first_containing_tag": 29,
-                "acknowledged_on": "2026-08-11",
+                "as_of_release": "1.32.0",
+                "releases_behind": 78,
+                "minor_releases_behind_first_containing_tag": 30,
+                "acknowledged_on": "2026-08-20",
                 "review_by": "2026-10-31",
-                "note": "76 live openadapt-flow releases postdate 0.1.0; v0.2.0 is the first release tag containing the pinned commit. The machine-readable minor_releases_behind_first_containing_tag field records the release distance without duplicating it in this note. These are historical measurements and are deliberately NOT edited. The lag may not grow past the acknowledged value without a decision, and the acknowledgement expires on review_by so it cannot be renewed by silence. Refreshing means re-running the benchmarks: MockMed is deterministic and CI-reproducible; OpenEMR runs against a shared public demo that resets daily, so its refresh is a field run whose numbers will legitimately differ. Re-acknowledged on 2026-08-11 for v1.31.0 (76 -> 77). review_by is deliberately UNCHANGED at 2026-10-31: restating the count is not a decision to keep waiting, and this acknowledgement must still expire on its original date."
+                "note": "76 live openadapt-flow releases postdate 0.1.0; v0.2.0 is the first release tag containing the pinned commit. The machine-readable minor_releases_behind_first_containing_tag field records the release distance without duplicating it in this note. These are historical measurements and are deliberately NOT edited. The lag may not grow past the acknowledged value without a decision, and the acknowledgement expires on review_by so it cannot be renewed by silence. Refreshing means re-running the benchmarks: MockMed is deterministic and CI-reproducible; OpenEMR runs against a shared public demo that resets daily, so its refresh is a field run whose numbers will legitimately differ. Re-acknowledged on 2026-08-11 for v1.31.0 (76 -> 77). review_by is deliberately UNCHANGED at 2026-10-31: restating the count is not a decision to keep waiting, and this acknowledgement must still expire on its original date. Re-acknowledged on 2026-08-20 for v1.32.0 (77 -> 78). review_by stays 2026-10-31 for the same reason as the prior re-acknowledgement."
             },
             "attribution_required": [
                 {

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -78,7 +78,7 @@ control plane is a separate commercial product.
 
 - Engine source: https://github.com/OpenAdaptAI/openadapt-flow
 - Install route: https://github.com/OpenAdaptAI/OpenAdapt and `pip install openadapt`
-- Current published versions: launcher 1.12.1, Flow 1.31.0, capture 1.2.2, desktop 0.15.0
+- Current published versions: launcher 1.13.1, Flow 1.32.0, capture 1.2.2, desktop 0.15.0
 - Product lifecycle: Beta
 
 ---

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -9,7 +9,7 @@ OpenAdapt is for the case where the work is repetitive and consequential, the in
 ## Canonical machine-readable status
 
 - [status.json](https://openadapt.ai/status.json): The single source of truth for product lifecycle, released component versions, per-substrate availability, delivery boundary, and the linked acceptance evidence for each substrate. Public surfaces render their labels from this file. Prefer it over any prose on this site if the two ever disagree.
-- Current published versions: launcher 1.12.1, Flow (compiler/runtime) 1.31.0, capture 1.2.2, desktop 0.15.0. Product lifecycle: Beta.
+- Current published versions: launcher 1.13.1, Flow (compiler/runtime) 1.32.0, capture 1.2.2, desktop 0.15.0. Product lifecycle: Beta.
 
 ## Execution substrates and their evidence boundary
 

--- a/public/status.json
+++ b/public/status.json
@@ -1,57 +1,57 @@
 {
     "$comment": "Canonical machine-readable release, capability, evidence, and deployment status for OpenAdapt. Served at https://openadapt.ai/status.json and consumed by status-aware public surfaces and tests. OpenAdapt is one Beta product across browser, Windows, macOS, Linux, RDP, and Citrix/VDI. Capability availability is distinct from the deployment boundary and from the bounded evidence scope recorded for each substrate.",
-    "generated_at": "2026-08-11",
+    "generated_at": "2026-08-20",
     "product_lifecycle": "Beta",
     "versions": {
-        "launcher": "1.12.1",
-        "flow": "1.31.0",
+        "launcher": "1.13.1",
+        "flow": "1.32.0",
         "capture": "1.2.2",
         "desktop": "0.15.0"
     },
     "releases": {
         "launcher": {
             "package": "openadapt",
-            "version": "1.12.1",
+            "version": "1.13.1",
             "source": "pypi",
             "github_repository": "OpenAdaptAI/OpenAdapt",
-            "tag": "v1.12.1",
-            "release_commit": "aabecc8e2c3807f35d9bf3092fa302004df2e55e",
-            "qualified_source_commit": "c6fbd7535a638514d0366da1dcbe201244d30ea8",
+            "tag": "v1.13.1",
+            "release_commit": "7f69923e164a028893e7d570658aa5dcbebc121f",
+            "qualified_source_commit": "bb91e4b744fff1199241f48adf31761224771e11",
             "artifacts": [
                 {
                     "type": "bdist_wheel",
-                    "filename": "openadapt-1.12.1-py3-none-any.whl",
-                    "url": "https://files.pythonhosted.org/packages/b4/0b/af4c42a91d55795f73cf1f3891aa65d40eea1cfb38c6b4cd93f5df4733c7/openadapt-1.12.1-py3-none-any.whl",
-                    "sha256": "1b469f1171ed1c0e3d9165ba31cb9eedd94f55165eba66b4ddbb7c7305683b28"
+                    "filename": "openadapt-1.13.1-py3-none-any.whl",
+                    "url": "https://files.pythonhosted.org/packages/ac/5b/1c651245dde5124e9bca11be36b7b241ca5a9cd85678d1893718212b5a36/openadapt-1.13.1-py3-none-any.whl",
+                    "sha256": "e168825bf3f553e537786c2ab24a9da726f96a8043ac5d52604cb95d83e6ea3b"
                 },
                 {
                     "type": "sdist",
-                    "filename": "openadapt-1.12.1.tar.gz",
-                    "url": "https://files.pythonhosted.org/packages/db/a2/65234ea92c9dc24b289449a35a28741144b5e6ea0ec582dd5eb65b5b2269/openadapt-1.12.1.tar.gz",
-                    "sha256": "d1756fcbc09c106f9172af13c4682ab3c73be9c6afacc078f78f1dc87078eef7"
+                    "filename": "openadapt-1.13.1.tar.gz",
+                    "url": "https://files.pythonhosted.org/packages/14/3a/c5a50e0fdd22985453734e560507749dfb82485b9085dd08d666ca706ae3/openadapt-1.13.1.tar.gz",
+                    "sha256": "ba6a6c86bd21eebf31ed59b4d0f5c0860f16aed479826da8cf4dc6a5288b5de0"
                 }
             ]
         },
         "flow": {
             "package": "openadapt-flow",
-            "version": "1.31.0",
+            "version": "1.32.0",
             "source": "pypi",
             "github_repository": "OpenAdaptAI/openadapt-flow",
-            "tag": "v1.31.0",
-            "release_commit": "2d225dea9a0ad29ca84ce1b037cc0ac671367e28",
-            "qualified_source_commit": "faf9945537d4011baeb36ce5f063b6e1814903e6",
+            "tag": "v1.32.0",
+            "release_commit": "d1b054c718d60465fb8a2e1853e6a84c7f26dec2",
+            "qualified_source_commit": "02e68bf9e658d4d2147243fc33e69b4f2dd70b21",
             "artifacts": [
                 {
                     "type": "bdist_wheel",
-                    "filename": "openadapt_flow-1.31.0-py3-none-any.whl",
-                    "url": "https://files.pythonhosted.org/packages/a7/20/dd8ccd56afb0c3c369f13adb85695acf4f0495a0a61553f576ec0977ab19/openadapt_flow-1.31.0-py3-none-any.whl",
-                    "sha256": "81133db1528ad1bb1f26e3fcb6aea61b0651db6d905cf2e4943e8383c1f3d29c"
+                    "filename": "openadapt_flow-1.32.0-py3-none-any.whl",
+                    "url": "https://files.pythonhosted.org/packages/a9/88/eb6f1c789298c1dd0ff92050cd6bf0ef562eff328e97c1c13e5e1b1a8e03/openadapt_flow-1.32.0-py3-none-any.whl",
+                    "sha256": "d58dcf8b7e54c8a45199db4390a588dc261bb754c5ab2af0fdb540e44cb6bb8a"
                 },
                 {
                     "type": "sdist",
-                    "filename": "openadapt_flow-1.31.0.tar.gz",
-                    "url": "https://files.pythonhosted.org/packages/9b/47/07ea24067eaa93cc2416a432df83508fe9d2f77bdf7955298580f2e1d35f/openadapt_flow-1.31.0.tar.gz",
-                    "sha256": "cf1fc356d14d267df82be188de3e9a3575734f18f46ef91ac8075438cc731540"
+                    "filename": "openadapt_flow-1.32.0.tar.gz",
+                    "url": "https://files.pythonhosted.org/packages/df/25/f8adeb01a20a7034d1f6dc24d7da4ca04c23d7182fd39c8eeafbfe6a3153/openadapt_flow-1.32.0.tar.gz",
+                    "sha256": "c3125f16c1b12420dff4a3af4c3d676e1d267cd961cb9e5f4825beb372b7f97e"
                 }
             ]
         }


### PR DESCRIPTION
Release aftercare for `openadapt-flow` 1.32.0, plus a launcher entry that was
about to go stale on its own.

## What changed

| Component | Was | Now |
| --- | --- | --- |
| `openadapt-flow` | 1.31.0 | **1.32.0** |
| `openadapt` (launcher) | 1.12.1 | **1.13.1** |

`openadapt-flow` 1.32.0 was published today from the qualified `main` SHA
`02e68bf`, and carries the structured push-result contract (#369).

The launcher move is **not** part of that release. `openadapt` 1.13.1 was
published today at 01:12 UTC, after the last daily claims check ran on
2026-08-19. The networked check already fails on it, so tonight's scheduled run
would have gone red:

```
DRIFT: status-manifest-component-versions: public/status.json#/versions
advertises openadapt 1.12.1 as the current release, but PyPI's newest is 1.13.1.
```

Both are the same manifest refresh, so they land together.

## Surfaces

All four surfaces the registry binds:

- `public/status.json` - version, tag, release commit, qualified source commit,
  and the exact PyPI filename, URL, and SHA-256 for each artifact.
- `public/llms.txt` and `public/llms-full.txt` - the published-version line.
- `data/published-version-claims.json` - the claim, its evidence line, and the
  acknowledged lag.

Every artifact fact is read from the PyPI JSON API and the GitHub tag objects.
Nothing here is hand-typed.

## The acknowledged lag

`headline-benchmark-engine-build` advances 77 -> 78 for v1.32.0, which is what
the checker independently observes:

```
headline-benchmark-engine-build: measured on openadapt-flow 0.1.0,
78 published releases behind 1.32.0 (acknowledged 78, review by 2026-10-31).
```

`review_by` stays **2026-10-31**, following the precedent already recorded in
the note: restating the count is not a decision to keep waiting, so the
acknowledgement must still expire on its original date.

## Verification

- `node scripts/check_published_version_claims.mjs` (network enabled) -> exit 0,
  "Published version claims are consistent (5 claims)." This verifies each
  release commit against its tag object and each `qualified_source_commit`
  against that commit's first parent.
- `node scripts/check_published_version_claims.mjs --offline` -> exit 0.
- `node --test tests/*.test.js` -> 193 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)