### PR TITLE
feat: sharpen homepage buyer positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,11 @@
 
 Source for the [openadapt.ai](https://openadapt.ai) marketing site.
 
-OpenAdapt is a governed demonstration compiler for GUI workflows: record a task
-once, compile it, and replay it deterministically with zero model calls on the
-healthy path. When replay cannot verify what it is about to do, it halts instead
-of guessing. Every execution substrate is first-class under one governed loop:
-browser, Windows, macOS, Linux, RDP, and Citrix/VDI. OpenAdapt is local-first
-and open-core (MIT); managed cloud is optional.
+OpenAdapt provides verified automation from demonstration. It compiles repeated
+GUI work into deterministic programs for browser, Windows, macOS, Linux, RDP,
+and Citrix/VDI. Healthy runs make no model calls. OpenAdapt checks the declared
+result before it reports `VERIFIED` and stops when the required evidence is
+missing. The local runtime is MIT licensed; managed Cloud is optional.
 
 This repository is the public website only. Installers and the unified CLI live
 in [OpenAdaptAI/OpenAdapt](https://github.com/OpenAdaptAI/OpenAdapt), the

--- a/components/BusinessDecisionPreview.js
+++ b/components/BusinessDecisionPreview.js
@@ -17,15 +17,14 @@ export default function BusinessDecisionPreview() {
                 </figcaption>
             </figure>
             <div className={styles.copy}>
-                <p className={styles.eyebrow}>Human judgment capture</p>
+                <p className={styles.eyebrow}>Human decision</p>
                 <h2 id="business-decision-title">
-                    Keep institutional judgment inside the workflow.
+                    Ask a person when the workflow reaches a real judgment call.
                 </h2>
                 <p>
-                    When a workflow reaches a policy choice, OpenAdapt asks one
-                    authorized person one clear question. The choice selects a
-                    reviewed branch. The runner checks the live state again
-                    before it continues.
+                    OpenAdapt pauses at an approved policy choice and asks one
+                    authorized person one clear question. Before it continues,
+                    the runner checks the live application again.
                 </p>
                 <a
                     className={styles.demoLink}

--- a/components/CommercialOffer.js
+++ b/components/CommercialOffer.js
@@ -17,7 +17,7 @@ export default function CommercialOffer({ hostedOffer }) {
             <div className="mx-auto max-w-5xl">
                 <p className="eyebrow text-center">Commercial offer</p>
                 <h2 className="mx-auto mt-2 max-w-3xl text-center font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl">
-                    Qualify the workflow before scaling the deployment
+                    Start with one workflow
                 </h2>
                 <div className="mt-8 flex flex-col gap-5 rounded-2xl border border-hairline bg-panel p-5 sm:flex-row sm:items-center sm:justify-between md:px-7">
                     <div>
@@ -50,7 +50,7 @@ export default function CommercialOffer({ hostedOffer }) {
                             From $15,000
                         </h3>
                         <p className="mt-3 text-sm leading-relaxed text-ink-2">
-                            In a ten-business-day target, we assess one named
+                            We target a decision within ten business days. We assess one named
                             workflow, application, environment, identity contract,
                             effect verifier, failure boundary, deployment path,
                             and ROI. You receive a qualified prototype and a signed
@@ -76,10 +76,10 @@ export default function CommercialOffer({ hostedOffer }) {
                             <p className="mt-2 text-sm font-semibold text-ink">{runCap}</p>
                         )}
                         <p className="mt-3 text-sm leading-relaxed text-ink-2">
-                            A separate managed subscription for approved workflows,
-                            run history, evidence, and governed updates. Enterprise
-                            qualification, regulated deployment, and SLAs are scoped
-                            separately.
+                            Run approved browser workflows with managed runners,
+                            run history, evidence, and controlled updates. We scope
+                            enterprise qualification, regulated deployment, and
+                            SLAs separately.
                         </p>
                         <Link href="/pricing#cloud-preview" className="btn-ghost-ink mt-6 inline-block">
                             See Cloud and enterprise pricing
@@ -87,7 +87,8 @@ export default function CommercialOffer({ hostedOffer }) {
                     </article>
                 </div>
                 <p className="mt-5 text-center text-sm leading-relaxed text-ink-2">
-                    Building vertical software or operating workflows for clients?{' '}
+                    OpenAdapt Execute gives vertical software and service providers{' '}
+                    a verified last-mile execution API.{' '}
                     <Link href="/execute" className="font-medium text-accent hover:underline">
                         Explore OpenAdapt Execute.
                     </Link>

--- a/components/DashboardShowcase.js
+++ b/components/DashboardShowcase.js
@@ -179,14 +179,13 @@ export default function DashboardShowcase() {
                         className={styles.heading}
                         id="cloud-product-heading"
                     >
-                        From approved workflow to reviewable outcome.
+                        See every approved workflow, run, and result in one place
                     </h2>
                     <p className={styles.summary}>
-                        This is the hosted product running today at
-                        app.openadapt.ai. Workflows, runs, evidence, and
-                        reports stay connected in one reviewable dashboard.
-                        When a run needs a person, the same decision arrives
-                        as one focused mobile handoff.
+                        The hosted product at app.openadapt.ai connects each
+                        workflow version to its runs, evidence, and reports.
+                        When a run needs a person, it sends one focused mobile
+                        request.
                     </p>
                 </div>
 

--- a/components/FinalQualificationCta.js
+++ b/components/FinalQualificationCta.js
@@ -4,17 +4,17 @@ export default function FinalQualificationCta() {
     return (
         <section className="bg-ground px-5 py-20 md:py-28">
             <div className="mx-auto max-w-3xl text-center">
-                <p className="eyebrow">Bring the real workflow</p>
+                <p className="eyebrow">Workflow fit review</p>
                 <h2 className="mt-2 font-display text-3xl font-semibold tracking-tight text-ink md:text-4xl">
-                    Qualify one workflow
+                    See if one workflow fits
                 </h2>
                 <p className="mx-auto mt-4 max-w-2xl text-sm leading-relaxed text-ink-2 md:text-base">
-                    Bring the actual application, environment, workflow, and
-                    success condition. We will determine whether it should be
-                    automated and what verified production requires.
+                    Tell us the application, environment, repeated task, and
+                    how you confirm the result. We will assess the fit, main
+                    risks, verifier, and deployment path.
                 </p>
                 <Link href="/qualify" className="btn-ink mt-7 inline-block">
-                    Start the qualification
+                    Start the fit review
                 </Link>
             </div>
         </section>

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -151,9 +151,9 @@ export default function Footer({
                             <span className="font-semibold">Adapt</span>
                         </a>
                         <p className={styles.tagline}>
-                            OpenAdapt compiles demonstrated GUI workflows into
-                            deterministic, locally executable programs, and
-                            halts when it can’t verify the result.
+                            OpenAdapt turns demonstrated GUI work into
+                            deterministic automation and verifies the result
+                            before it reports success.
                         </p>
                         <a
                             href={qualificationHref}

--- a/components/HowItWorksCondensed.js
+++ b/components/HowItWorksCondensed.js
@@ -5,21 +5,21 @@
 const steps = [
     {
         number: '1',
-        name: 'Demonstrate and qualify',
+        name: 'Show the task',
         description:
-            'Show one bounded task. Review its program, risks, identities, effects, fault cases, and supported environment before certifying it.',
+            'Record one bounded workflow in its real application. OpenAdapt retains the actions and the evidence around each step.',
     },
     {
         number: '2',
-        name: 'Deploy in your boundary',
+        name: 'Qualify the program',
         description:
-            'Run approved browser workloads in managed execution or keep sensitive desktop, RDP, Citrix, private-network, and restricted-egress work customer-controlled.',
+            'Review the compiled steps, identities, expected results, failure cases, and target environment before you approve a version.',
     },
     {
         number: '3',
-        name: 'Execute, verify, and repair',
+        name: 'Run and verify',
         description:
-            'Healthy runs use no generative-model calls. OpenAdapt proves the declared effect, halts on uncertainty, and subjects every candidate repair to the workflow contract.',
+            'Replay the approved program. OpenAdapt checks the declared result, stops on uncertainty, and keeps each repair behind the same review gates.',
     },
 ]
 
@@ -32,11 +32,11 @@ export default function HowItWorksCondensed() {
             <div className="mx-auto max-w-5xl">
                 <p className="eyebrow text-center">How it works</p>
                 <h2 className="mx-auto mt-2 max-w-2xl text-center font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl">
-                    From demonstration to verified operation
+                    One demonstrated task becomes one approved program
                 </h2>
                 <p className="mx-auto mt-3 max-w-2xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
-                    One lifecycle connects qualification, execution, evidence,
-                    and governed change.
+                    The recording starts the work. Qualification defines what
+                    the program may do and what evidence counts as success.
                 </p>
                 <ol className="mt-9 grid gap-4 md:grid-cols-3">
                     {steps.map((step) => (

--- a/components/MastHead.js
+++ b/components/MastHead.js
@@ -1,8 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
 
-import ReplayHero from '@components/ReplayHero'
-import BusinessDecisionPreview from '@components/BusinessDecisionPreview'
 import { track, EVENTS } from 'utils/analytics'
 import useLiveRepositoryStats from 'utils/useLiveRepositoryStats'
 
@@ -25,7 +23,7 @@ export default function Home({ githubStats: initialGithubStats }) {
                             </div>
                             <div className="mb-4 flex flex-wrap items-center justify-center gap-3">
                                 <span className={styles.heroPill}>
-                                    FREE TO RUN LOCALLY · MIT OPEN SOURCE
+                                    VERIFIED AUTOMATION FROM DEMONSTRATION
                                 </span>
                                 {githubStats && githubStats.stars > 0 && (
                                     <a
@@ -53,48 +51,51 @@ export default function Home({ githubStats: initialGithubStats }) {
                                 )}
                             </div>
                             <h1 className="font-display text-2xl md:text-3xl mt-0 mb-4 font-semibold tracking-tight text-ink">
-                                Automate the UI-only work your APIs can&rsquo;t reach.
+                                Automate the work your systems still make people do.
                             </h1>
                             <p className="mt-0 mb-4 mx-auto max-w-2xl font-sans font-normal text-base md:text-lg text-ink-2">
-                                OpenAdapt compiles demonstrations into one
-                                governed loop across browser, desktop, RDP, and
-                                Citrix. Browser runs in production today;
-                                desktop, RDP, and Citrix run through
-                                customer-controlled qualification. It verifies
-                                consequential results and halts when it cannot
-                                prove the intended outcome.
+                                Show OpenAdapt a repeated task. It compiles the
+                                demonstration into a deterministic program for
+                                browser, desktop, RDP, or Citrix, then verifies
+                                the result before it reports success.
                             </p>
                             <p className={styles.fitLine}>
-                                Verified business effects · fail-closed execution ·
-                                customer-controlled sensitive data
+                                Healthy runs make no model calls. An unverified
+                                production run stops.
                             </p>
                             <div id="register">
                                 <div className="flex flex-wrap items-center justify-center gap-3 mt-0 mb-4">
                                     <Link
                                         className={styles.heroCloud}
                                         href="/qualify"
+                                        data-testid="workflow-fit-cta"
                                         onClick={() =>
                                             track(EVENTS.HERO_CTA_CLICK, {
                                                 cta: 'qualify_one_workflow',
                                             })
                                         }
                                     >
-                                        Qualify one workflow
+                                        See if your workflow fits
                                     </Link>
                                     <Link
                                         className="btn-ghost-ink"
-                                        href="/book"
-                                        data-testid="book-call-cta"
+                                        href="#demo"
+                                        data-testid="demo-cta"
                                         onClick={() =>
                                             track(EVENTS.HERO_CTA_CLICK, {
-                                                cta: 'book_call',
+                                                cta: 'watch_demo',
                                             })
                                         }
                                     >
-                                        Book a 30-minute call
+                                        Watch the 65-second demo
                                     </Link>
+                                </div>
+                                <p className="mb-8 text-sm leading-relaxed text-ink-3">
+                                    <code className="rounded border border-hairline bg-panel px-2 py-1 text-ink">
+                                        pip install openadapt
+                                    </code>
+                                    <span aria-hidden="true"> · </span>
                                     <Link
-                                        className="btn-ghost-ink"
                                         href="/start"
                                         data-testid="local-quickstart-cta"
                                         onClick={() =>
@@ -102,37 +103,13 @@ export default function Home({ githubStats: initialGithubStats }) {
                                                 cta: 'run_locally_free',
                                             })
                                         }
+                                        className="font-medium text-accent underline"
                                     >
-                                        Run locally for free
+                                        Run it locally
                                     </Link>
-                                    <a
-                                        className="btn-ghost-ink"
-                                        href="https://app.openadapt.ai/demo"
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        data-testid="cloud-demo-cta"
-                                        onClick={() =>
-                                            track(EVENTS.HERO_CTA_CLICK, {
-                                                cta: 'explore_cloud_demo',
-                                            })
-                                        }
-                                    >
-                                        Explore the app
-                                    </a>
-                                </div>
-                                <p className="mb-8 text-sm leading-relaxed text-ink-3">
-                                    <code className="rounded border border-hairline bg-panel px-2 py-1 text-ink">
-                                        pip install openadapt
-                                    </code>
                                     <span aria-hidden="true"> · </span>
-                                    MIT licensed
-                                    <span aria-hidden="true"> · </span>
-                                    No account or Cloud required
+                                    MIT licensed · no account required
                                 </p>
-                            </div>
-                            <div className="flex flex-col align-center justify-center px-4 min-w-0 max-w-full overflow-hidden">
-                                <ReplayHero />
-                                <BusinessDecisionPreview />
                             </div>
                         </div>
                     </div>

--- a/components/MastHead.module.css
+++ b/components/MastHead.module.css
@@ -22,9 +22,9 @@
     color: var(--ink-3);
 }
 
-/* Primary enterprise CTA. The adjacent ghost action is the equally direct
-   local/open-source path, while the install command below carries the
-   no-account trust contract without adding a third competing button. */
+/* Primary workflow-fit CTA. The adjacent action jumps to the evidence demo.
+   The compact install line keeps the local, no-account path available without
+   adding a third competing button. */
 .heroCloud {
     display: inline-flex;
     align-items: center;

--- a/components/ProductStatus.js
+++ b/components/ProductStatus.js
@@ -18,7 +18,7 @@ const boundaries = [
 const executionSurfaces = [
     {
         title: 'Browser',
-        detail: 'Combine DOM, accessibility, visual, and interaction evidence for governed web execution.',
+        detail: 'Use DOM, accessibility, visual, and interaction evidence to run approved web workflows.',
     },
     {
         title: 'Native desktop',
@@ -26,7 +26,7 @@ const executionSurfaces = [
     },
     {
         title: 'Remote applications',
-        detail: 'Drive RDP, Citrix Workspace, and VDI externally through pixels, keyboard, and mouse while preserving identity, policy, verification, and audit.',
+        detail: 'Operate RDP, Citrix Workspace, and VDI through pixels, keyboard, and mouse, with the same identity and result checks.',
     },
 ]
 
@@ -37,15 +37,14 @@ export default function ProductStatus() {
             className="border-b border-hairline bg-panel px-5 py-20 md:py-28"
         >
             <div className="mx-auto max-w-5xl">
-                <p className="eyebrow text-center">Cross-surface execution</p>
+                <p className="eyebrow text-center">Browser, desktop, and remote</p>
                 <h2 className="mx-auto mt-2 max-w-2xl text-center font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl">
-                    One governance model across the interfaces you use
+                    Use one verified workflow across the interfaces you use
                 </h2>
                 <p className="mx-auto mt-3 max-w-3xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
-                    Portable workflow intent stays separate from each
-                    environment-specific binding, so DOM selectors,
-                    accessibility elements, and remote visual anchors are never
-                    treated as interchangeable.
+                    OpenAdapt keeps the workflow and its safety checks separate
+                    from the controls used in each application. Each surface
+                    uses the strongest evidence it provides.
                 </p>
                 <p className="mx-auto mt-3 max-w-3xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
                     Browser runs in production today; desktop, RDP, and Citrix

--- a/components/Qualification.js
+++ b/components/Qualification.js
@@ -1,4 +1,5 @@
 const fits = [
+    'A person can demonstrate the task from start to finish.',
     'Inputs are mostly structured and the business intent stays stable.',
     'The target application has no practical write API for the last mile.',
     'A wrong action has operational, financial, or compliance cost.',
@@ -13,19 +14,18 @@ export default function Qualification() {
             className="border-b border-hairline bg-panel px-5 py-20 md:py-28"
         >
             <div className="mx-auto max-w-5xl">
-                <p className="eyebrow text-center">The right fit</p>
+                <p className="eyebrow text-center">A strong first workflow</p>
                 <h2 className="mx-auto mt-2 max-w-2xl text-center font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl">
-                    Where OpenAdapt creates the most value
+                    Start where an error has a cost and the result can be checked
                 </h2>
                 <p className="mx-auto mt-3 max-w-2xl text-center text-sm leading-relaxed text-ink-2 md:text-base">
-                    Start with one repeated workflow trapped behind a browser,
-                    desktop, RDP, or Citrix interface. OpenAdapt turns it into
-                    governed execution with evidence of the result.
+                    A good candidate repeats often, follows stable rules, and
+                    ends in a result that another system or session can verify.
                 </p>
                 <div className="mx-auto mt-8 max-w-4xl">
                     <article className="rounded-2xl border border-hairline bg-ground p-6 md:p-8">
                         <h3 className="font-display text-lg font-semibold tracking-tight text-ink">
-                            A strong first workflow
+                            Use this quick fit check
                         </h3>
                         <ul className="mt-5 grid gap-3 text-sm leading-relaxed text-ink-2 md:grid-cols-2 md:gap-x-8">
                             {fits.map((item) => (

--- a/components/ReplayHero.js
+++ b/components/ReplayHero.js
@@ -32,8 +32,9 @@ export default function ReplayHero() {
                 <a
                     className="btn-ink"
                     href="https://app.openadapt.ai/demo"
+                    data-testid="cloud-demo-cta"
                 >
-                    Open the end-to-end demo
+                    Explore the full demo
                 </a>
                 <Link className="btn-ghost-ink" href="/compare">
                     Compare methods and results

--- a/components/StructuredData.js
+++ b/components/StructuredData.js
@@ -71,7 +71,7 @@ export const organizationNode = {
     },
     image: `${SITE_URL}/og.png`,
     description:
-        'OpenAdapt builds an open-source governed workflow compiler and runtime for repeated GUI work in applications without a usable API. A demonstrated task is compiled into a deterministic local program; healthy runs make no model calls; every consequential run ends verified or halted with a preserved report.',
+        'OpenAdapt provides verified automation from demonstration. It compiles repeated GUI work into deterministic local programs, makes no model calls on healthy runs, and keeps the evidence behind each typed outcome.',
     foundingDate: '2023',
     sameAs: SAME_AS,
     knowsAbout: [
@@ -84,7 +84,7 @@ export const organizationNode = {
         'Healthcare revenue cycle automation',
         'Electronic health record workflow automation',
     ],
-    slogan: 'Automate the UI-only work your APIs cannot reach.',
+    slogan: 'Automate the work your systems still make people do.',
 }
 
 export const websiteNode = {
@@ -94,7 +94,7 @@ export const websiteNode = {
     alternateName: 'OpenAdapt',
     url: SITE_URL,
     description:
-        'OpenAdapt compiles demonstrated GUI workflows into deterministic, locally executable programs, verifies the intended business effect against the system of record, and halts when the execution contract cannot be proved.',
+        'OpenAdapt compiles demonstrated GUI work into deterministic automation and verifies the declared result before it reports success.',
     publisher: { '@id': ORGANIZATION_ID },
     inLanguage: 'en',
 }
@@ -122,7 +122,7 @@ export const softwareApplicationNode = {
     softwareVersion: status.versions.launcher,
     url: SITE_URL,
     description:
-        'Open-source governed workflow compiler and runtime. Demonstrate a bounded, repeated GUI task once; OpenAdapt compiles it into a deterministic local program, replays it with zero model calls on healthy runs, and re-resolves, proposes a reviewable repair, or halts when the interface drifts. Runs on browser, Windows, macOS, Linux, RDP, and Citrix/VDI surfaces.',
+        'Open-source compiler and governed runtime for repeated GUI work. OpenAdapt turns a bounded demonstration into a deterministic local program, replays it with zero model calls on healthy runs, and re-resolves, proposes a governed repair, or halts when the interface drifts. Runs on browser, Windows, macOS, Linux, RDP, and Citrix/VDI surfaces.',
     downloadUrl: 'https://pypi.org/project/openadapt/',
     installUrl: `${SITE_URL}/download`,
     softwareHelp: { '@type': 'CreativeWork', url: 'https://docs.openadapt.ai' },

--- a/components/TrustSummary.js
+++ b/components/TrustSummary.js
@@ -13,9 +13,9 @@ export default function TrustSummary() {
     return (
         <section className="border-b border-hairline bg-panel px-5 py-20 md:py-28">
             <div className="mx-auto max-w-5xl">
-                <p className="eyebrow text-center">Trust by construction</p>
+                <p className="eyebrow text-center">Data and control</p>
                 <h2 className="mx-auto mt-2 max-w-3xl text-center font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl">
-                    Keep control of the data, action, and evidence
+                    Keep sensitive work in the boundary you approve
                 </h2>
                 <ul className="mx-auto mt-8 grid max-w-4xl gap-4 text-sm leading-relaxed text-ink-2 md:grid-cols-2">
                     {controls.map((control) => (
@@ -34,4 +34,3 @@ export default function TrustSummary() {
         </section>
     )
 }
-

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -41,12 +41,12 @@ describe('public product truth', () => {
         cy.visit('/')
     })
 
-    it('leads with the governed compiler and qualifies the buyer', () => {
+    it('leads with the buyer outcome and routes to a workflow review', () => {
         cy.get('h1').should(
             'contain.text',
-            'Automate the UI-only work your APIs can’t reach.'
+            'Automate the work your systems still make people do.'
         )
-        cy.contains('a', 'Qualify one workflow').should(
+        cy.get('[data-testid="workflow-fit-cta"]').should(
             'have.attr',
             'href',
             '/qualify'

--- a/cypress/e2e/public-surface-coherence.cy.js
+++ b/cypress/e2e/public-surface-coherence.cy.js
@@ -38,7 +38,7 @@ describe('public surface coherence', () => {
             .and('have.attr', 'href', '/qualify')
         cy.get('[data-testid="demo-cta"]')
             .should('be.visible')
-            .and('have.attr', 'href', '#demo')
+            .and('have.attr', 'href', '/#demo')
         cy.get('[data-testid="local-quickstart-cta"]')
             .should('be.visible')
             .and('have.attr', 'href', '/start')

--- a/cypress/e2e/public-surface-coherence.cy.js
+++ b/cypress/e2e/public-surface-coherence.cy.js
@@ -33,14 +33,16 @@ describe('public surface coherence', () => {
             'contain.text',
             'stars on OpenAdapt'
         )
-        cy.contains('a', 'Qualify one workflow')
+        cy.get('[data-testid="workflow-fit-cta"]')
             .should('be.visible')
             .and('have.attr', 'href', '/qualify')
+        cy.get('[data-testid="demo-cta"]')
+            .should('be.visible')
+            .and('have.attr', 'href', '#demo')
         cy.get('[data-testid="local-quickstart-cta"]')
             .should('be.visible')
             .and('have.attr', 'href', '/start')
         cy.get('[data-testid="cloud-demo-cta"]')
-            .should('be.visible')
             .and(
                 'have.attr',
                 'href',

--- a/cypress/e2e/reference-demo.cy.js
+++ b/cypress/e2e/reference-demo.cy.js
@@ -90,19 +90,55 @@ describe('shared real-application demo', () => {
                 .should(($video) => {
                     expect($video[0].videoWidth).to.be.greaterThan(0)
                 })
-                .then(($video) => {
-                    const video = $video[0]
-                    return new Cypress.Promise((resolve) => {
-                        video.currentTime = 0.59
-                        setTimeout(() => {
-                            video.playbackRate = 0.25
-                            video.play().then(resolve)
-                        }, 100)
+            cy.get('@player').then(($player) => {
+                const player = $player[0]
+                const video = player.querySelector('video')
+                const Observer =
+                    player.ownerDocument.defaultView.MutationObserver
+
+                return new Cypress.Promise((resolve, reject) => {
+                    let timeoutId
+                    let playbackTimer
+                    const fail = (error) => {
+                        observer.disconnect()
+                        video.pause()
+                        clearTimeout(timeoutId)
+                        clearTimeout(playbackTimer)
+                        reject(error)
+                    }
+                    const finishIfBound = () => {
+                        if (
+                            player.getAttribute('data-decoded-frame-index') !== '1'
+                        ) {
+                            return false
+                        }
+                        video.pause()
+                        observer.disconnect()
+                        clearTimeout(timeoutId)
+                        clearTimeout(playbackTimer)
+                        resolve()
+                        return true
+                    }
+                    const observer = new Observer(finishIfBound)
+                    video.pause()
+                    observer.observe(player, {
+                        attributes: true,
+                        attributeFilter: ['data-decoded-frame-index'],
                     })
+                    timeoutId = setTimeout(() => {
+                        fail(new Error('Decoded frame 1 was not observed'))
+                    }, 10000)
+
+                    if (finishIfBound()) return
+                    playbackTimer = setTimeout(() => {
+                        video.currentTime = 0.59
+                        video.playbackRate = 0.25
+                        video.play().catch(fail)
+                    }, 100)
                 })
+            })
             cy.get('@player')
                 .should('have.attr', 'data-decoded-frame-index', '1')
-                .then(($player) => $player.find('video')[0].pause())
                 .should('contain.text', 'Evidence')
                 .find('[data-decoded-frame-index="1"]')
                 .should('be.visible')

--- a/data/customerCaseStudies.js
+++ b/data/customerCaseStudies.js
@@ -38,7 +38,7 @@ export const RVU_RECOVERY_CASE = {
         'Disclosure: Dr. Abrich is the founder’s brother. This is OpenAdapt’s founding deployment, not independent validation.',
     title: 'Recovering missed billables with automated RVU audits',
     summary:
-        'OpenAdapt automated the repetitive EMR evidence collection and spreadsheet reconciliation behind Dr. Victor Abrich’s monthly RVU audits, helping recover about $75,000 a year in missed billables while saving several hours of physician time each month.',
+        'OpenAdapt now handles the repetitive EMR evidence collection and spreadsheet reconciliation behind Dr. Victor Abrich’s monthly RVU audits. The workflow helps recover about $75,000 a year in missed billables and saves several hours of physician time each month.',
     challenge:
         'Reviewing every relevant chart and reconciling the findings against monthly RVU reports took several hours each month, and manual review still missed billable work.',
     workflow: [

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,16 +1,16 @@
 import Head from 'next/head'
 
+import BusinessDecisionPreview from '@components/BusinessDecisionPreview'
 import CommercialOffer from '@components/CommercialOffer'
-import ContributeSection from '@components/ContributeSection'
 import CustomerCaseStudy from '@components/CustomerCaseStudy'
 import DashboardShowcase from '@components/DashboardShowcase'
 import FinalQualificationCta from '@components/FinalQualificationCta'
 import Footer from '@components/Footer'
-import HeroProofStrip from '@components/HeroProofStrip'
 import HowItWorksCondensed from '@components/HowItWorksCondensed'
 import MastHead from '@components/MastHead'
 import ProductStatus from '@components/ProductStatus'
 import Qualification from '@components/Qualification'
+import ReplayHero from '@components/ReplayHero'
 import Reveal from '@components/Reveal'
 import TrustSummary from '@components/TrustSummary'
 import { OPENADAPT_STATS_SNAPSHOT } from '../data/repositoryStats'
@@ -31,7 +31,7 @@ const organizationSchema = {
         height: 512,
     },
     description:
-        'The verified execution layer for consequential work trapped behind human interfaces. OpenAdapt governs UI-only work across browser, desktop, RDP, and Citrix.',
+        'Verified automation from demonstration. OpenAdapt compiles repeated work into deterministic programs and verifies the result before it reports success.',
     foundingDate: '2023',
     sameAs: [
         'https://github.com/OpenAdaptAI/OpenAdapt',
@@ -48,7 +48,7 @@ const organizationSchema = {
         'Effect Verification',
         'Governed Automation',
     ],
-    slogan: 'Automate the UI-only work your APIs cannot reach.',
+    slogan: 'Automate the work your systems still make people do.',
 }
 
 const softwareSchema = {
@@ -59,7 +59,7 @@ const softwareSchema = {
     applicationCategory: 'DeveloperApplication',
     operatingSystem: 'Windows, macOS, Linux',
     description:
-        'Governed execution for consequential UI-only work across browser, Windows, macOS, Linux, RDP, and Citrix, with identity gates, effect verification, and fail-closed outcomes.',
+        'OpenAdapt compiles demonstrated work into deterministic programs for browser, Windows, macOS, Linux, RDP, and Citrix, then verifies the declared result.',
     url: 'https://openadapt.ai',
     downloadUrl: 'https://pypi.org/project/openadapt/',
     author: {
@@ -76,8 +76,7 @@ const softwareSchema = {
         priceCurrency: 'USD',
     },
     featureList: [
-        'Compile a demonstrated, bounded GUI workflow',
-        'Compile demonstrations into editable automation scripts',
+        'Compile a demonstrated GUI workflow into an inspectable program',
         'Local replay with zero per-run model cost',
         'Deterministic UI re-resolution with auditable bundle updates',
         'Optional AI-assisted repair subject to configured verification and policy',
@@ -95,7 +94,7 @@ const websiteSchema = {
     alternateName: 'OpenAdapt',
     url: 'https://openadapt.ai',
     description:
-        'OpenAdapt automates UI-only work that APIs cannot reach, verifies the intended business effect, and halts when the execution contract cannot be proved.',
+        'OpenAdapt turns demonstrated GUI work into deterministic automation and verifies the result before it reports success.',
     publisher: {
         '@type': 'Organization',
         name: 'OpenAdapt.AI',
@@ -123,9 +122,9 @@ export async function getStaticProps() {
 
 export default function Home({ githubStats, hostedOffer }) {
     const currentGithubStats = githubStats || OPENADAPT_STATS_SNAPSHOT
-    const title = 'OpenAdapt — Verified execution for UI-only work'
+    const title = 'OpenAdapt: Verified automation from demonstration'
     const description =
-        'Automate consequential UI-only work across browser, desktop, RDP, and Citrix. OpenAdapt verifies the business effect and halts on uncertainty.'
+        'Automate the work your systems still make people do. OpenAdapt compiles a demonstration into a deterministic program and verifies the result.'
 
     return (
         <div>
@@ -158,28 +157,37 @@ export default function Home({ githubStats, hostedOffer }) {
                 />
             </Head>
             <MastHead githubStats={currentGithubStats} />
-            <HeroProofStrip />
             <div id="customer-result">
                 <Reveal>
                     <CustomerCaseStudy />
                 </Reveal>
             </div>
+            <section
+                id="demo"
+                className="border-b border-hairline bg-panel px-5 py-20 md:py-28"
+            >
+                <div className="mx-auto max-w-5xl">
+                    <div className="mx-auto mb-9 max-w-3xl text-center">
+                        <p className="eyebrow">See it run</p>
+                        <h2 className="mt-2 font-display text-2xl font-semibold tracking-tight text-ink md:text-3xl">
+                            From a demonstrated task to a verified result
+                        </h2>
+                        <p className="mx-auto mt-3 max-w-2xl text-sm leading-relaxed text-ink-2 md:text-base">
+                            Watch the source demonstration, the compiled replay,
+                            and the independent result check in three real
+                            applications.
+                        </p>
+                    </div>
+                    <ReplayHero />
+                    <BusinessDecisionPreview />
+                </div>
+            </section>
             <Reveal><HowItWorksCondensed /></Reveal>
             <Reveal><Qualification /></Reveal>
             <Reveal><ProductStatus /></Reveal>
             <Reveal><CommercialOffer hostedOffer={hostedOffer} /></Reveal>
             <Reveal><DashboardShowcase /></Reveal>
             <Reveal><TrustSummary /></Reveal>
-            {/*
-             * Contribute-for-credits sits after the trust summary because it
-             * is a commons / flywheel message that extends the open-source
-             * trust story: sanitized contributions strengthen the shared
-             * hardening corpus. It stays out of the hero, the commercial
-             * offer, and the closing qualification CTA so it never interrupts
-             * the buying narrative. Early access, opt-in, links to
-             * /contribute.
-             */}
-            <Reveal><ContributeSection /></Reveal>
             <Reveal><FinalQualificationCta /></Reveal>
             <Footer repositoryStats={currentGithubStats} />
         </div>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,10 +1,10 @@
 # OpenAdapt.AI
 
-> OpenAdapt is an open-source (MIT) governed workflow compiler and runtime for repeated GUI work in applications that have no usable API. You demonstrate a bounded task once; OpenAdapt compiles the recording into a deterministic, locally executable program. A healthy replay makes zero model calls. When the interface drifts, OpenAdapt deterministically re-resolves the target from retained evidence, optionally proposes a reviewable repair, accepts a human correction, or halts. Every consequential run ends `VERIFIED` or `HALTED` with a preserved run report; a run is judged by an out-of-band check of the system of record, not by the acting session declaring itself successful.
+> OpenAdapt provides verified automation from demonstration. Show it a repeated GUI task and it compiles the recording into a deterministic, locally executable program. A healthy replay makes zero model calls. When the interface drifts, OpenAdapt re-resolves the target from retained evidence, proposes a governed repair, accepts an authorized correction, or halts. A governed run reports a typed outcome and keeps the evidence used to reach it. `VERIFIED` means the declared result check passed.
 
 ## What it is, in one line
 
-OpenAdapt is for the case where the work is repetitive and consequential, the interface is visual or integration-hostile, and a silently wrong write would be worse than no write at all.
+OpenAdapt fits repetitive, consequential work where the application has no practical API and another system or session can verify the result.
 
 ## Canonical machine-readable status
 
@@ -15,19 +15,19 @@ OpenAdapt is for the case where the work is repetitive and consequential, the in
 
 Availability below is the released capability. It is distinct from the deployment boundary and from the bounded acceptance evidence recorded for each substrate. Exact evidence URLs are in `status.json`.
 
-- **Browser — Available.** Local, managed OpenAdapt Cloud, or customer-controlled. The reference loop: record, compile, and replay end to end with no model calls on healthy runs.
-- **Windows (UI Automation) — Available.** Local or customer-controlled. Accepted WinForms matrix: 3/3 independently verified effects, 3/3 stale targets refused, 3/3 ambiguous targets refused, zero silent incorrect successes, zero over-halts, zero model calls.
-- **macOS (Accessibility) — Available.** Local or customer-controlled. Binds one exact application window and refuses ambiguity before input. Counted TextEdit evidence: 3/3 exact-byte effects plus a two-window ambiguity refusal.
-- **Linux (AT-SPI) — Available.** Local or customer-controlled. Required current-main CI: 3/3 exact-file effects, 3/3 ambiguity refusals, 3/3 stale-target refusals.
-- **RDP — Available.** Local or customer-controlled. Two accepted bounded results: 3/3 real Aardwolf-over-Windows transport/input effects, and a full record-to-compile-to-governed-replay lifecycle over a real FreeRDP round trip with 3/3 healthy effects and 3/3 drift safe-halts.
-- **Citrix / VDI — Available.** Local or customer-controlled. The shipped `--backend citrix` path binds the exact Citrix Workspace window and runs the same identity, effect, policy, and halt contracts. Qualification boundary, stated explicitly: the accepted artifact records `ica_hdx_accepted=false`. It qualifies the Citrix Workspace-window backend contract over a no-DOM canvas stand-in (3/3 healthy effects, 3/3 drift safe-halts), not a counted real ICA/HDX batch. An exact ICA/HDX environment is qualified separately before consequential use.
-- **Hosted Cloud — Beta.** Managed browser runner and control plane, with run history, reporting, usage, and governed workflow updates. Windows, macOS, Linux, RDP, and Citrix/VDI execute through local, self-hosted, or customer-controlled runtimes; they are not silently moved into the shared managed browser boundary.
+- **Browser: Available.** Local, managed OpenAdapt Cloud, or customer-controlled. The reference loop records, compiles, and replays end to end with no model calls on healthy runs.
+- **Windows (UI Automation): Available.** Local or customer-controlled. Accepted WinForms matrix: 3/3 independently verified effects, 3/3 stale targets refused, 3/3 ambiguous targets refused, zero silent incorrect successes, zero over-halts, zero model calls.
+- **macOS (Accessibility): Available.** Local or customer-controlled. Binds one exact application window and refuses ambiguity before input. Counted TextEdit evidence: 3/3 exact-byte effects plus a two-window ambiguity refusal.
+- **Linux (AT-SPI): Available.** Local or customer-controlled. Required current-main CI: 3/3 exact-file effects, 3/3 ambiguity refusals, 3/3 stale-target refusals.
+- **RDP: Available.** Local or customer-controlled. Two accepted bounded results: 3/3 real Aardwolf-over-Windows transport/input effects, and a full record-to-compile-to-governed-replay lifecycle over a real FreeRDP round trip with 3/3 healthy effects and 3/3 drift safe-halts.
+- **Citrix / VDI: Available.** Local or customer-controlled. The shipped `--backend citrix` path binds the exact Citrix Workspace window and runs the same identity, effect, policy, and halt contracts. Qualification boundary, stated explicitly: the accepted artifact records `ica_hdx_accepted=false`. It qualifies the Citrix Workspace-window backend contract over a no-DOM canvas stand-in (3/3 healthy effects, 3/3 drift safe-halts), not a counted real ICA/HDX batch. An exact ICA/HDX environment is qualified separately before consequential use.
+- **Hosted Cloud: Beta.** The managed browser runner and control plane include run history, reporting, usage, and governed workflow updates. Windows, macOS, Linux, RDP, and Citrix/VDI execute through local, self-hosted, or customer-controlled runtimes. OpenAdapt does not move them into the shared managed browser boundary.
 
 ## Start here
 
 - [Run it locally, free](https://openadapt.ai/start): The CLI and the Desktop cockpit are equal first-class local lanes. Both produce the same portable recording, workflow bundle, and run evidence. Cloud is an optional handoff after local success.
 - [Install](https://openadapt.ai/download): Installers and `pip install openadapt`, then `openadapt flow ...`.
-- [How it works](https://openadapt.ai/how-it-works): Record and compile, replay deterministically, then resolve, repair, or halt under drift — including what a compiled program actually contains and where repair stops.
+- [How it works](https://openadapt.ai/how-it-works): Record and compile, replay deterministically, then resolve, repair, or halt under drift. The page shows what a compiled program contains and where repair stops.
 - [Documentation](https://docs.openadapt.ai): Installation, quick start, CLI reference, and what works today.
 
 ## Decide whether it fits
@@ -44,7 +44,7 @@ Availability below is the released capability. It is distinct from the deploymen
 ## Trust, safety, and data boundaries
 
 - [Trust center](https://openadapt.ai/security): Screenshot, model, secret, report, certification, and commercial deployment boundaries; build provenance, code signing, and SBOM.
-- [Safety model](https://openadapt.ai/safety): The refusal ladder — what makes a run halt rather than guess, with worked cases.
+- [Safety model](https://openadapt.ai/safety): The refusal ladder shows what makes a run halt rather than guess, with worked cases.
 - [Privacy module](https://github.com/OpenAdaptAI/openadapt-privacy): Open-source PII/PHI scrubbing used before any artifact leaves the local boundary.
 - [Privacy policy](https://openadapt.ai/privacy-policy) · [Terms of service](https://openadapt.ai/terms-of-service)
 
@@ -53,7 +53,7 @@ Availability below is the released capability. It is distinct from the deploymen
 - [Research](https://openadapt.ai/research): The technical paper, machine-checked benchmark constants, methodology, limitations, and artifact checklist.
 - [Technical paper (PDF)](https://openadapt.ai/paper): Reader-facing paper page; source lives in the openadapt-flow repository.
 - [Workflow reference catalog](https://openadapt.ai/workflows): Every reference workflow with its substrate, oracle, and status label reconciled against `status.json`.
-- [Customer Case Study — RVU Audits](https://openadapt.ai/customers/rvu-audit-heart-care): A board-certified cardiac electrophysiologist's monthly Cerner PowerChart evidence collection and RVU spreadsheet reconciliation, helping recover about $75,000 a year in missed billables while saving several hours of physician time each month. Disclosed on the page: the physician is the founder's brother, this is OpenAdapt's founding deployment rather than independent validation, and the figures are preliminary pending customer confirmation. The same page separately reports a reproducible six-month synthetic governed-validation cohort: 2,880 cases (480/month), 2,856 VERIFIED (99.2%), 18 HALTED, 6 FAILED before actuation, zero observed silent incorrect successes, zero model calls, $0.03 modeled reference cost per case.
+- [Customer Case Study: RVU Audits](https://openadapt.ai/customers/rvu-audit-heart-care): A board-certified cardiac electrophysiologist's monthly Cerner PowerChart evidence collection and RVU spreadsheet reconciliation, helping recover about $75,000 a year in missed billables while saving several hours of physician time each month. Disclosed on the page: the physician is the founder's brother, this is OpenAdapt's founding deployment rather than independent validation, and the figures are preliminary pending customer confirmation. The same page separately reports a reproducible six-month synthetic governed-validation cohort: 2,880 cases (480/month), 2,856 VERIFIED (99.2%), 18 HALTED, 6 FAILED before actuation, zero observed silent incorrect successes, zero model calls, $0.03 modeled reference cost per case.
 
 ## Where it is used
 
@@ -68,18 +68,18 @@ Availability below is the released capability. It is distinct from the deploymen
 Every template corresponds to something that actually runs. Proven references execute end to end against real open-source applications in the `openadapt-flow` repository with system-of-record verification. Pattern templates are workflow shapes compiled from a recording of the customer's own team, anchored to those references. No template exists for a workflow that has not actually been run.
 
 - [Template gallery](https://openadapt.ai/templates): All templates with proof level, demonstrated steps, verification oracles, and CLI quickstart.
-- [Patient triage note](https://openadapt.ai/templates/patient-triage-note): Proven — the canonical tutorial on the bundled synthetic clinic app, including the clinical-write policy gate refusing an under-verified bundle.
-- [OpenEMR patient note](https://openadapt.ai/templates/openemr-patient-note): Proven — 18-step add-patient-note workflow verified against the record itself, with a published field run of 20/20 compiled trials at zero model calls, measured 2026-07-08 on openadapt-flow 0.1.0 (a pre-v0.2.0 source build).
-- [Frappe lending loan application](https://openadapt.ai/templates/frappe-loan-application): Proven — verified by independent REST, SQL, and exact table-delta oracles.
-- [openIMIS claim intake](https://openadapt.ai/templates/openimis-claim-intake): Proven — verified by a direct SQL claim-row oracle.
-- [Dental insurance eligibility checks](https://openadapt.ai/templates/dental-insurance-eligibility): Pattern — a practice's own payer-portal verification workflow, compiled from its own recording.
-- [Insurance eligibility and coverage checks](https://openadapt.ai/templates/insurance-eligibility-check): Pattern — repeated carrier-portal lookups with per-case parameters and halt-on-ambiguity.
-- [New patient record entry](https://openadapt.ai/templates/new-patient-record): Pattern — registration re-keying with per-patient parameters, anchored to the OpenEMR reference.
-- [Report export with arrival verification](https://openadapt.ai/templates/report-export-verification): Pattern — exports accepted only when exactly one conforming file actually arrived, with optional SHA-256 content identity.
+- [Patient triage note](https://openadapt.ai/templates/patient-triage-note): Proven. The canonical tutorial uses the bundled synthetic clinic app. Its clinical-write policy gate refuses an under-verified bundle.
+- [OpenEMR patient note](https://openadapt.ai/templates/openemr-patient-note): Proven. The 18-step add-patient-note workflow checks the record itself. A published field run completed 20/20 compiled trials with zero model calls, measured 2026-07-08 on openadapt-flow 0.1.0 (a pre-v0.2.0 source build).
+- [Frappe lending loan application](https://openadapt.ai/templates/frappe-loan-application): Proven. Independent REST, SQL, and exact table-delta oracles verify the result.
+- [openIMIS claim intake](https://openadapt.ai/templates/openimis-claim-intake): Proven. A direct SQL claim-row oracle verifies the result.
+- [Dental insurance eligibility checks](https://openadapt.ai/templates/dental-insurance-eligibility): Pattern. The workflow is compiled from the practice's own payer-portal demonstration.
+- [Insurance eligibility and coverage checks](https://openadapt.ai/templates/insurance-eligibility-check): Pattern. The workflow repeats carrier-portal lookups with per-case parameters and halts on ambiguity.
+- [New patient record entry](https://openadapt.ai/templates/new-patient-record): Pattern. The workflow handles registration re-keying with per-patient parameters. It is anchored to the OpenEMR reference.
+- [Report export with arrival verification](https://openadapt.ai/templates/report-export-verification): Pattern. The workflow accepts an export only when exactly one conforming file arrived. It can also check the SHA-256 content identity.
 
 ## Buy, qualify, and partner
 
-- [Pricing](https://openadapt.ai/pricing): Three ways to start. **OpenAdapt Community** — free, MIT-licensed local runtime and qualification tools, no Cloud account required. **Workflow Qualification Sprint** — from $15,000 with a ten-business-day target, qualifying one application, one environment, and one measurable business effect; native, RDP, and Citrix qualifications are typically $25,000–$40,000; the sprint is paid even when the correct outcome is not to automate. **OpenAdapt Cloud** — $500/month managed browser execution for non-regulated data, with no production SLA and no regulated deployment included. Production, pilot, and OEM paths follow a successful qualification.
+- [Pricing](https://openadapt.ai/pricing): Three ways to start. **OpenAdapt Community:** free, MIT-licensed local runtime and qualification tools, with no Cloud account required. **Workflow Qualification Sprint:** from $15,000 with a ten-business-day target. It qualifies one application, one environment, and one measurable business effect. Native, RDP, and Citrix qualifications are typically $25,000–$40,000. The sprint is paid even when the correct outcome is not to automate. **OpenAdapt Cloud:** $500/month managed browser execution for non-regulated data, with no production SLA and no regulated deployment included. Production, pilot, and OEM paths follow a successful qualification.
 - [OpenAdapt Execute](https://openadapt.ai/execute): Private partner API and OEM integration for software and service providers that already know the transaction but cannot complete it in a customer system. It returns a verified receipt or a typed exception through an approved customer-controlled runner.
 - [Qualify a workflow](https://openadapt.ai/qualify): Submit one exact application, environment, workflow, volume, verification path, and deployment boundary for a paid qualification.
 - [Partner program](https://openadapt.ai/partners): Application-based tracks for vertical software/OEM, RCM and BPO operators, integration and services firms, and MSP/deployment partners.
@@ -89,7 +89,7 @@ Every template corresponds to something that actually runs. Proven references ex
 ## Source code
 
 - [OpenAdapt (launcher / flagship)](https://github.com/OpenAdaptAI/OpenAdapt): MIT-licensed public entry point and the stable install route.
-- [openadapt-flow (compiler and governed runtime)](https://github.com/OpenAdaptAI/openadapt-flow): The canonical engine — compilation, resolution ladder, identity and effect verification, policy gates, run reports, and every substrate backend.
+- [openadapt-flow (compiler and governed runtime)](https://github.com/OpenAdaptAI/openadapt-flow): The canonical engine. It includes compilation, the resolution ladder, identity and effect verification, policy gates, run reports, and every substrate backend.
 - [openadapt-capture](https://github.com/OpenAdaptAI/openadapt-capture): Native screen, mouse, keyboard, timing, and window-scoped capture.
 - [openadapt-privacy](https://github.com/OpenAdaptAI/openadapt-privacy): PII/PHI scrubbing.
 - [openadapt-evals](https://github.com/OpenAdaptAI/openadapt-evals): Benchmark tooling, including Windows Agent Arena integration.

--- a/tests/contributeProgram.test.js
+++ b/tests/contributeProgram.test.js
@@ -7,7 +7,7 @@ const pricing = fs.readFileSync('components/Pricing.js', 'utf8')
 const page = fs.readFileSync('pages/contribute.js', 'utf8')
 const intake = fs.readFileSync('components/ContributorProgramForm.js', 'utf8')
 const formDefinitions = fs.readFileSync('public/form.html', 'utf8')
-const home = fs.readFileSync('pages/index.js', 'utf8')
+const footer = fs.readFileSync('components/Footer.js', 'utf8')
 
 // JSX wraps prose across indented lines, so phrase assertions run against a
 // whitespace-normalized view. Banned-phrase checks also strip JS comments,
@@ -85,10 +85,10 @@ test('contributor leads use a dedicated Netlify form, segmented from contact', (
     assert.doesNotMatch(page, /ContactBookingSection/)
 })
 
-test('the homepage renders the contribute section and pricing carries the credits callout', () => {
-    assert.match(home, /<ContributeSection \/>/)
+test('pricing and the footer link to the contributor program', () => {
     assert.match(norm(pricing), /Earn credits by contributing/)
     assert.match(pricing, /href="\/contribute"/)
+    assert.match(footer, /href: '\/contribute'/)
     // The page links to the real pricing route, not a stale homepage anchor.
     assert.match(page, /href="\/pricing"/)
     assert.doesNotMatch(page, /href="\/#pricing"/)

--- a/tests/customerCaseStudy.test.js
+++ b/tests/customerCaseStudy.test.js
@@ -82,5 +82,5 @@ test('links the customer result from the public discovery surfaces', () => {
     assert.match(read('pages/index.js'), /<CustomerCaseStudy \/>/)
     assert.match(read('components/NavHeader.js'), /Customer results/)
     assert.match(read('public/sitemap.xml'), /\/customers\/rvu-audit-heart-care/)
-    assert.match(read('public/llms.txt'), /Customer Case Study — RVU Audits/)
+    assert.match(read('public/llms.txt'), /Customer Case Study: RVU Audits/)
 })


### PR DESCRIPTION
## Summary

- position OpenAdapt as verified automation from demonstration
- lead with the buyer outcome, customer proof, and one workflow-fit action
- reduce competing homepage actions and move detailed evidence below the proof
- align metadata, machine-readable discovery copy, and public entry copy

## Validation

- npm test: 193 passed
- npm run build: passed
- desktop and 390 px mobile visual review: passed
- git diff --check: passed